### PR TITLE
fix(issue 86): remove `requests_cache.install_cache`

### DIFF
--- a/rocrate_validator/cli/__init__.py
+++ b/rocrate_validator/cli/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .commands import profiles, validate
-from .main import cli
+from rocrate_validator.cli.commands import profiles, validate
+from rocrate_validator.cli.main import cli
 
 __all__ = ["cli", "profiles", "validate"]

--- a/rocrate_validator/cli/main.py
+++ b/rocrate_validator/cli/main.py
@@ -86,7 +86,7 @@ def cli(ctx: click.Context, debug: bool, version: bool, disable_color: bool, no_
         # If no subcommand is provided, invoke the default command
         if ctx.invoked_subcommand is None:
             # If no subcommand is provided, invoke the default command
-            from .commands.validate import validate
+            from rocrate_validator.cli.commands.validate import validate
             ctx.invoke(validate)
         else:
             logger.debug("Command invoked: %s", ctx.invoked_subcommand)

--- a/rocrate_validator/colors.py
+++ b/rocrate_validator/colors.py
@@ -14,7 +14,7 @@
 
 from typing import Union
 
-from .models import LevelCollection, Severity
+from rocrate_validator.models import LevelCollection, Severity
 
 
 def get_severity_color(severity: Union[str, Severity]) -> str:

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -88,4 +88,4 @@ JSON_OUTPUT_FORMAT_VERSION = "0.2"
 
 # Http Cache Settings
 DEFAULT_HTTP_CACHE_TIMEOUT = 60
-DEFAULT_HTTP_CACHE_PATH = '/tmp/rocrate_validator_cache'
+DEFAULT_HTTP_CACHE_PATH_PREFIX = '/tmp/rocrate_validator_cache'

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -86,5 +86,6 @@ VALID_REQUIREMENT_LEVELS_TYPES = typing.Literal[
 # Current JSON output format
 JSON_OUTPUT_FORMAT_VERSION = "0.2"
 
-# Default value for the HTTP cache timeout
+# Http Cache Settings
 DEFAULT_HTTP_CACHE_TIMEOUT = 60
+DEFAULT_HTTP_CACHE_PATH = '/tmp/rocrate_validator_cache'

--- a/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
@@ -14,12 +14,11 @@
 
 from typing import Any
 
-import requests
-
 import rocrate_validator.log as logging
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import (PyFunctionCheck, check,
                                                    requirement)
+from rocrate_validator.utils import HttpRequester
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -84,7 +83,7 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
     def __check_remote_context__(self, context_uri: str) -> bool:
         # Try to retrieve the context
         try:
-            raw_data = requests.get(context_uri, headers={"Accept": "application/ld+json"})
+            raw_data = HttpRequester().get(context_uri, headers={"Accept": "application/ld+json"})
             if raw_data.status_code != 200:
                 raise RuntimeError(f"Unable to retrieve the JSON-LD context '{context_uri}'", self)
             logger.debug(f"Retrieved context from {context_uri}")
@@ -234,7 +233,7 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
 
         logger.debug(f"Retrieving context from {context_uri}...")
         # Try to retrieve the context
-        raw_data = requests.get(context_uri, headers={"Accept": "application/ld+json"})
+        raw_data = HttpRequester().get(context_uri, headers={"Accept": "application/ld+json"})
         if raw_data.status_code != 200:
             raise RuntimeError(f"Unable to retrieve the JSON-LD context '{context_uri}'")
 

--- a/rocrate_validator/requirements/python/__init__.py
+++ b/rocrate_validator/requirements/python/__init__.py
@@ -18,10 +18,11 @@ from pathlib import Path
 from typing import Callable, Optional, Type
 
 import rocrate_validator.log as logging
-
-from ...models import (LevelCollection, Profile, Requirement, RequirementCheck,
-                       RequirementLevel, RequirementLoader, Severity, ValidationContext)
-from ...utils import get_classes_from_file
+from rocrate_validator.models import (LevelCollection, Profile, Requirement,
+                                      RequirementCheck, RequirementLevel,
+                                      RequirementLoader, Severity,
+                                      ValidationContext)
+from rocrate_validator.utils import get_classes_from_file
 
 # set up logging
 logger = logging.getLogger(__name__)

--- a/rocrate_validator/requirements/shacl/__init__.py
+++ b/rocrate_validator/requirements/shacl/__init__.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .checks import SHACLCheck
-from .errors import SHACLValidationError
-from .requirements import SHACLRequirement, SHACLRequirementLoader
-from .validator import SHACLValidationResult, SHACLValidator
+from rocrate_validator.requirements.shacl.checks import SHACLCheck
+from rocrate_validator.requirements.shacl.errors import SHACLValidationError
+from rocrate_validator.requirements.shacl.requirements import (
+    SHACLRequirement, SHACLRequirementLoader)
+from rocrate_validator.requirements.shacl.validator import (
+    SHACLValidationResult, SHACLValidator)
 
 __all__ = ["SHACLCheck", "SHACLValidator", "SHACLValidationResult",
            "SHACLValidationError", "SHACLRequirement", "SHACLRequirementLoader"]

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -25,10 +25,10 @@ from rocrate_validator.models import (LevelCollection, Requirement,
                                       SkipRequirementCheck, ValidationContext)
 from rocrate_validator.requirements.shacl.models import Shape
 from rocrate_validator.requirements.shacl.utils import make_uris_relative
-
-from .validator import (SHACLValidationAlreadyProcessed,
-                        SHACLValidationContext, SHACLValidationContextManager,
-                        SHACLValidationSkip, SHACLValidator, SHACLViolation)
+from rocrate_validator.requirements.shacl.validator import (
+    SHACLValidationAlreadyProcessed, SHACLValidationContext,
+    SHACLValidationContextManager, SHACLValidationSkip, SHACLValidator,
+    SHACLViolation)
 
 logger = logging.getLogger(__name__)
 

--- a/rocrate_validator/requirements/shacl/errors.py
+++ b/rocrate_validator/requirements/shacl/errors.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...errors import ValidationError
-from .validator import SHACLValidationResult
+from rocrate_validator.errors import ValidationError
+from rocrate_validator.requirements.shacl.validator import \
+    SHACLValidationResult
 
 
 class SHACLValidationError(ValidationError):

--- a/rocrate_validator/requirements/shacl/requirements.py
+++ b/rocrate_validator/requirements/shacl/requirements.py
@@ -19,11 +19,10 @@ from rdflib import RDF
 
 import rocrate_validator.log as logging
 from rocrate_validator.constants import VALIDATOR_NS
-
-from ...models import (Profile, Requirement, RequirementCheck,
-                       RequirementLevel, RequirementLoader)
-from .checks import SHACLCheck
-from .models import Shape, ShapesRegistry
+from rocrate_validator.models import (Profile, Requirement, RequirementCheck,
+                                      RequirementLevel, RequirementLoader)
+from rocrate_validator.requirements.shacl.checks import SHACLCheck
+from rocrate_validator.requirements.shacl.models import Shape, ShapesRegistry
 
 # set up logging
 logger = logging.getLogger(__name__)

--- a/rocrate_validator/requirements/shacl/validator.py
+++ b/rocrate_validator/requirements/shacl/validator.py
@@ -24,16 +24,16 @@ from rdflib import BNode, Graph
 from rdflib.term import Node, URIRef
 
 import rocrate_validator.log as logging
+from rocrate_validator.constants import (DEFAULT_ONTOLOGY_FILE,
+                                         RDF_SERIALIZATION_FORMATS,
+                                         RDF_SERIALIZATION_FORMATS_TYPES,
+                                         SHACL_NS, VALID_INFERENCE_OPTIONS,
+                                         VALID_INFERENCE_OPTIONS_TYPES)
 from rocrate_validator.models import (Profile, RequirementCheck, Severity,
                                       ValidationContext, ValidationResult)
+from rocrate_validator.requirements.shacl.models import ShapesRegistry
 from rocrate_validator.requirements.shacl.utils import (make_uris_relative,
                                                         map_severity)
-
-from ...constants import (DEFAULT_ONTOLOGY_FILE, RDF_SERIALIZATION_FORMATS,
-                          RDF_SERIALIZATION_FORMATS_TYPES, SHACL_NS,
-                          VALID_INFERENCE_OPTIONS,
-                          VALID_INFERENCE_OPTIONS_TYPES)
-from .models import ShapesRegistry
 
 # set up logging
 logger = logging.getLogger(__name__)

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -23,12 +23,11 @@ from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import unquote
 
-import requests
 from rdflib import Graph
 
 from rocrate_validator import log as logging
 from rocrate_validator.errors import ROCrateInvalidURIError
-from rocrate_validator.utils import URI, validate_rocrate_uri
+from rocrate_validator.utils import URI, HttpRequester, validate_rocrate_uri
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -525,7 +524,7 @@ class ROCrate(ABC):
         :return: the content of the file
         :rtype: Union[str, bytes]
         """
-        response = requests.get(str(uri))
+        response = HttpRequester().get(str(uri))
         response.raise_for_status()
         return response.content if binary_mode else response.text
 
@@ -542,7 +541,7 @@ class ROCrate(ABC):
 
         :raises requests.HTTPError: if the request fails
         """
-        response = requests.head(str(uri))
+        response = HttpRequester().head(str(uri))
         response.raise_for_status()
         return int(response.headers.get('Content-Length'))
 
@@ -727,7 +726,7 @@ class ROCrateRemoteZip(ROCrateLocalZip):
 
     @property
     def size(self) -> int:
-        response = requests.head(str(self.uri))
+        response = HttpRequester().head(str(self.uri))
         response.raise_for_status()  # Check if the request was successful
         file_size = response.headers.get('Content-Length')
         if file_size is not None:
@@ -738,7 +737,7 @@ class ROCrateRemoteZip(ROCrateLocalZip):
     @staticmethod
     def __fetch_range__(uri: str, start, end):
         headers = {'Range': f'bytes={start}-{end}'}
-        response = requests.get(uri, headers=headers)
+        response = HttpRequester().get(uri, headers=headers)
         response.raise_for_status()
         return response.content
 

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -444,79 +444,16 @@ class HttpRequester:
             except Exception as e:
                 logger.error(f"Error deleting cache directory: {e}")
 
-    def get(self, url: str, **kwargs):
+    def __getattr__(self, name):
         """
-        Perform a GET request.
+        Delegate HTTP methods to the session object.
 
-        :param url: The URL to send the GET request to.
-        :param kwargs: Additional arguments to pass to the session's GET method.
-        :return: The response object.
+        :param name: The name of the method to call.
+        :return: The method from the session object.
         """
-        return self.session.get(url, **kwargs)
-
-    def post(self, url: str, data=None, json=None, **kwargs):
-        """
-        Perform a POST request.
-
-        :param url: The URL to send the POST request to.
-        :param data: The data to send in the body of the POST request.
-        :param json: A JSON object to send in the body of the POST request.
-        :param kwargs: Additional arguments to pass to the session's POST method.
-        :return: The response object.
-        """
-        return self.session.post(url, data=data, json=json, **kwargs)
-
-    def put(self, url: str, data=None, **kwargs):
-        """
-        Perform a PUT request.
-
-        :param url: The URL to send the PUT request to.
-        :param data: The data to send in the body of the PUT request.
-        :param kwargs: Additional arguments to pass to the session's PUT method.
-        :return: The response object.
-        """
-        return self.session.put(url, data=data, **kwargs)
-
-    def delete(self, url: str, **kwargs):
-        """
-        Perform a DELETE request.
-
-        :param url: The URL to send the DELETE request to.
-        :param kwargs: Additional arguments to pass to the session's DELETE method.
-        :return: The response object.
-        """
-        return self.session.delete(url, **kwargs)
-
-    def head(self, url: str, **kwargs):
-        """
-        Perform a HEAD request.
-
-        :param url: The URL to send the HEAD request to.
-        :param kwargs: Additional arguments to pass to the session's HEAD method.
-        :return: The response object.
-        """
-        return self.session.head(url, **kwargs)
-
-    def options(self, url: str, **kwargs):
-        """
-        Perform an OPTIONS request.
-
-        :param url: The URL to send the OPTIONS request to.
-        :param kwargs: Additional arguments to pass to the session's OPTIONS method.
-        :return: The response object.
-        """
-        return self.session.options(url, **kwargs)
-
-    def patch(self, url: str, data=None, **kwargs):
-        """
-        Perform a PATCH request.
-
-        :param url: The URL to send the PATCH request to.
-        :param data: The data to send in the body of the PATCH request.
-        :param kwargs: Additional arguments to pass to the session's PATCH method.
-        :return: The response object.
-        """
-        return self.session.patch(url, data=data, **kwargs)
+        if name.upper() in {"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"}:
+            return getattr(self.session, name.lower())
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
 
 class URI:

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -359,6 +359,104 @@ def to_camel_case(snake_str: str) -> str:
     return components[0].capitalize() + ''.join(x.title() for x in components[1:])
 
 
+class HttpRequester:
+    """
+    A singleton class to handle HTTP requests
+    """
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(HttpRequester, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if constants.DEFAULT_HTTP_CACHE_TIMEOUT > 0:
+            from requests_cache import CachedSession
+            self.session = CachedSession(
+                cache_name=constants.DEFAULT_HTTP_CACHE_PATH,  # Cache name
+                expire_after=constants.DEFAULT_HTTP_CACHE_TIMEOUT,  # Cache expiration time in seconds
+                backend='sqlite',  # Use SQLite backend
+                allowable_methods=('GET',),  # Cache GET
+                allowable_codes=(200, 302, 404)  # Cache responses with these status codes
+            )
+        else:
+            self.session = requests.Session()
+
+    def get(self, url: str, **kwargs):
+        """
+        Perform a GET request.
+
+        :param url: The URL to send the GET request to.
+        :param kwargs: Additional arguments to pass to the session's GET method.
+        :return: The response object.
+        """
+        return self.session.get(url, **kwargs)
+
+    def post(self, url: str, data=None, json=None, **kwargs):
+        """
+        Perform a POST request.
+
+        :param url: The URL to send the POST request to.
+        :param data: The data to send in the body of the POST request.
+        :param json: A JSON object to send in the body of the POST request.
+        :param kwargs: Additional arguments to pass to the session's POST method.
+        :return: The response object.
+        """
+        return self.session.post(url, data=data, json=json, **kwargs)
+
+    def put(self, url: str, data=None, **kwargs):
+        """
+        Perform a PUT request.
+
+        :param url: The URL to send the PUT request to.
+        :param data: The data to send in the body of the PUT request.
+        :param kwargs: Additional arguments to pass to the session's PUT method.
+        :return: The response object.
+        """
+        return self.session.put(url, data=data, **kwargs)
+
+    def delete(self, url: str, **kwargs):
+        """
+        Perform a DELETE request.
+
+        :param url: The URL to send the DELETE request to.
+        :param kwargs: Additional arguments to pass to the session's DELETE method.
+        :return: The response object.
+        """
+        return self.session.delete(url, **kwargs)
+
+    def head(self, url: str, **kwargs):
+        """
+        Perform a HEAD request.
+
+        :param url: The URL to send the HEAD request to.
+        :param kwargs: Additional arguments to pass to the session's HEAD method.
+        :return: The response object.
+        """
+        return self.session.head(url, **kwargs)
+
+    def options(self, url: str, **kwargs):
+        """
+        Perform an OPTIONS request.
+
+        :param url: The URL to send the OPTIONS request to.
+        :param kwargs: Additional arguments to pass to the session's OPTIONS method.
+        :return: The response object.
+        """
+        return self.session.options(url, **kwargs)
+
+    def patch(self, url: str, data=None, **kwargs):
+        """
+        Perform a PATCH request.
+
+        :param url: The URL to send the PATCH request to.
+        :param data: The data to send in the body of the PATCH request.
+        :param kwargs: Additional arguments to pass to the session's PATCH method.
+        :return: The response object.
+        """
+        return self.session.patch(url, data=data, **kwargs)
+
 class URI:
 
     REMOTE_SUPPORTED_SCHEMA = ('http', 'https', 'ftp')

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -595,7 +595,7 @@ class URI:
         """Check if the resource is available"""
         if self.is_remote_resource():
             try:
-                response = requests.head(self._uri, allow_redirects=True)
+                response = HttpRequester().head(self._uri, allow_redirects=True)
                 return response.status_code in (200, 302)
             except Exception as e:
                 if logger.isEnabledFor(logging.DEBUG):

--- a/rocrate_validator/utils.py
+++ b/rocrate_validator/utils.py
@@ -14,10 +14,14 @@
 
 from __future__ import annotations
 
+import atexit
 import inspect
 import os
+import random
 import re
+import string
 import sys
+import threading
 from importlib import import_module
 from pathlib import Path
 from typing import Optional, Union
@@ -28,8 +32,7 @@ import toml
 from rdflib import Graph
 
 import rocrate_validator.log as logging
-
-from . import constants, errors
+from rocrate_validator import constants, errors
 
 # current directory
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -364,24 +367,82 @@ class HttpRequester:
     A singleton class to handle HTTP requests
     """
     _instance = None
+    _lock = threading.Lock()
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(HttpRequester, cls).__new__(cls)
+            with cls._lock:
+                if cls._instance is None:
+                    logger.debug(f"Creating instance of {cls.__name__}")
+                    cls._instance = super(HttpRequester, cls).__new__(cls)
+                    atexit.register(cls._instance.__del__)
+                    logger.debug(f"Instance created: {cls._instance.__class__.__name__}")
         return cls._instance
 
     def __init__(self):
-        if constants.DEFAULT_HTTP_CACHE_TIMEOUT > 0:
-            from requests_cache import CachedSession
-            self.session = CachedSession(
-                cache_name=constants.DEFAULT_HTTP_CACHE_PATH,  # Cache name
-                expire_after=constants.DEFAULT_HTTP_CACHE_TIMEOUT,  # Cache expiration time in seconds
-                backend='sqlite',  # Use SQLite backend
-                allowable_methods=('GET',),  # Cache GET
-                allowable_codes=(200, 302, 404)  # Cache responses with these status codes
-            )
+        # check if the instance is already initialized
+        if not hasattr(self, "_initialized"):
+            # check if the instance is already initialized
+            with self._lock:
+                if not getattr(self, "_initialized", False):
+                    # set the initialized flag
+                    self._initialized = False
+                    # initialize the session
+                    self.__initialize_session__()
+                    # set the initialized flag
+                    self._initialized = True
         else:
+            logger.debug(f"Instance of {self} already initialized")
+
+    def __initialize_session__(self):
+        # initialize the session
+        self.session = None
+        logger.debug(f"Initializing instance of {self.__class__.__name__}")
+        assert not self._initialized, "Session already initialized"
+        # check if requests_cache is installed
+        # and set up the cached session
+        try:
+            if constants.DEFAULT_HTTP_CACHE_TIMEOUT > 0:
+                from requests_cache import CachedSession
+
+                # Generate a random path for the cache
+                # to avoid conflicts with other instances
+                random_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+                # Initialize the session with a cache
+                self.session = CachedSession(
+                    # Cache name with random suffix
+                    cache_name=f"{constants.DEFAULT_HTTP_CACHE_PATH_PREFIX}_{random_suffix}",
+                    expire_after=constants.DEFAULT_HTTP_CACHE_TIMEOUT,  # Cache expiration time in seconds
+                    backend='sqlite',  # Use SQLite backend
+                    allowable_methods=('GET',),  # Cache GET
+                    allowable_codes=(200, 302, 404)  # Cache responses with these status codes
+                )
+        except ImportError:
+            logger.warning("requests_cache is not installed. Using requests instead.")
+        except Exception as e:
+            logger.error("Error initializing requests_cache: %s", e)
+            logger.warning("Using requests instead of requests_cache")
+        # if requests_cache is not installed or an error occurred, use requests
+        # instead of requests_cache
+        # and create a new session
+        if not self.session:
+            logger.debug("Using requests instead of requests_cache")
             self.session = requests.Session()
+
+    def __del__(self):
+        """
+        Destructor to clean up the cache file used by CachedSession.
+        """
+        logger.debug(f"Deleting instance of {self.__class__.__name__}")
+        if self.session and hasattr(self.session, 'cache') and self.session.cache:
+            try:
+                logger.debug(f"Deleting cache directory: {self.session.cache.cache_name}")
+                cache_path = f"{self.session.cache.cache_name}.sqlite"
+                if os.path.exists(cache_path):
+                    os.remove(cache_path)
+                    logger.debug(f"Deleted cache directory: {cache_path}")
+            except Exception as e:
+                logger.error(f"Error deleting cache directory: {e}")
 
     def get(self, url: str, **kwargs):
         """
@@ -456,6 +517,7 @@ class HttpRequester:
         :return: The response object.
         """
         return self.session.patch(url, data=data, **kwargs)
+
 
 class URI:
 


### PR DESCRIPTION
This PR replaces the globally applied cache via the `requests_cache.install_cache` patch with the session-scoped cache provided by the `requests_cache.CachedSession` class.


(fix #86)