### PR TITLE
enhancement: validate jsonld is properly flattened

### DIFF
--- a/tests/data/crates/invalid/0_file_descriptor_format/invalid_jsonld_format/not_flattened/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/0_file_descriptor_format/invalid_jsonld_format/not_flattened/ro-crate-metadata.json
@@ -1,0 +1,31 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@type": "Dataset",
+                "@id": "./",
+                "hasPart": [
+                    {
+                        "@type": "File",
+                        "@id": "test.csv",
+                        "encodingFormat": "text/csv",
+                        "name": "This is a test file",
+                        "description": "This is a test dataset"
+                    }
+                ],
+                "name": "This is a test dataset",
+                "description": "This is a test dataset",
+                "license": {
+                    "@id": "https://creativecommons.org/licenses/by/4.0/"
+                },
+                "datePublished": "2024-11-05"
+            }
+        }
+    ]
+}

--- a/tests/integration/profiles/ro-crate/test_file_descriptor_format.py
+++ b/tests/integration/profiles/ro-crate/test_file_descriptor_format.py
@@ -59,6 +59,19 @@ def test_not_valid_jsonld_format_missing_context():
     )
 
 
+def test_not_valid_jsonld_format_not_flattened():
+    """Test a RO-Crate with an invalid JSON-LD file descriptor format.
+    One or more entities in the file descriptor are not flattened.
+    """
+    do_entity_test(
+        f"{paths.invalid_jsonld_format}/not_flattened",
+        models.Severity.REQUIRED,
+        False,
+        ["File Descriptor JSON-LD format"],
+        ["RO-Crate file descriptor \"ro-crate-metadata.json\" is not fully flattened"]
+    )
+
+
 def test_not_valid_jsonld_format_missing_ids():
     """
     Test a RO-Crate with an invalid JSON-LD file descriptor format.

--- a/tests/ro_crates.py
+++ b/tests/ro_crates.py
@@ -95,6 +95,10 @@ class InvalidFileDescriptor:
     def invalid_jsonld_format(self) -> Path:
         return self.base_path / "invalid_jsonld_format"
 
+    @property
+    def invalid_not_flattened(self) -> Path:
+        return self.base_path / "invalid_not_flattened"
+
 
 class InvalidRootDataEntity:
 


### PR DESCRIPTION
This addresses #27 by introducing a new test for a flattened jsonld structure.

I first tried to solve it with pyld by flattening the input jsonld and comparing the flattened and original one but ran into the issue that pyld does not preserve key order in python dicts. Also, pyld was rather slow.

Right now, the check instead goes through all entities in the graph and fails if a nested dict has more properties than an id.