### PR TITLE
feat: checks for provenance run crate connections

### DIFF
--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -23,11 +23,25 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix wfrun: <https://w3id.org/ro/terms/workflow-run#> .
 
-provenance-run-crate:ProvRCParameterConnectionRequired a sh:NodeShape ;
-    sh:name "ProvRC ParameterConnection MUST" ;
-    sh:description "Required properties of a Provenance Run Crate ParameterConnection" ;
-    sh:target [
-        a sh:SPARQLTarget ;
+
+provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeShape ;
+    sh:name "ParamenterConnection references" ;
+    sh:description "Recommended references for ParameterConnection entities" ;
+    sh:targetClass wfrun:ParameterConnection ;
+    sh:property [
+        sh:name "ParamenterConnection references" ;
+        sh:description """References to `ParameterConnection` instances 
+        SHOULD follow the CWL convention,
+        where connections to workflow output parameters are referenced by the workflow
+        while other connections are referenced by the receiving step
+        """ ;
+        sh:path [
+            sh:inversePath wfrun:connection ;
+        ] ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:message """Missing `connection` to this `ParameterConnection` entity""" ;
+    ] .
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
             SELECT ?this

--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -68,21 +68,29 @@ provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape
     sh:message """Missing connection to this `ParameterConnection` entity""" ;
 .
 
-    sh:property [
-        a sh:PropertyShape ;
-        sh:name "ParameterConnection inverse connection" ;
-        sh:description "A ParameterConnection that links to a workflow output parameter should be referenced by the workflow via connection" ;
-        sh:path wfrun:targetParameter ;
-        sh:sparql [
-            sh:prefixes ro-crate:sparqlPrefixes ;
-            sh:select """
-                SELECT ?this
-                WHERE {
-                    ?this wfrun:targetParameter ?param .
-                    ?workflow bioschemas-cw:output ?param .
-                    ?param a bioschemas:FormalParameter .
+provenance-run-crate:ProvRCHowToStepParameterConnectionRecommended a sh:NodeShape ;
+    sh:name "ParamenterConnection references on HowToStep instances" ;
+    sh:description """RECOMMENDED references to ParameterConnection instances
+    SHOULD follow the CWL convention,
+    i.e., there SHOULD be a HowToStep that defines a `connection` to the `ParameterConnection` entity
+    which links the `input` of the HowToStep's `workExample` through its `targetParameter`""" ;
+    sh:targetClass wfrun:ParameterConnection ;
+    sh:sparql [
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?step (wfrun:connection as ?path) ?this # this is the workflow
+            WHERE {
+                ?this a wfrun:ParameterConnection .
+                ?param a bioschemas:FormalParameter .
+                ?this wfrun:targetParameter ?param .
+                ?step a schema:HowToStep .
+                ?tool bioschemas-cw:input ?param .
+                ?step schema:workExample ?tool .
+                FILTER NOT EXISTS {
+                    ?step wfrun:connection ?this .
                 }
-            """ ;
-        ] ;
-        # sh:message "A ParameterConnection that links to a workflow output parameter should be referenced by the workflow via connection" ;
-    ] .
+            }
+        """ ;
+    ] ;
+    sh:message "Missing connection to this `ParameterConnection` entity" ;
+.

--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -25,7 +25,7 @@
 
 
 provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeShape ;
-    sh:name "ParamenterConnection references" ;
+    sh:name "ParameterConnection references" ;
     sh:description "Recommended references for ParameterConnection entities" ;
     sh:targetClass wfrun:ParameterConnection ;
     sh:property [
@@ -44,7 +44,7 @@ provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeSha
     ] .
 
 provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape ;
-    sh:name "ParamenterConnection references on computational workflows" ;
+    sh:name "ParameterConnection references on computational workflows" ;
     sh:description """RECOMMENDED references to ParameterConnection instances 
     SHOULD follow the CWL convention,
     i.e., there SHOULD be a workflow that defines a `connection` to the `ParameterConnection` entity
@@ -65,11 +65,11 @@ provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape
             }
         """ ;
     ] ;
-    sh:message """Missing connection to this `ParameterConnection` entity""" ;
+    sh:message """Missing `ComputationalWorkflow` connection to this `ParameterConnection` entity""" ;
 .
 
 provenance-run-crate:ProvRCHowToStepParameterConnectionRecommended a sh:NodeShape ;
-    sh:name "ParamenterConnection references on HowToStep instances" ;
+    sh:name "ParameterConnection references on HowToStep instances" ;
     sh:description """RECOMMENDED references to ParameterConnection instances
     SHOULD follow the CWL convention,
     i.e., there SHOULD be a HowToStep that defines a `connection` to the `ParameterConnection` entity
@@ -92,5 +92,5 @@ provenance-run-crate:ProvRCHowToStepParameterConnectionRecommended a sh:NodeShap
             }
         """ ;
     ] ;
-    sh:message "Missing connection to this `ParameterConnection` entity" ;
+    sh:message "Missing `HowToStep` connection to this `ParameterConnection` entity" ;
 .

--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -42,16 +42,31 @@ provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeSha
         sh:minCount 1 ;
         sh:message """Missing `connection` to this `ParameterConnection` entity""" ;
     ] .
+
+provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape ;
+    sh:name "ParamenterConnection references on computational workflows" ;
+    sh:description """RECOMMENDED references to ParameterConnection instances 
+    SHOULD follow the CWL convention,
+    i.e., there SHOULD be a workflow that defines a `connection` to the `ParameterConnection` entity
+    which links the workflow's `output` through its `targetParameter`""" ;
+    sh:targetClass wfrun:ParameterConnection ;
+    sh:sparql [
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-            SELECT ?this
+            SELECT ?workflow (wfrun:connection as ?path) ?this # this is the workflow
             WHERE {
                 ?this a wfrun:ParameterConnection .
-                ?workflow wfrun:connection ?this .
-                ?workflow a bioschemas:ComputationalWorkflow .
+                ?workflow bioschemas-cw:output ?param .
+                ?param a bioschemas:FormalParameter .
+                ?this wfrun:targetParameter ?param .
+                FILTER NOT EXISTS {
+                    ?workflow wfrun:connection ?this .
+                }
             }
-        """
+        """ ;
     ] ;
+    sh:message """Missing connection to this `ParameterConnection` entity""" ;
+.
 
     sh:property [
         a sh:PropertyShape ;

--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -1,0 +1,59 @@
+# Copyright (c) 2024 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix ro-crate: <https://github.com/crs4/rocrate-validator/profiles/ro-crate/> .
+@prefix provenance-run-crate: <https://github.com/crs4/rocrate-validator/profiles/provenance-run-crate/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix bioschemas: <https://bioschemas.org/> .
+@prefix bioschemas-cw: <https://bioschemas.org/ComputationalWorkflow#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix wfrun: <https://w3id.org/ro/terms/workflow-run#> .
+
+provenance-run-crate:ProvRCParameterConnectionRequired a sh:NodeShape ;
+    sh:name "ProvRC ParameterConnection MUST" ;
+    sh:description "Required properties of a Provenance Run Crate ParameterConnection" ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes ro-crate:sparqlPrefixes ;
+        sh:select """
+            SELECT ?this
+            WHERE {
+                ?this a wfrun:ParameterConnection .
+                ?workflow wfrun:connection ?this .
+                ?workflow a bioschemas:ComputationalWorkflow .
+            }
+        """
+    ] ;
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "ParameterConnection inverse connection" ;
+        sh:description "A ParameterConnection that links to a workflow output parameter should be referenced by the workflow via connection" ;
+        sh:path wfrun:targetParameter ;
+        sh:sparql [
+            sh:prefixes ro-crate:sparqlPrefixes ;
+            sh:select """
+                SELECT ?this
+                WHERE {
+                    ?this wfrun:targetParameter ?param .
+                    ?workflow bioschemas-cw:output ?param .
+                    ?param a bioschemas:FormalParameter .
+                }
+            """ ;
+        ] ;
+        # sh:message "A ParameterConnection that links to a workflow output parameter should be referenced by the workflow via connection" ;
+    ] .

