### PR TITLE
feat: swap default behaviour for fail fast

### DIFF
--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -135,10 +135,10 @@ def get_single_char(console: Optional[Console] = None, end: str = "\n",
 @cli.command("validate")
 @click.argument("rocrate-uri", callback=validate_uri, default=".")
 @click.option(
-    '-nff',
-    '--no-fail-fast',
+    '-ff',
+    '--fail-fast',
     is_flag=True,
-    help="Disable fail fast validation mode",
+    help="Fail fast validation mode",
     default=False,
     show_default=True
 )
@@ -239,7 +239,7 @@ def validate(ctx,
              requirement_severity: str = Severity.REQUIRED.name,
              requirement_severity_only: bool = False,
              rocrate_uri: Path = ".",
-             no_fail_fast: bool = False,
+             fail_fast: bool = False,
              no_paging: bool = False,
              verbose: bool = False,
              output_format: str = "text",
@@ -264,8 +264,8 @@ def validate(ctx,
 
     logger.debug("disable_inheritance: %s", disable_profile_inheritance)
     logger.debug("rocrate_uri: %s", rocrate_uri)
-    logger.debug("no_fail_fast: %s", no_fail_fast)
-    logger.debug("fail fast: %s", not no_fail_fast)
+    logger.debug("fail_fast: %s", fail_fast)
+    logger.debug("no fail fast: %s", not fail_fast)
 
     if rocrate_uri:
         logger.debug("rocrate_path: %s", os.path.abspath(rocrate_uri))
@@ -280,7 +280,7 @@ def validate(ctx,
             "enable_profile_inheritance": not disable_profile_inheritance,
             "verbose": verbose,
             "rocrate_uri": rocrate_uri,
-            "abort_on_first": not no_fail_fast
+            "abort_on_first": fail_fast
         }
 
         # Print the application header
@@ -406,7 +406,7 @@ def validate(ctx,
                             report_layout.show_validation_details(None, enable_pager=False)
 
             # Interrupt the validation if the fail fast mode is enabled
-            if no_fail_fast and not is_valid:
+            if fail_fast and not is_valid:
                 break
 
         # using ctx.exit seems to raise an Exception that gets caught below,


### PR DESCRIPTION
The default behaviour of fail fast is currently to always fail fast.

https://github.com/crs4/rocrate-validator/pull/42#discussion_r1852587846 discussed that this could be swapped to not fail fast by default. This PR implements this behaviour by changing -nff to -ff for "fail-fast"

I personally feel that this is a more sensible default behaviour for CLI, since users are likely interested in knowing everything that is wrong with their crate.

With this PR, options look like this:
```
> rocrate-validator validate --help
                                                                                                                                                                                                              
 Usage: rocrate-validator validate [OPTIONS] [ROCRATE_URI]                                                                                                                                                    
                                                                                                                                                                                                              
 rocrate-validator: Validate a RO-Crate against a profile 

╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --fail-fast                    -ff                                   Fail fast validation mode
(...)
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```

And work as expected:
```bash
> rocrate-validator validate -f json -p workflow-run-crate-0.5 .
{
    "meta": {
        "version": "0.1"
    },
    "validation_settings": {
        "profile_identifier": "workflow-run-crate-0.5",
        "enable_profile_inheritance": true,
        "abort_on_first": false,
        "requirement_severity": "REQUIRED",
        "rocrate_validator_version": "0.4.6_26877b5+0-dirty"
    },
    "passed": false,
    "issues": [
        {
            "severity": "REQUIRED",
            "message": "The Main Workflow must refer to its language via programmingLanguage",
            "violatingEntity": "./workflow.yaml",
            "violatingProperty": "http://schema.org/programmingLanguage",
            "violatingPropertyValue": null,
            "check": {
                "identifier": "workflow-ro-crate-1.0_2.2",
                "label": "MUST 2.2",
                "order": 2,
                "name": "Main Workflow language",
                "description": "The Main Workflow must refer to its language via programmingLanguage",
                "severity": "REQUIRED",
                "requirement": {
                    "identifier": "workflow-ro-crate-1.0_2",
                    "name": "Main Workflow definition",
                    "description": "Main Workflow properties defined as MUST",
                    "order": 2,
                    "profile": {
                        "identifier": "workflow-ro-crate-1.0",
                        "uri": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
                        "name": "Workflow RO-Crate Metadata Specification 1.0",
                        "description": "Workflow RO-Crate Metadata Specification."
                    }
                }
            }
        },
        {
            "severity": "REQUIRED",
            "message": "The Root Data Entity MUST reference a CreativeWork entity with an @id URI that is consistent with the versioned permalink of the Workflow Run Crate profile",
            "violatingEntity": "./",
            "violatingProperty": "http://purl.org/dc/terms/conformsTo",
            "violatingPropertyValue": null,
            "check": {
                "identifier": "workflow-run-crate-0.5_2.1",
                "label": "MUST 2.1",
                "order": 1,
                "name": "Root Data Entity conformsTo",
                "description": "The Root Data Entity MUST reference a CreativeWork entity with an @id URI that is consistent with the versioned permalink of the Workflow Run Crate profile",
                "severity": "REQUIRED",
                "requirement": {
                    "identifier": "workflow-run-crate-0.5_2",
                    "name": "Root Data Entity Metadata",
                    "description": "Properties of the Root Data Entity",
                    "order": 2,
                    "profile": {
                        "identifier": "workflow-run-crate-0.5",
                        "uri": "https://w3id.org/ro/wfrun/workflow/0.5",
                        "name": "Workflow Run Crate 0.5",
                        "description": "Workflow Run Crate Metadata Specification 0.5"
                    }
                }
            }
        }
    ]
}
```
vs.
```bash
> rocrate-validator validate -ff -f json -p workflow-run-crate-0.5 .
{
    "meta": {
        "version": "0.1"
    },
    "validation_settings": {
        "profile_identifier": "workflow-run-crate-0.5",
        "enable_profile_inheritance": true,
        "abort_on_first": true,
        "requirement_severity": "REQUIRED",
        "rocrate_validator_version": "0.4.6_26877b5+0-dirty"
    },
    "passed": false,
    "issues": [
        {
            "severity": "REQUIRED",
            "message": "The Root Data Entity MUST reference a CreativeWork entity with an @id URI that is consistent with the versioned permalink of the Workflow Run Crate profile",
            "violatingEntity": "./",
            "violatingProperty": "http://purl.org/dc/terms/conformsTo",
            "violatingPropertyValue": null,
            "check": {
                "identifier": "workflow-run-crate-0.5_2.1",
                "label": "MUST 2.1",
                "order": 1,
                "name": "Root Data Entity conformsTo",
                "description": "The Root Data Entity MUST reference a CreativeWork entity with an @id URI that is consistent with the versioned permalink of the Workflow Run Crate profile",
                "severity": "REQUIRED",
                "requirement": {
                    "identifier": "workflow-run-crate-0.5_2",
                    "name": "Root Data Entity Metadata",
                    "description": "Properties of the Root Data Entity",
                    "order": 2,
                    "profile": {
                        "identifier": "workflow-run-crate-0.5",
                        "uri": "https://w3id.org/ro/wfrun/workflow/0.5",
                        "name": "Workflow Run Crate 0.5",
                        "description": "Workflow Run Crate Metadata Specification 0.5"
                    }
                }
            }
        }
    ]
}
```