### PR TITLE
feat(profile/rocrate): refine data entities definition

### DIFF
--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
@@ -38,6 +38,15 @@ class DataEntityRequiredChecker(PyFunctionCheck):
             logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
             try:
                 logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
+                if entity.has_local_identifier():
+                    logger.debug(
+                        "Ignoring the Data Entity '%s' as it is a local entity with a local identifier. "
+                        "According to the RO-Crate specification, local entities with local identifiers "
+                        "are not required to be included in the RO-Crate payload"
+                        "(see https://github.com/ResearchObject/ro-crate/issues/400#issuecomment-2779152885 and "
+                        "https://github.com/ResearchObject/ro-crate/pull/426 for more details)",
+                        entity.id)
+                    continue
                 if not entity.has_relative_path():
                     logger.debug(
                         "Ignoring the Data Entity '%s' as it is a local entity with an absolute path. "

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
@@ -90,6 +90,8 @@ ro-crate:DirectoryDataEntity a sh:NodeShape ;
                 ?metadatafile schema:about ?root .
                 FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
                 FILTER(?this != ?root)
+                # Exclude all dataset entities that ends with `#<something>`
+                FILTER(!REGEX(STR(?this), "/#(?!/).*"))
             }
         """
     ] ;

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
@@ -48,7 +48,9 @@ ro-crate:FileDataEntity a sh:NodeShape ;
             SELECT ?this
             WHERE {
                 ?this a schema:MediaObject .
-                FILTER(?this != ro:ro-crate-metadata.json && STRSTARTS(STR(?this), "#"))
+                FILTER(?this != ro:ro-crate-metadata.json)
+                # Exclude all file entities that ends with `#<something>`
+                FILTER(!REGEX(STR(?this), "/#(?!/).*"))
             }
         """
     ] ;

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
@@ -49,7 +49,7 @@ ro-crate:FileDataEntity a sh:NodeShape ;
             WHERE {
                 ?this a schema:MediaObject .
                 FILTER(?this != ro:ro-crate-metadata.json)
-                # Exclude all file entities that ends with `#<something>`
+                # Exclude all file entities that ends with `/#<something>`
                 FILTER(!REGEX(STR(?this), "/#(?!/).*"))
             }
         """
@@ -90,7 +90,7 @@ ro-crate:DirectoryDataEntity a sh:NodeShape ;
                 ?metadatafile schema:about ?root .
                 FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
                 FILTER(?this != ?root)
-                # Exclude all dataset entities that ends with `#<something>`
+                # Exclude all dataset entities that ends with `/#<something>`
                 FILTER(!REGEX(STR(?this), "/#(?!/).*"))
             }
         """

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
@@ -48,7 +48,7 @@ ro-crate:FileDataEntity a sh:NodeShape ;
             SELECT ?this
             WHERE {
                 ?this a schema:MediaObject .
-                FILTER(?this != ro:ro-crate-metadata.json)
+                FILTER(?this != ro:ro-crate-metadata.json && STRSTARTS(STR(?this), "#"))
             }
         """
     ] ;

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.ttl
@@ -48,9 +48,9 @@ ro-crate:FileDataEntity a sh:NodeShape ;
             SELECT ?this
             WHERE {
                 ?this a schema:MediaObject .
-                FILTER(?this != ro:ro-crate-metadata.json)
-                # Exclude all file entities that ends with `/#<something>`
-                FILTER(!REGEX(STR(?this), "/#(?!/).*"))
+                ?metadatafile schema:about ?root .
+                FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
+                FILTER(!STRSTARTS(STR(?this), CONCAT(STR(?root), "#")))
             }
         """
     ] ;
@@ -88,10 +88,10 @@ ro-crate:DirectoryDataEntity a sh:NodeShape ;
             WHERE {
                 ?this a schema:Dataset .
                 ?metadatafile schema:about ?root .
+                # Exclude all dataset entities that ends with `./#<something>`
                 FILTER(contains(str(?metadatafile), "ro-crate-metadata.json"))
                 FILTER(?this != ?root)
-                # Exclude all dataset entities that ends with `/#<something>`
-                FILTER(!REGEX(STR(?this), "/#(?!/).*"))
+                FILTER(!STRSTARTS(STR(?this), CONCAT(STR(?root), "#")))
             }
         """
     ] ;

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -136,7 +136,12 @@ class ROCrateEntity:
         return not self.has_absolute_path()
 
     def has_local_identifier(self) -> bool:
-        return self.id.startswith('#')
+        has_local_id = self.id.startswith('#') or \
+            f"{self.ro_crate.uri}/#" in self.id or \
+            f"file://{self.ro_crate.uri}/#" in self.id
+        logger.debug("Identifier '%s' is %s a local identifier", self.id,
+                     "" if has_local_id else " not")
+        return has_local_id
 
     def has_type(self, entity_type: str) -> bool:
         assert isinstance(entity_type, str), "Entity type must be a string"

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -135,6 +135,9 @@ class ROCrateEntity:
     def has_relative_path(self) -> bool:
         return not self.has_absolute_path()
 
+    def has_local_identifier(self) -> bool:
+        return self.id.startswith('#')
+
     def has_type(self, entity_type: str) -> bool:
         assert isinstance(entity_type, str), "Entity type must be a string"
         e_types = self.type if isinstance(self.type, list) else [self.type]

--- a/tests/data/crates/valid/rocrate_with_data_entities/ro-crate-metadata.json
+++ b/tests/data/crates/valid/rocrate_with_data_entities/ro-crate-metadata.json
@@ -156,6 +156,13 @@
             "name": "2018-06-11 12.56.14.jpg (input)"
         },
         {
+            "@id": "#thisIsNotDataEntity",
+            "@type": "File",
+            "description": "A File type that is not a data entity",
+            "encodingFormat": "text/plain",
+            "name": "thisIsNotDataEntity.txt"
+        },
+        {
             "@id": "pics/2019-06-11 12.56.14.jpg",
             "@type": "File",
             "description": "Original image",

--- a/tests/data/crates/valid/rocrate_with_data_entities/ro-crate-metadata.json
+++ b/tests/data/crates/valid/rocrate_with_data_entities/ro-crate-metadata.json
@@ -180,6 +180,16 @@
             }
         },
         {
+            "@id": "#xdata%20set/",
+            "@type": "Dataset",
+            "name": "Data set with a local ID",
+            "description": "A dataset",
+            "datePublished": "2024-05-17T01:04:52+01:00",
+            "license": {
+                "@id": "http://spdx.org/licenses/CC0-1.0"
+            }
+        },
+        {
             "@id": "data%20set2/",
             "@type": "Dataset",
             "name": "Data set 2",


### PR DESCRIPTION
This PR refines the definition of the `File` and `Dataset` data entities in the base `rocrate` validation profile, aligning them with the clarifications introduced in [ResearchObject/ro-crate#426](https://github.com/ResearchObject/ro-crate/pull/426).
See also https://github.com/ResearchObject/ro-crate/issues/400.

(fix issue #62)