### PR TITLE
fix: RO-Crate validation should work for nested properties without id

### DIFF
--- a/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
@@ -109,7 +109,7 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                             return False
                 # if this is not the root element, it must not contain more properties than @id
                 else:
-                    if "@id" in entity and len(entity) > 1:
+                    if "@id" not in entity or len(entity) > 1:
                         return False
             if isinstance(entity, list):
                 for element in entity:

--- a/tests/data/crates/invalid/0_file_descriptor_format/invalid_jsonld_format/not_flattened/ro-crate-metadata.json
+++ b/tests/data/crates/invalid/0_file_descriptor_format/invalid_jsonld_format/not_flattened/ro-crate-metadata.json
@@ -8,24 +8,24 @@
                 "@id": "https://w3id.org/ro/crate/1.1"
             },
             "about": {
-                "@type": "Dataset",
-                "@id": "./",
-                "hasPart": [
-                    {
-                        "@type": "File",
-                        "@id": "test.csv",
-                        "encodingFormat": "text/csv",
-                        "name": "This is a test file",
-                        "description": "This is a test dataset"
-                    }
-                ],
-                "name": "This is a test dataset",
-                "description": "This is a test dataset",
-                "license": {
-                    "@id": "https://creativecommons.org/licenses/by/4.0/"
-                },
-                "datePublished": "2024-11-05"
+                "@id": "./"
             }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "This is a test dataset",
+            "description": "This is a test dataset",
+            "license": {
+                "@id": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            "datePublished": "2024-11-05",
+            "hasPart": [
+                {
+                    "@type": "File",
+                    "name": "File in a nested entity"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This should fix the case @simleo raised in issue #27