### PR TITLE
Update readme to specify python 3.9 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ report positive and negative feedback. We also welcome contributions, but we sug
 
 ## Installation
 
-You can install the package using `pip` or `poetry`. The following instructions assume you have Python 3.8 or later installed.
+You can install the package using `pip` or `poetry`. The following instructions assume you have Python 3.9 or later installed.
 
 #### [Optional Step: Create a Virtual Environment](#optional-step-create-a-virtual-environment)
 


### PR DESCRIPTION
Hello, rocrate-validator devs:

This is PR just changes one number in the README.

I was following the README installation guide with Python 3.8.10, until I bumped into issues arising from Python 3.9's type annotation.

```
    def detect_profiles(settings: Union[dict, ValidationSettings]) -> list[Profile]:
TypeError: 'type' object is not subscriptable
```