### PR TITLE
feat: json output enhancement

### DIFF
--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1217,8 +1217,7 @@ class ValidationResult:
         return self._issues == other._issues
 
     def to_dict(self) -> dict:
-        allowed_properties = ["data_path", "profiles_path",
-                              "profile_identifier", "inherit_profiles", "requirement_severity", "abort_on_first"]
+        allowed_properties = ["profile_identifier", "inherit_profiles", "requirement_severity", "abort_on_first"]
         return {
             "rocrate": str(self.rocrate_path),
             "validation_settings": {key: self.validation_settings[key]

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -388,6 +388,14 @@ class Profile:
     def __str__(self) -> str:
         return f"{self.name} ({self.identifier})"
 
+    def to_dict(self) -> dict:
+        return {
+            "identifier": self.identifier,
+            "uri": self.uri,
+            "name": self.name,
+            "description": self.description
+        }
+
     @staticmethod
     def __extract_version_from_token__(token: str) -> Optional[str]:
         if not token:
@@ -892,6 +900,16 @@ class RequirementCheck(ABC):
     @abstractmethod
     def execute_check(self, context: ValidationContext) -> bool:
         raise NotImplementedError()
+
+    def to_dict(self) -> dict:
+        return {
+            "identifier": self.relative_identifier,
+            "name": self.name,
+            "description": self.description,
+            "level": self.level.name,
+            "severity": self.severity.name,
+            "profile": self.requirement.profile.to_dict()
+        }
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RequirementCheck):

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -942,18 +942,12 @@ class CheckIssue:
         check (RequirementCheck): The check that generated the issue
     """
 
-    # TODO:
-    # 2. CheckIssue has the check, so it is able to determine the level and the Severity
-    #    without having it provided through an additional argument.
-    def __init__(self, severity: Severity,
+    def __init__(self,
                  check: RequirementCheck,
                  message: Optional[str] = None,
                  resultPath: Optional[str] = None,
                  focusNode: Optional[str] = None,
                  value: Optional[str] = None):
-        if not isinstance(severity, Severity):
-            raise TypeError(f"CheckIssue constructed with a severity '{severity}' of type {type(severity)}")
-        self._severity = severity
         self._message = message
         self._check: RequirementCheck = check
         self._resultPath = resultPath
@@ -973,7 +967,7 @@ class CheckIssue:
     @property
     def severity(self) -> Severity:
         """Severity of the RequirementLevel associated with this check."""
-        return self._severity
+        return self._check.severity
 
     @property
     def level_name(self) -> str:
@@ -999,16 +993,15 @@ class CheckIssue:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, CheckIssue) and \
             self._check == other._check and \
-            self._severity == other._severity and \
             self._message == other._message
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, CheckIssue):
             raise TypeError(f"Cannot compare {type(self)} with {type(other)}")
-        return (self._check, self._severity, self._message) < (other._check, other._severity, other._message)
+        return (self._check, self._message) < (other._check, other._message)
 
     def __hash__(self) -> int:
-        return hash((self._check, self._severity, self._message))
+        return hash((self._check, self._message))
 
     def __repr__(self) -> str:
         return f'CheckIssue(severity={self.severity}, check={self.check}, message={self.message})'
@@ -1139,18 +1132,15 @@ class ValidationResult:
     def add_check_issue(self,
                         message: str,
                         check: RequirementCheck,
-                        severity: Optional[Severity] = None,
                         resultPath: Optional[str] = None,
                         focusNode: Optional[str] = None,
                         value: Optional[str] = None) -> CheckIssue:
-        sev_value = severity if severity is not None else check.severity
-        c = CheckIssue(sev_value, check, message, resultPath=resultPath, focusNode=focusNode, value=value)
-        # self._issues.append(c)
+        c = CheckIssue(check, message, resultPath=resultPath, focusNode=focusNode, value=value)
         bisect.insort(self._issues, c)
         return c
 
     def add_error(self, message: str, check: RequirementCheck) -> CheckIssue:
-        return self.add_check_issue(message, check, Severity.REQUIRED)
+        return self.add_check_issue(message, check)
 
     #  --- Requirements ---
     @property

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1031,7 +1031,7 @@ class CheckIssue:
         return {
             "severity": self.severity.name,
             "message": self.message,
-            "check": self.check.name,
+            "check": self.check.to_dict(),
             "resultPath": self.resultPath,
             "focusNode": self.focusNode,
             "value": self.value

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -29,6 +29,7 @@ from typing import Optional, Tuple, Union
 from rdflib import RDF, RDFS, Graph, Namespace, URIRef
 
 import rocrate_validator.log as logging
+from rocrate_validator import __version__
 from rocrate_validator.constants import (DEFAULT_ONTOLOGY_FILE,
                                          DEFAULT_PROFILE_IDENTIFIER,
                                          DEFAULT_PROFILE_README_FILE,
@@ -1224,6 +1225,9 @@ class ValidationResult:
             "passed": self.passed(self.context.settings["requirement_severity"]),
             "issues": [issue.to_dict() for issue in self.issues]
         }
+        # add validator version to the settings
+        result["validation_settings"]["rocrate-validator-version"] = __version__
+        return result
 
     def to_json(self, path: Optional[Path] = None) -> str:
 

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1218,8 +1218,7 @@ class ValidationResult:
 
     def to_dict(self) -> dict:
         allowed_properties = ["profile_identifier", "inherit_profiles", "requirement_severity", "abort_on_first"]
-        return {
-            "rocrate": str(self.rocrate_path),
+        result = {
             "validation_settings": {key: self.validation_settings[key]
                                     for key in allowed_properties if key in self.validation_settings},
             "passed": self.passed(self.context.settings["requirement_severity"]),

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1048,7 +1048,6 @@ class CheckIssue:
         result = {
             "severity": self.severity.name,
             "message": self.message,
-            "resultPath": self.resultPath,
             "focusNode": self.focusNode,
             "value": self.value
         }

--- a/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
+++ b/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
@@ -34,7 +34,7 @@ class MainWorkflowFileExistence(PyFunctionCheck):
                 context.result.add_check_issue("main workflow does not exist in metadata file", self)
                 return False
             if not main_workflow.is_available():
-                context.result.add_check_issue("Main Workflow {main_workflow.id} not found in crate", self)
+                context.result.add_check_issue(f"Main Workflow {main_workflow.id} not found in crate", self)
                 return False
             return True
         except ValueError as e:

--- a/rocrate_validator/requirements/python/__init__.py
+++ b/rocrate_validator/requirements/python/__init__.py
@@ -84,8 +84,14 @@ class PyRequirement(Requirement):
                 severity = None
                 try:
                     severity = member.severity
+                    logger.debug("Severity set for check '%r' from decorator: %r", check_name, severity)
                 except Exception:
+                    pass
+                if not severity:
+                    logger.debug(f"No explicit severity set for check '{check_name}' from decorator."
+                                 f"Getting severity from path: {self.severity_from_path}")
                     severity = self.severity_from_path or Severity.REQUIRED
+                logger.error("Severity log: %r", severity)
                 check = self.requirement_check_class(self,
                                                      check_name,
                                                      member,

--- a/rocrate_validator/requirements/python/__init__.py
+++ b/rocrate_validator/requirements/python/__init__.py
@@ -91,7 +91,7 @@ class PyRequirement(Requirement):
                     logger.debug(f"No explicit severity set for check '{check_name}' from decorator."
                                  f"Getting severity from path: {self.severity_from_path}")
                     severity = self.severity_from_path or Severity.REQUIRED
-                logger.error("Severity log: %r", severity)
+                logger.debug("Severity log: %r", severity)
                 check = self.requirement_check_class(self,
                                                      check_name,
                                                      member,

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -201,7 +201,6 @@ class SHACLCheck(RequirementCheck):
                     c = shacl_context.result.add_check_issue(
                         message=violation.get_result_message(shacl_context.rocrate_path),
                         check=requirementCheck,
-                        severity=violation.get_result_severity(),
                         resultPath=violation.resultPath.toPython() if violation.resultPath else None,
                         focusNode=make_uris_relative(
                             violation.focusNode.toPython(), shacl_context.publicID),

--- a/rocrate_validator/requirements/shacl/models.py
+++ b/rocrate_validator/requirements/shacl/models.py
@@ -58,7 +58,7 @@ class SHACLNode:
     def name(self) -> str:
         """Return the name of the shape"""
         if not self._name:
-            self._name = self._node.split("#")[-1] if "#" in self.node else self._node.split("/")[-1]
+            self._name = self.node_name
         return self._name or self._node.split("/")[-1]
 
     @name.setter
@@ -85,6 +85,11 @@ class SHACLNode:
     def node(self):
         """Return the node of the shape"""
         return self._node
+
+    @property
+    def node_name(self):
+        """Return the name of the node"""
+        return self._node.split("#")[-1] if "#" in self.node else self._node.split("/")[-1]
 
     @property
     def graph(self):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -93,7 +93,7 @@ def do_entity_test(
                     f"\"{expected_triggered_requirement}\" was not found in the failed requirements"
 
         # check requirement issues
-        detected_issues = [issue.message for issue in result.get_issues(models.Severity.RECOMMENDED)
+        detected_issues = [issue.message for issue in result.get_issues(requirement_severity)
                            if issue.message is not None]
         logger.debug("Detected issues: %s", detected_issues)
         logger.debug("Expected issues: %s", expected_triggered_issues)

--- a/tests/unit/requirements/test_profiles.py
+++ b/tests/unit/requirements/test_profiles.py
@@ -405,7 +405,7 @@ def test_profile_check_overriding(check_overriding_profiles_path: str):
 
         # Get the check
         check = requirement.get_checks()[0]
-        logger.debug("The check: %r of requirement %r of the profiles %f", check, requirement, profile.token)
+        logger.debug("The check: %r of requirement %r of the profiles %s", check, requirement, profile.token)
 
         # Check the profile 'a'
         if profile.token == "a":


### PR DESCRIPTION
This PR fixes and extends the JSON output of validator:
* fixes the incorrect representation of check severity;
* extends the check representation with additional details

```json
{
    "validation_settings": {
        "profile_identifier": "provenance-run-crate-0.5",
        "inherit_profiles": true,
        "requirement_severity": "RECOMMENDED",
        "abort_on_first": false,
        "rocrate_validator_version": "0.4.1"
    },
    "passed": false,
    "issues": [
        {
            "severity": "RECOMMENDED",
            "message": "The Application SHOULD have a url",
            "focusNode": "./#bfeb87c1-f284-4bbf-8cb6-8b8674e81e2b",
            "value": null,
            "check": {
                "identifier": "process-run-crate-0.5.3.2",
                "label": "SHOULD 3.2",
                "order": 2,
                "name": "Application url",
                "description": "The Application SHOULD have a url",
                "severity": "RECOMMENDED",
                "requirement": {
                    "identifier": "process-run-crate-0.5.3",
                    "name": "ProcRC Application",
                    "description": "Properties of a Process Run Crate Application",
                    "order": 3,
                    "profile": {
                        "identifier": "process-run-crate-0.5",
                        "uri": "https://w3id.org/ro/wfrun/process/0.5",
                        "name": "Process Run Crate 0.5",
                        "description": "RO-Crate Metadata Specification."
                    }
                }
            }
        },
...
```

