### PR TITLE
feature: Handle Ctrl+C

### DIFF
--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -109,6 +109,8 @@ def __get_single_char_unix__(console: Optional[Console] = None, end: str = "\n",
         try:
             tty.setraw(sys.stdin.fileno())
             char = sys.stdin.read(1)
+            if char == "\x03":
+                raise KeyboardInterrupt
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
             if console:

--- a/rocrate_validator/cli/utils.py
+++ b/rocrate_validator/cli/utils.py
@@ -58,7 +58,7 @@ class SystemPager(Pager):
     """Uses the pager installed on the system."""
 
     def _pager(self, content: str) -> Any:
-        return pydoc.pipepager(content, "less -R")
+        return pydoc.pipepager(content, "less -R -K")
 
     def show(self, content: str) -> None:
         """Use the same pager used by pydoc."""


### PR DESCRIPTION
On Unix, sending `SIGINT` (Ctrl+C) to a process should always kill it.
@floWetzels noticed that this is not working when the validator asks you if you want to see details on failed checks (It only allows y/n but ignores Ctrl+C)

This fixes the issue by checking if the send char is a SIGINT and raises the appropriate exception. I also included the `-K` flag for the `less` pager, which allows to exit the pager by sending Ctrl+C in addition to sending `q`.