### PR TITLE
fix: datetime validation

### DIFF
--- a/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/2_root_data_entity_metadata.ttl
@@ -148,13 +148,12 @@ ro-crate:RootDataEntityRequiredProperties
         a sh:PropertyShape ;
         sh:name "Root Data Entity: `datePublished` property" ;
         sh:description """Check if the Root Data Entity includes a `datePublished` (as specified by schema.org)
-        to provide the date when the dataset was published. The datePublished MUST be a valid ISO 8601 date.
-        It SHOULD be specified to at least the day level, but MAY include a time component.""" ;
+        to provide the date when the dataset was published. The datePublished MUST be a valid ISO 8601 date.""" ;
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path schema_org:datePublished ;
-        sh:pattern "^(\\d{4}-\\d{2}-\\d{2})(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?\\+\\d{2}:\\d{2})?$" ;
-        sh:message "The Root Data Entity MUST have a `datePublished` property (as specified by schema.org) with a valid ISO 8601 date and the precision of at least the day level" ;
+        sh:pattern "^([\\+-]?\\d{4})((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)?[0-5]\\d)?|24:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$" ;
+        sh:message "The Root Data Entity MUST have a `datePublished` property (as specified by schema.org) with a valid ISO 8601 date" ;
     ] .
 
 ro-crate:RootDataEntityHasPartValueRestriction

--- a/rocrate_validator/profiles/ro-crate/should/2_root_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/should/2_root_data_entity_metadata.ttl
@@ -59,4 +59,16 @@ ro-crate:RootDataEntityDirectRecommendedProperties a sh:NodeShape ;
         sh:message "The `publisher` property of a `Root Data Entity` SHOULD be an `Organization`";
         sh:nodeKind sh:IRI ;
         sh:class schema_org:Organization ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "Root Data Entity: RECOMMENDED `datePublished` property" ;
+        sh:description """Check if the Root Data Entity includes a `datePublished` (as specified by schema.org)
+        to provide the date when the dataset was published. The datePublished MUST be a valid ISO 8601 date.
+        It SHOULD be specified to at least the day level, but MAY include a time component.""" ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path schema_org:datePublished ;
+        sh:pattern "^([\\+-]?\\d{4})((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))|W([0-4]\\d|5[0-2])(-?[1-7])|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)?[0-5]\\d)?|24:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)$" ;
+        sh:message "The Root Data Entity MUST have a `datePublished` property (as specified by schema.org) with a valid ISO 8601 date and the precision of at least the day level" ;
     ] .

--- a/rocrate_validator/profiles/ro-crate/should/5_web_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/should/5_web_data_entity_metadata.ttl
@@ -58,8 +58,6 @@ ro-crate:WebBasedDataEntityRequiredValueRestriction a sh:NodeShape ;
         sh:name "Web-based Data Entity: `sdDatePublished` property" ;
         sh:description """Check if the Web-based Data Entity has a `sdDatePublished` property""" ;
         sh:path schema_org:sdDatePublished ;
-        # sh:datatype xsd:dateTime ;
-        sh:pattern "^(\\d{4}-\\d{2}-\\d{2})(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?\\+\\d{2}:\\d{2})?$" ;
-        sh:severity sh:Warning ;
-        sh:message """Web-based Data Entities SHOULD have a `sdDatePublished` property""" ;
+        sh:pattern "^([\\+-]?\\d{4})((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))|W([0-4]\\d|5[0-2])(-?[1-7])|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)?[0-5]\\d)?|24:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)$" ;
+        sh:message """Web-based Data Entities SHOULD have a `sdDatePublished` property to indicate when the absolute URL was accessed""" ;
     ] .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,3 +110,39 @@ def ro_crate_profile_should_path(ro_crate_profile_path):
 @fixture
 def ro_crate_profile_may_path(ro_crate_profile_path):
     return os.path.join(ro_crate_profile_path, "may")
+
+
+@fixture(params=[
+    "2024 01 01",
+    "2024 Jan 01",
+    "2021-13-01",
+    "2021-00-10",
+    "2021-01-32",
+    "2021-01-01T25:00",
+    "2021-01-01T23:60",
+    "2021-01-01T23:59:60",
+    "T23:59:59",
+])
+def invalid_datetime(request):
+    return request.param
+
+
+@fixture(params=[
+    "2024",
+    "2024-01",
+    "202401",
+    "2024-01-01",
+    "20240101",
+    "2024-001",
+    "2024-W01",
+    "2024-W01-1",
+    "2024-01-01T00:00",
+    "2024-01-01T00:00:00",
+    "2024-01-01T00:00:00Z",
+    "2024-01-01T00:00:00+00:00",
+    "2024-01-01T00:00:00.000",
+    "2024-01-01T00:00:00.000Z",
+    "2024-01-01T00:00:00.000+00:00",
+])
+def valid_datetime(request):
+    return request.param

--- a/tests/data/crates/invalid/2_root_data_entity_metadata/invalid_recommended_root_date/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/2_root_data_entity_metadata/invalid_recommended_root_date/ro-crate-metadata.json
@@ -1,0 +1,152 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "GithubService": "https://w3id.org/ro/terms/test#GithubService",
+            "JenkinsService": "https://w3id.org/ro/terms/test#JenkinsService",
+            "PlanemoEngine": "https://w3id.org/ro/terms/test#PlanemoEngine",
+            "TestDefinition": "https://w3id.org/ro/terms/test#TestDefinition",
+            "TestInstance": "https://w3id.org/ro/terms/test#TestInstance",
+            "TestService": "https://w3id.org/ro/terms/test#TestService",
+            "TestSuite": "https://w3id.org/ro/terms/test#TestSuite",
+            "TravisService": "https://w3id.org/ro/terms/test#TravisService",
+            "definition": "https://w3id.org/ro/terms/test#definition",
+            "engineVersion": "https://w3id.org/ro/terms/test#engineVersion",
+            "instance": "https://w3id.org/ro/terms/test#instance",
+            "resource": "https://w3id.org/ro/terms/test#resource",
+            "runsOn": "https://w3id.org/ro/terms/test#runsOn"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "datePublished": "202401",
+            "description": "This RO Crate contains the workflow MyWorkflow",
+            "hasPart": [
+                {
+                    "@id": "my-workflow.ga"
+                },
+                {
+                    "@id": "my-workflow-test.yml"
+                },
+                {
+                    "@id": "test-data/"
+                },
+                {
+                    "@id": "README.md"
+                }
+            ],
+            "isBasedOn": "https://github.com/kikkomep/myworkflow",
+            "license": "MIT",
+            "mainEntity": {
+                "@id": "my-workflow.ga"
+            },
+            "mentions": [
+                {
+                    "@id": "#1d230a09-a465-411a-82bb-d7d4f3f1be02"
+                }
+            ],
+            "name": "MyWorkflow"
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                }
+            ]
+        },
+        {
+            "@id": "my-workflow.ga",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow"
+            ],
+            "name": "MyWorkflow",
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+            },
+            "url": "https://github.com/kikkomep/myworkflow",
+            "version": "main"
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
+            "@type": "ComputerLanguage",
+            "identifier": {
+                "@id": "https://galaxyproject.org/"
+            },
+            "name": "Galaxy",
+            "url": {
+                "@id": "https://galaxyproject.org/"
+            }
+        },
+        {
+            "@id": "#1d230a09-a465-411a-82bb-d7d4f3f1be02",
+            "@type": "TestSuite",
+            "definition": {
+                "@id": "my-workflow-test.yml"
+            },
+            "instance": [
+                {
+                    "@id": "#350f2567-6ed2-4080-b354-a0921f49a4a9"
+                }
+            ],
+            "mainEntity": {
+                "@id": "my-workflow.ga"
+            },
+            "name": "Test suite for MyWorkflow"
+        },
+        {
+            "@id": "#350f2567-6ed2-4080-b354-a0921f49a4a9",
+            "@type": "TestInstance",
+            "name": "GitHub Actions workflow for testing MyWorkflow",
+            "resource": "repos/kikkomep/myworkflow/actions/workflows/main.yml",
+            "runsOn": {
+                "@id": "https://w3id.org/ro/terms/test#GithubService"
+            },
+            "url": "https://api.github.com"
+        },
+        {
+            "@id": "https://w3id.org/ro/terms/test#GithubService",
+            "@type": "TestService",
+            "name": "Github Actions",
+            "url": {
+                "@id": "https://github.com"
+            }
+        },
+        {
+            "@id": "my-workflow-test.yml",
+            "@type": [
+                "File",
+                "TestDefinition"
+            ],
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/terms/test#PlanemoEngine"
+            }
+        },
+        {
+            "@id": "https://w3id.org/ro/terms/test#PlanemoEngine",
+            "@type": "SoftwareApplication",
+            "name": "Planemo",
+            "url": {
+                "@id": "https://github.com/galaxyproject/planemo"
+            }
+        },
+        {
+            "@id": "test-data/",
+            "@type": "Dataset",
+            "description": "Data files for testing the workflow"
+        },
+        {
+            "@id": "README.md",
+            "@type": "File",
+            "description": "Workflow documentation"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/4_data_entity_metadata/invalid_sdDatePublished/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/4_data_entity_metadata/invalid_sdDatePublished/ro-crate-metadata.json
@@ -1,0 +1,140 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "sort-and-change-case Workflow RO-Crate",
+            "description": "sort-and-change-case Workflow RO-Crate",
+            "datePublished": "2024-04-17T13:39:44+00:00",
+            "hasPart": [
+                {
+                    "@id": "sort-and-change-case.ga"
+                },
+                {
+                    "@id": "https://sort-and-change-case.cwl"
+                },
+                {
+                    "@id": "blank.png"
+                },
+                {
+                    "@id": "README.md"
+                },
+                {
+                    "@id": "test/"
+                },
+                {
+                    "@id": "examples/"
+                }
+            ],
+            "license": {
+                "@id": "https://spdx.org/licenses/Apache-2.0.html"
+            },
+            "mainEntity": {
+                "@id": "sort-and-change-case.ga"
+            }
+        },
+        {
+            "@id": "https://spdx.org/licenses/Apache-2.0.html",
+            "@type": "CreativeWork",
+            "name": "Apache 2.0 license"
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
+        },
+        {
+            "@id": "sort-and-change-case.ga",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow"
+            ],
+            "conformsTo": {
+                "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
+            },
+            "description": "sort lines and change text to upper case",
+            "image": {
+                "@id": "blank.png"
+            },
+            "license": "https://spdx.org/licenses/MIT.html",
+            "name": "sort-and-change-case",
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+            },
+            "subjectOf": {
+                "@id": "https://sort-and-change-case.cwl"
+            }
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
+            "@type": "ComputerLanguage",
+            "identifier": {
+                "@id": "https://galaxyproject.org/"
+            },
+            "name": "Galaxy",
+            "url": {
+                "@id": "https://galaxyproject.org/"
+            }
+        },
+        {
+            "@id": "https://sort-and-change-case.cwl",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "HowTo"
+            ],
+            "name": "sort-and-change-case",
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
+            },
+            "sdDatePublished": "2024 Jan 01"
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
+            "@type": "ComputerLanguage",
+            "alternateName": "CWL",
+            "identifier": {
+                "@id": "https://w3id.org/cwl/"
+            },
+            "name": "Common Workflow Language",
+            "url": {
+                "@id": "https://www.commonwl.org/"
+            }
+        },
+        {
+            "@id": "blank.png",
+            "@type": [
+                "File",
+                "ImageObject"
+            ]
+        },
+        {
+            "@id": "README.md",
+            "@type": "File",
+            "about": {
+                "@id": "./"
+            },
+            "encodingFormat": "text/markdown"
+        },
+        {
+            "@id": "test/",
+            "@type": "Dataset"
+        },
+        {
+            "@id": "examples/",
+            "@type": "Dataset"
+        }
+    ]
+}

--- a/tests/data/crates/invalid/4_data_entity_metadata/no_sdDatePublished/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/4_data_entity_metadata/no_sdDatePublished/ro-crate-metadata.json
@@ -1,0 +1,139 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "sort-and-change-case Workflow RO-Crate",
+            "description": "sort-and-change-case Workflow RO-Crate",
+            "datePublished": "2024-04-17T13:39:44+00:00",
+            "hasPart": [
+                {
+                    "@id": "sort-and-change-case.ga"
+                },
+                {
+                    "@id": "https://sort-and-change-case.cwl"
+                },
+                {
+                    "@id": "blank.png"
+                },
+                {
+                    "@id": "README.md"
+                },
+                {
+                    "@id": "test/"
+                },
+                {
+                    "@id": "examples/"
+                }
+            ],
+            "license": {
+                "@id": "https://spdx.org/licenses/Apache-2.0.html"
+            },
+            "mainEntity": {
+                "@id": "sort-and-change-case.ga"
+            }
+        },
+        {
+            "@id": "https://spdx.org/licenses/Apache-2.0.html",
+            "@type": "CreativeWork",
+            "name": "Apache 2.0 license"
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "./"
+            },
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
+        },
+        {
+            "@id": "sort-and-change-case.ga",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow"
+            ],
+            "conformsTo": {
+                "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE"
+            },
+            "description": "sort lines and change text to upper case",
+            "image": {
+                "@id": "blank.png"
+            },
+            "license": "https://spdx.org/licenses/MIT.html",
+            "name": "sort-and-change-case",
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+            },
+            "subjectOf": {
+                "@id": "https://sort-and-change-case.cwl"
+            }
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
+            "@type": "ComputerLanguage",
+            "identifier": {
+                "@id": "https://galaxyproject.org/"
+            },
+            "name": "Galaxy",
+            "url": {
+                "@id": "https://galaxyproject.org/"
+            }
+        },
+        {
+            "@id": "https://sort-and-change-case.cwl",
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "HowTo"
+            ],
+            "name": "sort-and-change-case",
+            "programmingLanguage": {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
+            }
+        },
+        {
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
+            "@type": "ComputerLanguage",
+            "alternateName": "CWL",
+            "identifier": {
+                "@id": "https://w3id.org/cwl/"
+            },
+            "name": "Common Workflow Language",
+            "url": {
+                "@id": "https://www.commonwl.org/"
+            }
+        },
+        {
+            "@id": "blank.png",
+            "@type": [
+                "File",
+                "ImageObject"
+            ]
+        },
+        {
+            "@id": "README.md",
+            "@type": "File",
+            "about": {
+                "@id": "./"
+            },
+            "encodingFormat": "text/markdown"
+        },
+        {
+            "@id": "test/",
+            "@type": "Dataset"
+        },
+        {
+            "@id": "examples/",
+            "@type": "Dataset"
+        }
+    ]
+}

--- a/tests/integration/profiles/ro-crate/test_root_data_entity.py
+++ b/tests/integration/profiles/ro-crate/test_root_data_entity.py
@@ -15,7 +15,7 @@
 import logging
 
 from rocrate_validator import models
-from tests.ro_crates import InvalidRootDataEntity
+from tests.ro_crates import InvalidRootDataEntity, ValidROC
 from tests.shared import do_entity_test
 
 # set up logging
@@ -114,11 +114,16 @@ def test_valid_required_root_date(valid_datetime):
         rocrate_entity_patch={"./": {"datePublished": valid_datetime}}
     )
 
+
+def test_invalid_recommended_root_date():
+    """Test a RO-Crate with an invalid root data entity date."""
+    do_entity_test(
+        paths.invalid_recommended_root_date,
         models.Severity.RECOMMENDED,
         False,
         ["RO-Crate Root Data Entity RECOMMENDED properties"],
         ["The Root Data Entity MUST have a `datePublished` property (as specified by schema.org) "
-         "with a valid ISO 8601 date and the precision of at least the day level"]
+            "with a valid ISO 8601 date and the precision of at least the day level"]
     )
 
 

--- a/tests/integration/profiles/ro-crate/test_root_data_entity.py
+++ b/tests/integration/profiles/ro-crate/test_root_data_entity.py
@@ -92,10 +92,28 @@ def test_recommended_root_data_entity_value():
     )
 
 
-def test_invalid_root_date():
+def test_invalid_required_root_date(invalid_datetime):
     """Test a RO-Crate with an invalid root data entity date."""
     do_entity_test(
         paths.invalid_root_date,
+        models.Severity.REQUIRED,
+        False,
+        ["RO-Crate Root Data Entity REQUIRED properties"],
+        ["The Root Data Entity MUST have a `datePublished` property (as specified by schema.org) "
+            "with a valid ISO 8601 date"],
+        rocrate_entity_patch={"./": {"datePublished": invalid_datetime}}
+    )
+
+
+def test_valid_required_root_date(valid_datetime):
+    """Test a RO-Crate with a valid root data entity date."""
+    do_entity_test(
+        ValidROC().wrroc_paper,
+        models.Severity.REQUIRED,
+        True,
+        rocrate_entity_patch={"./": {"datePublished": valid_datetime}}
+    )
+
         models.Severity.RECOMMENDED,
         False,
         ["RO-Crate Root Data Entity RECOMMENDED properties"],

--- a/tests/integration/profiles/ro-crate/test_web_based_data_entity.py
+++ b/tests/integration/profiles/ro-crate/test_web_based_data_entity.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from rocrate_validator import models
+from tests.ro_crates import InvalidDataEntity
+from tests.shared import do_entity_test
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+#  Global set up the paths
+paths = InvalidDataEntity()
+
+
+def test_no_recommended_sdDatePublished():
+    """Test a web based data entity without a recommended sdDatePublished property."""
+    do_entity_test(
+        paths.no_sdDatePublished,
+        models.Severity.RECOMMENDED,
+        False,
+        ["Web-based Data Entity: RECOMMENDED properties"],
+        ["Web-based Data Entities SHOULD have "
+         "a `sdDatePublished` property to indicate when the absolute URL was accessed"]
+    )
+
+
+def test_invalid_recommended_sdDatePublished(invalid_datetime):
+    """Test a web based data entity with an invalid sdDatePublished property."""
+    do_entity_test(
+        paths.invalid_sdDatePublished,
+        models.Severity.RECOMMENDED,
+        False,
+        ["Web-based Data Entity: RECOMMENDED properties"],
+        ["Web-based Data Entities SHOULD have "
+         "a `sdDatePublished` property to indicate when the absolute URL was accessed"],
+        rocrate_entity_patch={"https://sort-and-change-case.cwl": {"datePublished": invalid_datetime}}
+    )

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -121,6 +121,10 @@ class InvalidRootDataEntity:
         return self.base_path / "invalid_root_date"
 
     @property
+    def invalid_recommended_root_date(self) -> Path:
+        return self.base_path / "invalid_recommended_root_date"
+
+    @property
     def missing_root_name(self) -> Path:
         return self.base_path / "missing_root_name"
 

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -226,6 +226,14 @@ class InvalidDataEntity:
     def valid_encoding_format_pronom(self) -> Path:
         return self.base_path / "valid_encoding_format_pronom"
 
+    @property
+    def no_sdDatePublished(self) -> Path:
+        return self.base_path / "no_sdDatePublished"
+
+    @property
+    def invalid_sdDatePublished(self) -> Path:
+        return self.base_path / "invalid_sdDatePublished"
+
 
 class InvalidMainWorkflow:
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -41,7 +41,8 @@ def do_entity_test(
         expected_triggered_requirements: Optional[list[str]] = None,
         expected_triggered_issues: Optional[list[str]] = None,
         abort_on_first: bool = True,
-        profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER
+        profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
+        rocrate_entity_patch: Optional[dict] = None,
 ):
     """
     Shared function to test a RO-Crate entity
