### PR TITLE
enhancement: validation of RO-Crate URI input

### DIFF
--- a/rocrate_validator/cli/commands/errors.py
+++ b/rocrate_validator/cli/commands/errors.py
@@ -18,7 +18,8 @@ import textwrap
 from rich.console import Console
 
 import rocrate_validator.log as logging
-from rocrate_validator.errors import InvalidProfilePath, ProfileNotFound, ProfilesDirectoryNotFound
+from rocrate_validator.errors import (InvalidProfilePath, ProfileNotFound,
+                                      ProfilesDirectoryNotFound)
 
 # Create a logger for this module
 logger = logging.getLogger(__name__)

--- a/rocrate_validator/errors.py
+++ b/rocrate_validator/errors.py
@@ -243,9 +243,9 @@ class CheckValidationError(ValidationError):
 class ROCrateInvalidURIError(ROCValidatorError):
     """Raised when an invalid URI is provided."""
 
-    def __init__(self, uri: Optional[str] = None, message: Optional[str] = None):
+    def __init__(self, uri: str, message: Optional[str] = None):
         self._uri = uri
-        self._message = message
+        self._message = message or self.default_error_message(uri)
 
     @property
     def uri(self) -> Optional[str]:
@@ -258,13 +258,15 @@ class ROCrateInvalidURIError(ROCValidatorError):
         return self._message
 
     def __str__(self) -> str:
-        if self._message:
-            return f"Invalid URI \"{self._uri!r}\": {self._message!r}"
-        else:
-            return f"Invalid URI \"{self._uri!r}\""
+        return self._message
 
     def __repr__(self):
         return f"ROCrateInvalidURIError({self._uri!r})"
+
+    @classmethod
+    def default_error_message(cls, uri: str) -> str:
+        return f"Invalid RO-Crate URI \"{uri}\": "\
+            "it MUST be the local path to the root RO-Crate directory or a ZIP file (local or remote)."
 
 
 class ROCrateMetadataNotFoundError(ROCValidatorError):

--- a/rocrate_validator/errors.py
+++ b/rocrate_validator/errors.py
@@ -265,8 +265,8 @@ class ROCrateInvalidURIError(ROCValidatorError):
 
     @classmethod
     def default_error_message(cls, uri: str) -> str:
-        return f"Invalid RO-Crate URI \"{uri}\": "\
-            "it MUST be the local path to the root RO-Crate directory or a ZIP file (local or remote)."
+        return f"\"{uri}\" is not a valid RO-Crate URI. "\
+            "It MUST be either a local path to the RO-Crate root directory or a local/remote RO-Crate ZIP file."
 
 
 class ROCrateMetadataNotFoundError(ROCValidatorError):

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -362,8 +362,8 @@ class ROCrate(ABC):
     @staticmethod
     def new_instance(uri: Union[str, Path, URI]) -> 'ROCrate':
         # check if the URI is valid
-        if not uri:
-            raise ValueError("Invalid URI")
+        validate_rocrate_uri(uri, silent=False)
+        # create a new instance based on the URI
         if not isinstance(uri, URI):
             uri = URI(uri)
         # check if the URI is a local directory
@@ -376,7 +376,7 @@ class ROCrate(ABC):
         if uri.is_remote_resource():
             return ROCrateRemoteZip(uri)
         # if the URI is not supported, raise an error
-        raise ROCrateInvalidURIError(uri=uri, message="Unsupported URI")
+        raise ROCrateInvalidURIError(uri=uri, message="Unsupported RO-Crate URI")
 
 
 class ROCrateLocalFolder(ROCrate):

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -27,7 +27,7 @@ from rdflib import Graph
 
 from rocrate_validator import log as logging
 from rocrate_validator.errors import ROCrateInvalidURIError
-from rocrate_validator.utils import URI
+from rocrate_validator.utils import URI, validate_rocrate_uri
 
 # set up logging
 logger = logging.getLogger(__name__)

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -480,7 +480,7 @@ def validate_rocrate_uri(uri: Union[str, URI], silent: bool = False) -> bool:
                 raise errors.ROCrateInvalidURIError(uri)
             # check if the resource is available
             if not uri.is_available():
-                raise errors.ROCrateInvalidURIError(uri, message=f"RO-crate URI \"{uri}\" not available")
+                raise errors.ROCrateInvalidURIError(uri, message=f"The RO-crate at the URI \"{uri}\" is not available")
             return True
         except ValueError as e:
             logger.error(e)

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -375,7 +375,7 @@ class URI:
         except Exception as e:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(e)
-            raise ValueError("Invalid URI: %s", uri)
+            raise ValueError("Invalid URI: %s" % uri)
 
     @property
     def uri(self) -> str:

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -469,26 +469,24 @@ def validate_rocrate_uri(uri: Union[str, URI], silent: bool = False) -> bool:
     try:
         assert uri, "The RO-Crate URI is required"
         assert isinstance(uri, (str, URI)), "The RO-Crate URI must be a string or URI object"
-        error_message = f"Invalid RO-Crate URI \"{uri}\": "\
-            "it MUST be the local path to the root RO-Crate directory or a ZIP file (local or remote)."
         try:
             # parse the value to extract the scheme
             uri = URI(uri) if isinstance(uri, str) else uri
             # check if the URI is a remote resource or local directory or local file
             if not uri.is_remote_resource() and not uri.is_local_directory() and not uri.is_local_file():
-                raise errors.ROCrateInvalidURIError(error_message)
+                raise errors.ROCrateInvalidURIError(uri)
             # check if the local file is a ZIP file
             if uri.is_local_file() and uri.as_path().suffix != ".zip":
-                raise errors.ROCrateInvalidURIError(error_message)
+                raise errors.ROCrateInvalidURIError(uri)
             # check if the resource is available
             if not uri.is_available():
-                raise errors.ROCrateInvalidURIError(f"RO-crate URI \"{uri}\" not available")
+                raise errors.ROCrateInvalidURIError(uri, message=f"RO-crate URI \"{uri}\" not available")
             return True
         except ValueError as e:
             logger.error(e)
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception(e)
-            raise errors.ROCrateInvalidURIError(error_message)
+            raise errors.ROCrateInvalidURIError(uri)
     except Exception as e:
         if not silent:
             raise e


### PR DESCRIPTION
This PR addresses issue #33 by fixing and extending the validation of the RO-Crate URI provided as input to the validator.

With these changes, the validator should now raise the following error message in the case mentioned in issue #33:

```bash
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value for '[ROCRATE_URI]': "data/myCrate/ro-crate-metadata.json" is not a valid                          │
│ RO-Crate URI. It MUST be either a local path to the RO-Crate root directory or a local/remote RO-Crate ZIP file. │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

[fix #33]