--- a/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/should/5_parameterconnection.ttl
@@ -30,7 +30,7 @@ provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeSha
     sh:targetClass wfrun:ParameterConnection ;
     sh:property [
         sh:name "ParamenterConnection references" ;
-        sh:description """References to `ParameterConnection` instances 
+        sh:description """References to `ParameterConnection` instances
         SHOULD follow the CWL convention,
         where connections to workflow output parameters are referenced by the workflow
         while other connections are referenced by the receiving step
@@ -45,7 +45,7 @@ provenance-run-crate:ProvRCParameterConnectionReferencesRecommended a sh:NodeSha
 
 provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape ;
     sh:name "ParameterConnection references on computational workflows" ;
-    sh:description """RECOMMENDED references to ParameterConnection instances 
+    sh:description """RECOMMENDED references to ParameterConnection instances
     SHOULD follow the CWL convention,
     i.e., there SHOULD be a workflow that defines a `connection` to the `ParameterConnection` entity
     which links the workflow's `output` through its `targetParameter`""" ;
@@ -53,7 +53,7 @@ provenance-run-crate:ProvRCWorkflowParameterConnectionRecommended a sh:NodeShape
     sh:sparql [
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-            SELECT ?workflow (wfrun:connection as ?path) ?this # this is the workflow
+            SELECT ?workflow (wfrun:connection as ?path) ?this
             WHERE {
                 ?this a wfrun:ParameterConnection .
                 ?workflow bioschemas-cw:output ?param .
@@ -78,7 +78,7 @@ provenance-run-crate:ProvRCHowToStepParameterConnectionRecommended a sh:NodeShap
     sh:sparql [
         sh:prefixes ro-crate:sparqlPrefixes ;
         sh:select """
-            SELECT ?step (wfrun:connection as ?path) ?this # this is the workflow
+            SELECT ?step (wfrun:connection as ?path) ?this
             WHERE {
                 ?this a wfrun:ParameterConnection .
                 ?param a bioschemas:FormalParameter .

--- a/rocrate_validator/profiles/ro-crate/prefixes.ttl
+++ b/rocrate_validator/profiles/ro-crate/prefixes.ttl
@@ -28,6 +28,10 @@ ro-crate:sparqlPrefixes
         sh:namespace "https://bioschemas.org/"^^xsd:anyURI ;
     ] ;
     sh:declare [
+        sh:prefix "bioschemas-cw" ;
+        sh:namespace "https://bioschemas.org/ComputationalWorkflow#"^^xsd:anyURI ;
+    ] ;
+    sh:declare [
         sh:prefix "rocrate" ;
         sh:namespace "https://w3id.org/ro/crate/1.1/"^^xsd:anyURI ;
     ] ;

--- a/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_referenced/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_referenced/ro-crate-metadata.json
@@ -1,0 +1,721 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        "https://w3id.org/ro/terms/workflow-run",
+        {
+            "buildInstructions": "https://codemeta.github.io/terms/buildInstructions"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "revsort run",
+            "description": "execution of the revsort workflow",
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/wfrun/process/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/workflow/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/provenance/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ],
+            "datePublished": "2024-10-02T10:11:09+00:00",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl"
+                },
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                },
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "primary-job.json"
+                },
+                {
+                    "@id": "revsort_env.yml"
+                },
+                {
+                    "@id": "rev_env.yml"
+                },
+                {
+                    "@id": "sort_env.yml"
+                }
+            ],
+            "license": "Apache-2.0",
+            "mainEntity": {
+                "@id": "packed.cwl"
+            },
+            "mentions": [
+                {
+                    "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+                }
+            ]
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/process/0.5",
+            "@type": "CreativeWork",
+            "name": "Process Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/workflow/0.5",
+            "@type": "CreativeWork",
+            "name": "Workflow Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/provenance/0.5",
+            "@type": "CreativeWork",
+            "name": "Provenance Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+            "@type": "CreativeWork",
+            "name": "Workflow RO-Crate",
+            "version": "1.0"
+        },
+        {
+            "@id": "packed.cwl",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow",
+                "HowTo"
+            ],
+            "xconnection": [
+                {
+                    "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a"
+                }
+            ],
+            "description": "Reverse the lines in a document, then sort those lines.",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl#revtool.cwl"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl"
+                }
+            ],
+            "input": [
+                {
+                    "@id": "packed.cwl#main/input"
+                },
+                {
+                    "@id": "packed.cwl#main/reverse_sort"
+                }
+            ],
+            "name": "packed.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
+            },
+            "buildInstructions": {
+                "@id": "revsort_env.yml"
+            },
+            "step": [
+                {
+                    "@id": "packed.cwl#main/rev"
+                },
+                {
+                    "@id": "packed.cwl#main/sorted"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
+            "@type": "ComputerLanguage",
+            "alternateName": "CWL",
+            "identifier": {
+                "@id": "https://w3id.org/cwl/v1.0/"
+            },
+            "name": "Common Workflow Language",
+            "url": {
+                "@id": "https://www.commonwl.org/"
+            },
+            "version": "v1.0"
+        },
+        {
+            "@id": "packed.cwl#main/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "defaultValue": "file:///home/stain/src/cwltool/tests/wf/hello.txt",
+            "description": "The input file to be processed.",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#main/reverse_sort",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "defaultValue": "True",
+            "description": "If true, reverse (decending) sort",
+            "name": "reverse_sort"
+        },
+        {
+            "@id": "packed.cwl#main/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "description": "The output with the lines reversed and sorted.",
+            "name": "output"
+        },
+        {
+            "@id": "revsort_env.yml",
+            "@type": "File",
+            "name": "revsort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#main/rev",
+            "@type": "HowToStep",
+            "connection": [
+                {
+                    "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de"
+                }
+            ],
+            "position": "0",
+            "buildInstructions": {
+                "@id": "rev_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#revtool.cwl"
+            }
+        },
+        {
+            "@id": "rev_env.yml",
+            "@type": "File",
+            "name": "rev conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Reverse each line using the `rev` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                }
+            ],
+            "name": "revtool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#revtool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/revtool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/revtool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/revtool.sh",
+            "@type": "SoftwareApplication",
+            "name": "revtool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "https://example.com/foobar/1.0.0/",
+            "@type": "SoftwareApplication",
+            "name": "foobar",
+            "softwareVersion": "1.0.0"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#revtool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "REVTOOL_ENV_VAR"
+        },
+        {
+            "@id": "packed.cwl#main/sorted",
+            "@type": "HowToStep",
+            "xconnection": [
+                {
+                    "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2"
+                },
+                {
+                    "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040"
+                }
+            ],
+            "position": "1",
+            "buildInstructions": {
+                "@id": "sort_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#sorttool.cwl"
+            }
+        },
+        {
+            "@id": "sort_env.yml",
+            "@type": "File",
+            "name": "sort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Sort lines using the `sort` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/reverse"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "name": "sorttool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#sorttool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/sorttool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/sorttool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/sorttool.sh",
+            "@type": "SoftwareApplication",
+            "name": "sorttool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/reverse",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "name": "reverse"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#sorttool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "SORTTOOL_ENV_VAR"
+        },
+        {
+            "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/input"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#revtool.cwl/input"
+            }
+        },
+        {
+            "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#revtool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/input"
+            }
+        },
+        {
+            "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            }
+        },
+        {
+            "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#sorttool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#main/output"
+            }
+        },
+        {
+            "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d",
+            "@type": "SoftwareApplication",
+            "name": "cwltool 1.0.20181012180214"
+        },
+        {
+            "@id": "#0e462147-3d98-4131-814f-6e082b83455e",
+            "@type": "OrganizeAction",
+            "agent": {
+                "@id": "https://orcid.org/0000-0001-9842-9718"
+            },
+            "instrument": {
+                "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d"
+            },
+            "name": "Run of cwltool 1.0.20181012180214",
+            "object": [
+                {
+                    "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a"
+                },
+                {
+                    "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf"
+                }
+            ],
+            "result": {
+                "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.210973"
+        },
+        {
+            "@id": "https://orcid.org/0000-0001-9842-9718",
+            "@type": "Person",
+            "name": "Stian Soiland-Reyes"
+        },
+        {
+            "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91",
+            "@type": "CreateAction",
+            "endTime": "2018-10-25T15:46:43.020168",
+            "instrument": {
+                "@id": "packed.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "#pv-main/reverse_sort"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.211153"
+        },
+        {
+            "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376",
+            "@type": "File",
+            "alternateName": "whale.txt",
+            "contentSize": "1111",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                },
+                {
+                    "@id": "packed.cwl#main/input"
+                }
+            ],
+            "sha1": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+        },
+        {
+            "@id": "#pv-main/reverse_sort",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "name": "reverse_sort",
+            "value": "True"
+        },
+        {
+            "@id": "b9214658cc453331b62c2282b772a5c063dbd284",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:38.058365",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "sha1": "b9214658cc453331b62c2282b772a5c063dbd284"
+        },
+        {
+            "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3"
+            },
+            "endTime": "2018-10-25T15:46:36.967359",
+            "instrument": {
+                "@id": "packed.cwl#revtool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/rev",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                }
+            ],
+            "environment": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "resourceUsage": [
+                {
+                    "@id": "#rev-run-realTime"
+                },
+                {
+                    "@id": "#rev-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:35.314101"
+        },
+        {
+            "@id": "#rev-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "12"
+        },
+        {
+            "@id": "#rev-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "110901"
+        },
+        {
+            "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/rev"
+            },
+            "name": "orchestrate revtool.cwl",
+            "actionStatus": "http://schema.org/FailedActionStatus",
+            "error": "this is just to test the error property",
+            "object": {
+                "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048"
+            }
+        },
+        {
+            "@id": "#revtool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#revtool_env_var"
+            },
+            "name": "REVTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:36.963254",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "sha1": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+        },
+        {
+            "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734"
+            },
+            "endTime": "2018-10-25T15:46:38.069110",
+            "instrument": {
+                "@id": "packed.cwl#sorttool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/sorted",
+            "object": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "#pv-main/sorted/reverse"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "environment": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "resourceUsage": [
+                {
+                    "@id": "#sort-run-realTime"
+                },
+                {
+                    "@id": "#sort-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:36.975235"
+        },
+        {
+            "@id": "#sort-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "15"
+        },
+        {
+            "@id": "#sort-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "123680"
+        },
+        {
+            "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/sorted"
+            },
+            "name": "orchestrate sorttool.cwl",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "object": {
+                "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7"
+            }
+        },
+        {
+            "@id": "#pv-main/sorted/reverse",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            },
+            "name": "reverse",
+            "value": "True"
+        },
+        {
+            "@id": "#sorttool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#sorttool_env_var"
+            },
+            "name": "SORTTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "primary-job.json",
+            "@type": "File",
+            "encodingFormat": "application/json",
+            "name": "input object document"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_step_referenced/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_step_referenced/ro-crate-metadata.json
@@ -61,6 +61,14 @@
                 {
                     "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
                 }
+            ],
+            "connection": [
+                {
+                    "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2"
+                },
+                {
+                    "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040"
+                }
             ]
         },
         {
@@ -289,14 +297,6 @@
         {
             "@id": "packed.cwl#main/sorted",
             "@type": "HowToStep",
-            "xconnection": [
-                {
-                    "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2"
-                },
-                {
-                    "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040"
-                }
-            ],
             "position": "1",
             "buildInstructions": {
                 "@id": "sort_env.yml"

--- a/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_step_referenced/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_step_referenced/ro-crate-metadata.json
@@ -1,0 +1,721 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        "https://w3id.org/ro/terms/workflow-run",
+        {
+            "buildInstructions": "https://codemeta.github.io/terms/buildInstructions"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "revsort run",
+            "description": "execution of the revsort workflow",
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/wfrun/process/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/workflow/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/provenance/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ],
+            "datePublished": "2024-10-02T10:11:09+00:00",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl"
+                },
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                },
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "primary-job.json"
+                },
+                {
+                    "@id": "revsort_env.yml"
+                },
+                {
+                    "@id": "rev_env.yml"
+                },
+                {
+                    "@id": "sort_env.yml"
+                }
+            ],
+            "license": "Apache-2.0",
+            "mainEntity": {
+                "@id": "packed.cwl"
+            },
+            "mentions": [
+                {
+                    "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+                }
+            ]
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/process/0.5",
+            "@type": "CreativeWork",
+            "name": "Process Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/workflow/0.5",
+            "@type": "CreativeWork",
+            "name": "Workflow Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/provenance/0.5",
+            "@type": "CreativeWork",
+            "name": "Provenance Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+            "@type": "CreativeWork",
+            "name": "Workflow RO-Crate",
+            "version": "1.0"
+        },
+        {
+            "@id": "packed.cwl",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow",
+                "HowTo"
+            ],
+            "connection": [
+                {
+                    "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a"
+                }
+            ],
+            "description": "Reverse the lines in a document, then sort those lines.",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl#revtool.cwl"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl"
+                }
+            ],
+            "input": [
+                {
+                    "@id": "packed.cwl#main/input"
+                },
+                {
+                    "@id": "packed.cwl#main/reverse_sort"
+                }
+            ],
+            "name": "packed.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
+            },
+            "buildInstructions": {
+                "@id": "revsort_env.yml"
+            },
+            "step": [
+                {
+                    "@id": "packed.cwl#main/rev"
+                },
+                {
+                    "@id": "packed.cwl#main/sorted"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
+            "@type": "ComputerLanguage",
+            "alternateName": "CWL",
+            "identifier": {
+                "@id": "https://w3id.org/cwl/v1.0/"
+            },
+            "name": "Common Workflow Language",
+            "url": {
+                "@id": "https://www.commonwl.org/"
+            },
+            "version": "v1.0"
+        },
+        {
+            "@id": "packed.cwl#main/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "defaultValue": "file:///home/stain/src/cwltool/tests/wf/hello.txt",
+            "description": "The input file to be processed.",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#main/reverse_sort",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "defaultValue": "True",
+            "description": "If true, reverse (decending) sort",
+            "name": "reverse_sort"
+        },
+        {
+            "@id": "packed.cwl#main/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "description": "The output with the lines reversed and sorted.",
+            "name": "output"
+        },
+        {
+            "@id": "revsort_env.yml",
+            "@type": "File",
+            "name": "revsort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#main/rev",
+            "@type": "HowToStep",
+            "connection": [
+                {
+                    "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de"
+                }
+            ],
+            "position": "0",
+            "buildInstructions": {
+                "@id": "rev_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#revtool.cwl"
+            }
+        },
+        {
+            "@id": "rev_env.yml",
+            "@type": "File",
+            "name": "rev conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Reverse each line using the `rev` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                }
+            ],
+            "name": "revtool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#revtool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/revtool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/revtool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/revtool.sh",
+            "@type": "SoftwareApplication",
+            "name": "revtool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "https://example.com/foobar/1.0.0/",
+            "@type": "SoftwareApplication",
+            "name": "foobar",
+            "softwareVersion": "1.0.0"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#revtool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "REVTOOL_ENV_VAR"
+        },
+        {
+            "@id": "packed.cwl#main/sorted",
+            "@type": "HowToStep",
+            "xconnection": [
+                {
+                    "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2"
+                },
+                {
+                    "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040"
+                }
+            ],
+            "position": "1",
+            "buildInstructions": {
+                "@id": "sort_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#sorttool.cwl"
+            }
+        },
+        {
+            "@id": "sort_env.yml",
+            "@type": "File",
+            "name": "sort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Sort lines using the `sort` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/reverse"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "name": "sorttool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#sorttool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/sorttool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/sorttool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/sorttool.sh",
+            "@type": "SoftwareApplication",
+            "name": "sorttool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/reverse",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "name": "reverse"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#sorttool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "SORTTOOL_ENV_VAR"
+        },
+        {
+            "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/input"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#revtool.cwl/input"
+            }
+        },
+        {
+            "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#revtool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/input"
+            }
+        },
+        {
+            "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            }
+        },
+        {
+            "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#sorttool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#main/output"
+            }
+        },
+        {
+            "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d",
+            "@type": "SoftwareApplication",
+            "name": "cwltool 1.0.20181012180214"
+        },
+        {
+            "@id": "#0e462147-3d98-4131-814f-6e082b83455e",
+            "@type": "OrganizeAction",
+            "agent": {
+                "@id": "https://orcid.org/0000-0001-9842-9718"
+            },
+            "instrument": {
+                "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d"
+            },
+            "name": "Run of cwltool 1.0.20181012180214",
+            "object": [
+                {
+                    "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a"
+                },
+                {
+                    "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf"
+                }
+            ],
+            "result": {
+                "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.210973"
+        },
+        {
+            "@id": "https://orcid.org/0000-0001-9842-9718",
+            "@type": "Person",
+            "name": "Stian Soiland-Reyes"
+        },
+        {
+            "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91",
+            "@type": "CreateAction",
+            "endTime": "2018-10-25T15:46:43.020168",
+            "instrument": {
+                "@id": "packed.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "#pv-main/reverse_sort"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.211153"
+        },
+        {
+            "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376",
+            "@type": "File",
+            "alternateName": "whale.txt",
+            "contentSize": "1111",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                },
+                {
+                    "@id": "packed.cwl#main/input"
+                }
+            ],
+            "sha1": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+        },
+        {
+            "@id": "#pv-main/reverse_sort",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "name": "reverse_sort",
+            "value": "True"
+        },
+        {
+            "@id": "b9214658cc453331b62c2282b772a5c063dbd284",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:38.058365",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "sha1": "b9214658cc453331b62c2282b772a5c063dbd284"
+        },
+        {
+            "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3"
+            },
+            "endTime": "2018-10-25T15:46:36.967359",
+            "instrument": {
+                "@id": "packed.cwl#revtool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/rev",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                }
+            ],
+            "environment": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "resourceUsage": [
+                {
+                    "@id": "#rev-run-realTime"
+                },
+                {
+                    "@id": "#rev-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:35.314101"
+        },
+        {
+            "@id": "#rev-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "12"
+        },
+        {
+            "@id": "#rev-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "110901"
+        },
+        {
+            "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/rev"
+            },
+            "name": "orchestrate revtool.cwl",
+            "actionStatus": "http://schema.org/FailedActionStatus",
+            "error": "this is just to test the error property",
+            "object": {
+                "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048"
+            }
+        },
+        {
+            "@id": "#revtool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#revtool_env_var"
+            },
+            "name": "REVTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:36.963254",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "sha1": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+        },
+        {
+            "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734"
+            },
+            "endTime": "2018-10-25T15:46:38.069110",
+            "instrument": {
+                "@id": "packed.cwl#sorttool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/sorted",
+            "object": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "#pv-main/sorted/reverse"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "environment": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "resourceUsage": [
+                {
+                    "@id": "#sort-run-realTime"
+                },
+                {
+                    "@id": "#sort-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:36.975235"
+        },
+        {
+            "@id": "#sort-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "15"
+        },
+        {
+            "@id": "#sort-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "123680"
+        },
+        {
+            "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/sorted"
+            },
+            "name": "orchestrate sorttool.cwl",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "object": {
+                "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7"
+            }
+        },
+        {
+            "@id": "#pv-main/sorted/reverse",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            },
+            "name": "reverse",
+            "value": "True"
+        },
+        {
+            "@id": "#sorttool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#sorttool_env_var"
+            },
+            "name": "SORTTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "primary-job.json",
+            "@type": "File",
+            "encodingFormat": "application/json",
+            "name": "input object document"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_workflow_referenced/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_workflow_referenced/ro-crate-metadata.json
@@ -1,0 +1,721 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        "https://w3id.org/ro/terms/workflow-run",
+        {
+            "buildInstructions": "https://codemeta.github.io/terms/buildInstructions"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "revsort run",
+            "description": "execution of the revsort workflow",
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/wfrun/process/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/workflow/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/ro/wfrun/provenance/0.5"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ],
+            "datePublished": "2024-10-02T10:11:09+00:00",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl"
+                },
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                },
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "primary-job.json"
+                },
+                {
+                    "@id": "revsort_env.yml"
+                },
+                {
+                    "@id": "rev_env.yml"
+                },
+                {
+                    "@id": "sort_env.yml"
+                }
+            ],
+            "license": "Apache-2.0",
+            "mainEntity": {
+                "@id": "packed.cwl"
+            },
+            "mentions": [
+                {
+                    "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+                }
+            ]
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/process/0.5",
+            "@type": "CreativeWork",
+            "name": "Process Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/workflow/0.5",
+            "@type": "CreativeWork",
+            "name": "Workflow Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/ro/wfrun/provenance/0.5",
+            "@type": "CreativeWork",
+            "name": "Provenance Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+            "@type": "CreativeWork",
+            "name": "Workflow RO-Crate",
+            "version": "1.0"
+        },
+        {
+            "@id": "packed.cwl",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow",
+                "HowTo"
+            ],
+            "xconnection": [
+                {
+                    "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a"
+                }
+            ],
+            "description": "Reverse the lines in a document, then sort those lines.",
+            "hasPart": [
+                {
+                    "@id": "packed.cwl#revtool.cwl"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl"
+                }
+            ],
+            "input": [
+                {
+                    "@id": "packed.cwl#main/input"
+                },
+                {
+                    "@id": "packed.cwl#main/reverse_sort"
+                }
+            ],
+            "name": "packed.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
+            },
+            "buildInstructions": {
+                "@id": "revsort_env.yml"
+            },
+            "step": [
+                {
+                    "@id": "packed.cwl#main/rev"
+                },
+                {
+                    "@id": "packed.cwl#main/sorted"
+                }
+            ]
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
+            "@type": "ComputerLanguage",
+            "alternateName": "CWL",
+            "identifier": {
+                "@id": "https://w3id.org/cwl/v1.0/"
+            },
+            "name": "Common Workflow Language",
+            "url": {
+                "@id": "https://www.commonwl.org/"
+            },
+            "version": "v1.0"
+        },
+        {
+            "@id": "packed.cwl#main/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "defaultValue": "file:///home/stain/src/cwltool/tests/wf/hello.txt",
+            "description": "The input file to be processed.",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#main/reverse_sort",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "defaultValue": "True",
+            "description": "If true, reverse (decending) sort",
+            "name": "reverse_sort"
+        },
+        {
+            "@id": "packed.cwl#main/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "description": "The output with the lines reversed and sorted.",
+            "name": "output"
+        },
+        {
+            "@id": "revsort_env.yml",
+            "@type": "File",
+            "name": "revsort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#main/rev",
+            "@type": "HowToStep",
+            "connection": [
+                {
+                    "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de"
+                }
+            ],
+            "position": "0",
+            "buildInstructions": {
+                "@id": "rev_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#revtool.cwl"
+            }
+        },
+        {
+            "@id": "rev_env.yml",
+            "@type": "File",
+            "name": "rev conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Reverse each line using the `rev` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                }
+            ],
+            "name": "revtool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#revtool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/revtool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/revtool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/revtool.sh",
+            "@type": "SoftwareApplication",
+            "name": "revtool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "https://example.com/foobar/1.0.0/",
+            "@type": "SoftwareApplication",
+            "name": "foobar",
+            "softwareVersion": "1.0.0"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#revtool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#revtool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "REVTOOL_ENV_VAR"
+        },
+        {
+            "@id": "packed.cwl#main/sorted",
+            "@type": "HowToStep",
+            "connection": [
+                {
+                    "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2"
+                },
+                {
+                    "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040"
+                }
+            ],
+            "position": "1",
+            "buildInstructions": {
+                "@id": "sort_env.yml"
+            },
+            "workExample": {
+                "@id": "packed.cwl#sorttool.cwl"
+            }
+        },
+        {
+            "@id": "sort_env.yml",
+            "@type": "File",
+            "name": "sort conda environment",
+            "encodingFormat": "application/yaml",
+            "conformsTo": {
+                "@id": "https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually"
+            }
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl",
+            "@type": "SoftwareApplication",
+            "description": "Sort lines using the `sort` command",
+            "input": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/reverse"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "name": "sorttool.cwl",
+            "output": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                }
+            ],
+            "environment": [
+                {
+                    "@id": "#sorttool_env_var"
+                }
+            ],
+            "softwareRequirements": [
+                { "@id": "actually/nonexistent/sorttool.sh" },
+                { "@id": "https://example.com/foobar/1.0.0/" }
+            ],
+            "mainEntity": {
+                "@id": "actually/nonexistent/sorttool.sh"
+            }
+        },
+        {
+            "@id": "actually/nonexistent/sorttool.sh",
+            "@type": "SoftwareApplication",
+            "name": "sorttool.sh",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/reverse",
+            "@type": "FormalParameter",
+            "additionalType": "Boolean",
+            "name": "reverse"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/input",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "input"
+        },
+        {
+            "@id": "packed.cwl#sorttool.cwl/output",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "output"
+        },
+        {
+            "@id": "#sorttool_env_var",
+            "@type": "FormalParameter",
+            "additionalType": "Integer",
+            "workExample": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "description": "An environment variable",
+            "name": "SORTTOOL_ENV_VAR"
+        },
+        {
+            "@id": "#a7e8c871-3e4b-49d9-8b7c-2ca8b96bc9de",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/input"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#revtool.cwl/input"
+            }
+        },
+        {
+            "@id": "#7835f386-2ae7-447e-8403-ee98d506c1e2",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#revtool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/input"
+            }
+        },
+        {
+            "@id": "#bffeb46f-c0bf-4814-8472-a368b45f8040",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            }
+        },
+        {
+            "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a",
+            "@type": "ParameterConnection",
+            "sourceParameter": {
+                "@id": "packed.cwl#sorttool.cwl/output"
+            },
+            "targetParameter": {
+                "@id": "packed.cwl#main/output"
+            }
+        },
+        {
+            "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d",
+            "@type": "SoftwareApplication",
+            "name": "cwltool 1.0.20181012180214"
+        },
+        {
+            "@id": "#0e462147-3d98-4131-814f-6e082b83455e",
+            "@type": "OrganizeAction",
+            "agent": {
+                "@id": "https://orcid.org/0000-0001-9842-9718"
+            },
+            "instrument": {
+                "@id": "#59d43342-19b6-47cf-ba0e-a8ffa8a52f4d"
+            },
+            "name": "Run of cwltool 1.0.20181012180214",
+            "object": [
+                {
+                    "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a"
+                },
+                {
+                    "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf"
+                }
+            ],
+            "result": {
+                "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.210973"
+        },
+        {
+            "@id": "https://orcid.org/0000-0001-9842-9718",
+            "@type": "Person",
+            "name": "Stian Soiland-Reyes"
+        },
+        {
+            "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91",
+            "@type": "CreateAction",
+            "endTime": "2018-10-25T15:46:43.020168",
+            "instrument": {
+                "@id": "packed.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                },
+                {
+                    "@id": "#pv-main/reverse_sort"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "startTime": "2018-10-25T15:46:35.211153"
+        },
+        {
+            "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376",
+            "@type": "File",
+            "alternateName": "whale.txt",
+            "contentSize": "1111",
+            "encodingFormat": "https://www.iana.org/assignments/media-types/text/plain",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/input"
+                },
+                {
+                    "@id": "packed.cwl#main/input"
+                }
+            ],
+            "sha1": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+        },
+        {
+            "@id": "#pv-main/reverse_sort",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#main/reverse_sort"
+            },
+            "name": "reverse_sort",
+            "value": "True"
+        },
+        {
+            "@id": "b9214658cc453331b62c2282b772a5c063dbd284",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:38.058365",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#sorttool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#main/output"
+                }
+            ],
+            "sha1": "b9214658cc453331b62c2282b772a5c063dbd284"
+        },
+        {
+            "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3"
+            },
+            "endTime": "2018-10-25T15:46:36.967359",
+            "instrument": {
+                "@id": "packed.cwl#revtool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/rev",
+            "object": [
+                {
+                    "@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                }
+            ],
+            "environment": {
+                "@id": "#revtool_env_var-pv"
+            },
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "resourceUsage": [
+                {
+                    "@id": "#rev-run-realTime"
+                },
+                {
+                    "@id": "#rev-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:35.314101"
+        },
+        {
+            "@id": "#rev-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "12"
+        },
+        {
+            "@id": "#rev-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "110901"
+        },
+        {
+            "@id": "#547745c6-afb0-4352-bc66-0d4377bb022a",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/rev"
+            },
+            "name": "orchestrate revtool.cwl",
+            "actionStatus": "http://schema.org/FailedActionStatus",
+            "error": "this is just to test the error property",
+            "object": {
+                "@id": "#9b6dc9de-26fb-45ff-a972-4cc8045cd048"
+            }
+        },
+        {
+            "@id": "#revtool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#revtool_env_var"
+            },
+            "name": "REVTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f",
+            "@type": "File",
+            "alternateName": "output.txt",
+            "contentSize": "1111",
+            "dateCreated": "2018-10-25T15:46:36.963254",
+            "exampleOfWork": [
+                {
+                    "@id": "packed.cwl#revtool.cwl/output"
+                },
+                {
+                    "@id": "packed.cwl#sorttool.cwl/input"
+                }
+            ],
+            "sha1": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+        },
+        {
+            "@id": "#a76054fd-3abf-478f-aa1f-2ea1dc0c1ca3",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7",
+            "@type": "CreateAction",
+            "containerImage": {
+                "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734"
+            },
+            "endTime": "2018-10-25T15:46:38.069110",
+            "instrument": {
+                "@id": "packed.cwl#sorttool.cwl"
+            },
+            "name": "Run of workflow/packed.cwl#main/sorted",
+            "object": [
+                {
+                    "@id": "97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
+                },
+                {
+                    "@id": "#pv-main/sorted/reverse"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "b9214658cc453331b62c2282b772a5c063dbd284"
+                }
+            ],
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "environment": {
+                "@id": "#sorttool_env_var-pv"
+            },
+            "resourceUsage": [
+                {
+                    "@id": "#sort-run-realTime"
+                },
+                {
+                    "@id": "#sort-run-peakVMEM"
+                }
+            ],
+            "startTime": "2018-10-25T15:46:36.975235"
+        },
+        {
+            "@id": "#sort-run-realTime",
+            "@type": "PropertyValue",
+            "name": "realTime",
+            "propertyID": "https://example.org/terms/ru#realTime",
+            "unitCode": "https://qudt.org/vocab/unit/MilliSEC",
+            "value": "15"
+        },
+        {
+            "@id": "#sort-run-peakVMEM",
+            "@type": "PropertyValue",
+            "name": "peakVMEM",
+            "propertyID": "https://example.org/terms/ru#peakVMEM",
+            "unitCode": "https://qudt.org/vocab/unit/BYTE",
+            "value": "123680"
+        },
+        {
+            "@id": "#29365b8d-cf76-4c62-a97d-fa8c2061e5cf",
+            "@type": "ControlAction",
+            "instrument": {
+                "@id": "packed.cwl#main/sorted"
+            },
+            "name": "orchestrate sorttool.cwl",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
+            "object": {
+                "@id": "#ba5b82a1-ce69-410f-a846-4a1d042233e7"
+            }
+        },
+        {
+            "@id": "#pv-main/sorted/reverse",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "packed.cwl#sorttool.cwl/reverse"
+            },
+            "name": "reverse",
+            "value": "True"
+        },
+        {
+            "@id": "#sorttool_env_var-pv",
+            "@type": "PropertyValue",
+            "exampleOfWork": {
+                "@id": "#sorttool_env_var"
+            },
+            "name": "SORTTOOL_ENV_VAR",
+            "value": "42"
+        },
+        {
+            "@id": "#bea7d7e2-5948-4319-b850-b4741e3fe734",
+            "@type": "ContainerImage",
+            "additionalType": {
+                "@id": "https://w3id.org/ro/terms/workflow-run#DockerImage"
+            },
+            "name": "debian",
+            "registry": "docker.io",
+            "tag": "8"
+        },
+        {
+            "@id": "primary-job.json",
+            "@type": "File",
+            "encodingFormat": "application/json",
+            "name": "input object document"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_workflow_referenced/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/5_provenance_run_crate/parameterconnection_not_workflow_referenced/ro-crate-metadata.json
@@ -61,6 +61,11 @@
                 {
                     "@id": "#8a058e09-e8c3-47ed-836d-d630fe659c91"
                 }
+            ],
+            "connection": [
+                {
+                    "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a"
+                }
             ]
         },
         {
@@ -109,11 +114,6 @@
                 "SoftwareSourceCode",
                 "ComputationalWorkflow",
                 "HowTo"
-            ],
-            "xconnection": [
-                {
-                    "@id": "#b768302e-95a9-4c0d-80db-8e4c48f9e65a"
-                }
             ],
             "description": "Reverse the lines in a document, then sort those lines.",
             "hasPart": [

--- a/tests/integration/profiles/provenance-run-crate/test_provrc_parameterconnection.py
+++ b/tests/integration/profiles/provenance-run-crate/test_provrc_parameterconnection.py
@@ -80,3 +80,48 @@ def test_parameterconnection_bad_targetparameter():
         ["ParameterConnection must have a targetParameter that references a FormalParameter"],
         profile_identifier="provenance-run-crate"
     )
+
+
+def test_parameterconnection_not_referenced():
+    """\
+    Test a Provenance Run Crate where a ParameterConnection is not referenced
+    by any other entity through the connection property.
+    """
+    do_entity_test(
+        InvalidProvRC().parameterconnection_not_referenced,
+        Severity.RECOMMENDED,
+        False,
+        ["ParameterConnection references"],
+        ["Missing `connection` to this `ParameterConnection` entity"],
+        profile_identifier="provenance-run-crate"
+    )
+
+
+def test_parameterconnection_not_workflow_referenced():
+    """\
+    Test a Provenance Run Crate where a ParameterConnection is not referenced
+    by any Workflow through the connection property.
+    """
+    do_entity_test(
+        InvalidProvRC().parameterconnection_not_workflow_referenced,
+        Severity.RECOMMENDED,
+        False,
+        ["ParameterConnection references on computational workflows"],
+        ["Missing `ComputationalWorkflow` connection to this `ParameterConnection` entity"],
+        profile_identifier="provenance-run-crate"
+    )
+
+
+def test_parameterconnection_not_step_referenced():
+    """\
+    Test a Provenance Run Crate where a ParameterConnection is not referenced
+    by any HowToStep through the connection property.
+    """
+    do_entity_test(
+        InvalidProvRC().parameterconnection_not_step_referenced,
+        Severity.RECOMMENDED,
+        False,
+        ["ParameterConnection references on HowToStep instances"],
+        ["Missing `HowToStep` connection to this `ParameterConnection` entity"],
+        profile_identifier="provenance-run-crate"
+    )

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -856,6 +856,18 @@ class InvalidProvRC:
         return self.base_path / "parameterconnection_bad_targetparameter"
 
     @property
+    def parameterconnection_not_referenced(self) -> Path:
+        return self.base_path / "parameterconnection_not_referenced"
+
+    @property
+    def parameterconnection_not_workflow_referenced(self) -> Path:
+        return self.base_path / "parameterconnection_not_workflow_referenced"
+
+    @property
+    def parameterconnection_not_step_referenced(self) -> Path:
+        return self.base_path / "parameterconnection_not_step_referenced"
+
+    @property
     def tool_no_softwarerequirements(self) -> Path:
         return self.base_path / "tool_no_softwarerequirements"
 


### PR DESCRIPTION
This PR extends the `provenance-run-crate` profile with new SHACL constraints to ensure that `ParameterConnection` instances are referenced by workflows or steps according to the CWL convention, as required by the [specification](https://www.researchobject.org/workflow-run-crate/profiles/0.5/provenance_run_crate/#representing-parameter-connections)