@@ -52,6 +53,26 @@ def do_entity_test(
 
     if not isinstance(rocrate_path, Path):
         rocrate_path = Path(rocrate_path)
+
+    temp_rocrate_path = None
+    if rocrate_entity_patch is not None and rocrate_path.is_dir():
+        # create a temporary copy of the RO-Crate
+        temp_rocrate_path = Path(tempfile.TemporaryDirectory().name)
+        # copy the RO-Crate to the temporary path using shutil
+        shutil.copytree(rocrate_path, temp_rocrate_path)
+        # load the RO-Crate metadata as RO-Crate JSON-LD
+        with open(temp_rocrate_path / "ro-crate-metadata.json", "r") as f:
+            rocrate = json.load(f)
+        # update the RO-Crate metadata with the patch
+        for key, value in rocrate_entity_patch.items():
+            for entity in rocrate["@graph"]:
+                if entity["@id"] == key:
+                    entity.update(value)
+                    break
+        # save the updated RO-Crate metadata
+        with open(temp_rocrate_path / "ro-crate-metadata.json", "w") as f:
+            json.dump(rocrate, f)
+        rocrate_path = temp_rocrate_path
 
     if expected_triggered_requirements is None:
         expected_triggered_requirements = []
@@ -111,3 +132,8 @@ def do_entity_test(
             logger.debug("Failed requirements: %s", failed_requirements)
             logger.debug("Detected issues: %s", detected_issues)
         raise e
+    finally:
+        # cleanup
+        if temp_rocrate_path is not None:
+            logger.debug("Cleaning up temporary RO-Crate @ path: %s", temp_rocrate_path)
+            shutil.rmtree(temp_rocrate_path)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -16,7 +16,10 @@
 Library of shared functions for testing RO-Crate profiles
 """
 
+import json
 import logging
+import shutil
+import tempfile
 from collections.abc import Collection
 from pathlib import Path
 from typing import Optional, TypeVar, Union


### PR DESCRIPTION
This PR updates the validation rules for datetime properties to conform to the ISO 8601 standard. 

Specifically, the `datePublished` property of the root data entity accepts any value that complies with the standard, while day-level precision is RECOMMENDED, as indicated by the specs.

[fix issue #26]