### PR TITLE
feat: validate metadata only

### DIFF
--- a/docs/3_usage_api.rst
+++ b/docs/3_usage_api.rst
@@ -29,3 +29,35 @@ Programmatic Validation
     :parser: myst_parser.sphinx_
     :start-line: 121
     :end-line: 162
+
+
+Metadata-only Validation
+------------------------
+
+In addition to full validation, which checks both metadata and data files,
+the library also supports metadata-only validation. This is useful when you
+want to ensure that the metadata conforms to the expected schema without
+checking the actual data files.
+
+To perform metadata-only validation, you can use the `validate_metadata_as_dict` 
+from the `rocrate_validator.services` module. This function takes a dictionary
+representing the metadata and validates it against a given validation profile. 
+
+.. code-block:: python
+
+    import json
+    from rocrate_validator.services import validate_metadata_as_dict
+
+    settings = {
+        "profile_identifier": "workflow-ro-crate-1.0"
+    }
+
+    with open('tests/data/crates/invalid/0_main_workflow/main_workflow_bad_type/ro-crate-metadata.json', 'r') as f:
+        # load the metadata from the JSON file
+        rocrate_metadata = json.load(f)
+        
+        # validate the metadata dictionary
+        result = validation_report = validate_metadata_as_dict(rocrate_metadata, settings=settings)
+
+        # process the validation result as needed
+        ...

--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -143,6 +143,14 @@ def get_single_char(console: Optional[Console] = None, end: str = "\n",
     show_default=True
 )
 @click.option(
+    '-m',
+    '--metadata-only',
+    is_flag=True,
+    help="Validate only the metadata of the RO-Crate",
+    default=False,
+    show_default=True
+)
+@click.option(
     '-ff',
     '--fail-fast',
     is_flag=True,
@@ -270,6 +278,7 @@ def validate(ctx,
              profiles_path: Path = DEFAULT_PROFILES_PATH,
              extra_profiles_path: Optional[Path] = None,
              profile_identifier: Optional[str] = None,
+             metadata_only: bool = False,
              no_auto_profile: bool = False,
              disable_profile_inheritance: bool = False,
              requirement_severity: str = Severity.REQUIRED.name,
@@ -340,7 +349,8 @@ def validate(ctx,
             "rocrate_uri": rocrate_uri,
             "rocrate_relative_root_path": relative_root_path,
             "abort_on_first": fail_fast,
-            "skip_checks": skip_checks_list
+            "skip_checks": skip_checks_list,
+            "metadata_only": metadata_only
         }
 
         # Print the application header

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1671,6 +1671,8 @@ class ValidationSettings:
     disable_check_for_duplicates: bool = False
     #: Checks to skip
     skip_checks: list[str] = None
+    #: Flag to validate only the metadata of the RO-Crate
+    metadata_only: bool = False
 
     def __post_init__(self):
         # if requirement_severity is a str, convert to Severity

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1673,6 +1673,8 @@ class ValidationSettings:
     skip_checks: list[str] = None
     #: Flag to validate only the metadata of the RO-Crate
     metadata_only: bool = False
+    #: RO-Crate metadata as dictionary
+    metadata_dict: dict = None
 
     def __post_init__(self):
         # if requirement_severity is a str, convert to Severity
@@ -1997,8 +1999,11 @@ class ValidationContext:
         self._properties = {}
 
         # initialize the ROCrate object
-        self._rocrate = ROCrate.new_instance(settings.rocrate_uri,
-                                             relative_root_path=settings.rocrate_relative_root_path)
+        if settings.metadata_dict:
+            self._rocrate = ROCrate.from_metadata_dict(settings.metadata_dict)
+        else:
+            self._rocrate = ROCrate.new_instance(settings.rocrate_uri,
+                                                 relative_root_path=settings.rocrate_relative_root_path)
         assert isinstance(self._rocrate, ROCrate), "Invalid RO-Crate instance"
 
     @property

--- a/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/must/0_file_descriptor_format.py
@@ -33,6 +33,9 @@ class FileDescriptorExistence(PyFunctionCheck):
         """
         Check if the file descriptor is present in the RO-Crate
         """
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor existence check in metadata-only mode")
+            return True
         if not context.ro_crate.has_descriptor():
             message = f'file descriptor "{context.rel_fd_path}" is not present'
             context.result.add_issue(message, self)
@@ -44,6 +47,9 @@ class FileDescriptorExistence(PyFunctionCheck):
         """
         Check if the file descriptor is not empty
         """
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor existence check in metadata-only mode")
+            return True
         if not context.ro_crate.has_descriptor():
             message = f'file descriptor {context.rel_fd_path} is empty'
             context.result.add_issue(message, self)

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
@@ -32,6 +32,11 @@ class DataEntityRequiredChecker(PyFunctionCheck):
         """
         Check the presence of the Data Entity in the RO-Crate
         """
+        # Skip the check in metadata-only mode
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor existence check in metadata-only mode")
+            return True
+        # Perform the check
         result = True
         for entity in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True):
             assert entity.id is not None, "Entity has no @id"

--- a/rocrate_validator/profiles/ro-crate/should/4_data_entity_existence.py
+++ b/rocrate_validator/profiles/ro-crate/should/4_data_entity_existence.py
@@ -34,6 +34,11 @@ class DataEntityRecommendedChecker(PyFunctionCheck):
         Check the availability of the Data Entity with absolute URI paths
         are available at the time of RO-Crate creation
         """
+        # Skip the check in metadata-only mode
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor existence check in metadata-only mode")
+            return True
+        # Perform the check
         result = True
         for entity in [
                 _ for _ in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)

--- a/rocrate_validator/profiles/workflow-ro-crate/may/1_main_workflow.py
+++ b/rocrate_validator/profiles/workflow-ro-crate/may/1_main_workflow.py
@@ -28,6 +28,10 @@ class WorkflowFilesExistence(PyFunctionCheck):
     @check(name="Workflow diagram existence")
     def check_workflow_diagram(self, context: ValidationContext) -> bool:
         """Check if the crate contains the workflow diagram."""
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor existence check in metadata-only mode")
+            return True
+
         try:
             main_workflow = context.ro_crate.metadata.get_main_workflow()
             image = main_workflow.get_property("image")
@@ -54,7 +58,7 @@ class WorkflowFilesExistence(PyFunctionCheck):
             if not description_relpath:
                 context.result.add_issue("main workflow does not have a 'subjectOf' property", self)
                 return False
-            if not main_workflow_subject.is_available():
+            if not context.settings.metadata_only and not main_workflow_subject.is_available():
                 context.result.add_issue(
                     f"Workflow CWL description {main_workflow_subject.id} not found in crate", self)
                 return False

--- a/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
+++ b/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
@@ -33,7 +33,7 @@ class MainWorkflowFileExistence(PyFunctionCheck):
             if not main_workflow:
                 context.result.add_issue("main workflow does not exist in metadata file", self)
                 return False
-            if not main_workflow.is_available():
+            if not context.settings.metadata_only and not main_workflow.is_available():
                 context.result.add_issue(f"Main Workflow {main_workflow.id} not found in crate", self)
                 return False
             return True

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -41,6 +41,26 @@ def detect_profiles(settings: Union[dict, ValidationSettings]) -> list[Profile]:
     return profiles
 
 
+def validate_metadata_as_dict(
+        metadata_dict: dict,
+        settings: Union[dict, ValidationSettings],
+        subscribers: Optional[list[Subscriber]] = None) -> ValidationResult:
+    """
+    Validate the RO-Crate metadata only against a profile and return the validation result.
+    """
+    assert metadata_dict is not None, "Metadata dictionary cannot be None"
+    assert isinstance(metadata_dict, dict), "Metadata must be a dictionary"
+    # set the RO-Crate metadata dictionary in the settings
+    if isinstance(settings, dict):
+        settings["metadata_dict"] = metadata_dict
+        settings["metadata_only"] = True
+    else:
+        settings.metadata_dict = metadata_dict
+        settings.metadata_only = True
+    # validate the RO-Crate metadata
+    return validate(settings, subscribers)
+
+
 def validate(settings: Union[dict, ValidationSettings],
              subscribers: Optional[list[Subscriber]] = None) -> ValidationResult:
     """
@@ -77,9 +97,9 @@ def __initialise_validator__(settings: Union[dict, ValidationSettings],
     logger.debug("Validating RO-Crate: %s", rocrate_path)
 
     # check if the RO-Crate exists
-    if not getattr(settings, "metadata_only", False):
-    if not rocrate_path.is_available():
-        raise FileNotFoundError(f"RO-Crate not found: {rocrate_path}")
+    if not getattr(settings, "metadata_only", False) and getattr(settings, "metadata_dict", None) is None:
+        if not rocrate_path.is_available():
+            raise FileNotFoundError(f"RO-Crate not found: {rocrate_path}")
 
     # check if remote validation is enabled
     disable_remote_crate_download = settings.disable_remote_crate_download

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -77,6 +77,7 @@ def __initialise_validator__(settings: Union[dict, ValidationSettings],
     logger.debug("Validating RO-Crate: %s", rocrate_path)
 
     # check if the RO-Crate exists
+    if not getattr(settings, "metadata_only", False):
     if not rocrate_path.is_available():
         raise FileNotFoundError(f"RO-Crate not found: {rocrate_path}")
 

--- a/tests/integration/profiles/test_metadata_only.py
+++ b/tests/integration/profiles/test_metadata_only.py
@@ -54,3 +54,24 @@ def test_valid_ro_crates_from_folder(valid_roc_path):
             [],
             metadata_only=True
         )
+
+
+@pytest.mark.parametrize("valid_roc_path", valid_roc_paths())
+def test_valid_ro_crates_from_metadata_dict(valid_roc_path):
+    """Test all valid RO-Crates using metadata dict."""
+    metadata_dict = None
+    # Load the metadata dict from the RO-Crate
+    if not isinstance(valid_roc_path, str):
+        with open(valid_roc_path / "ro-crate-metadata.json", "r") as f:
+            metadata_dict = json.load(f)
+        assert metadata_dict is not None, "Failed to load metadata dict"
+        assert isinstance(metadata_dict, dict), "Metadata dict is not a dictionary"
+        do_entity_test(
+            valid_roc_path,
+            models.Severity.REQUIRED,
+            True,
+            [],
+            [],
+            metadata_dict=metadata_dict,
+            metadata_only=True
+        )

--- a/tests/integration/profiles/test_metadata_only.py
+++ b/tests/integration/profiles/test_metadata_only.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024-2025 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from pathlib import Path
+import shutil
+import tempfile
+
+from rocrate_validator import models
+from tests.ro_crates import ValidROC
+from tests.shared import do_entity_test
+import pytest
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+
+def valid_roc_paths():
+    """Fixture that returns a list of paths from ValidROC object."""
+    valid_roc = ValidROC()
+    return [
+        value
+        for attr in dir(valid_roc)
+        if not attr.startswith('_')
+        and not any(excluded in attr for excluded in ('bagit', 'multi_profile_crate', 'rocrate_with_relative_root'))
+        and not str(value := getattr(valid_roc, attr)).endswith('.zip')
+    ]
+
+
+@pytest.mark.parametrize("valid_roc_path", valid_roc_paths())
+def test_valid_ro_crates_from_folder(valid_roc_path):
+    """Test all valid RO-Crates."""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        temp_path = Path(tmpdirname) / valid_roc_path.name
+        shutil.copytree(valid_roc_path, temp_path)
+        valid_roc_path = temp_path
+        do_entity_test(
+            valid_roc_path,
+            models.Severity.REQUIRED,
+            True,
+            [],
+            [],
+            metadata_only=True
+        )

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -47,7 +47,8 @@ def do_entity_test(
         profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
         rocrate_entity_patch: Optional[dict] = None,
         skip_checks: Optional[list[str]] = (),
-        rocrate_relative_root_path: Optional[str] = None
+        rocrate_relative_root_path: Optional[str] = None,
+        metadata_only: bool = False
 ):
     """
     Shared function to test a RO-Crate entity

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -48,7 +48,8 @@ def do_entity_test(
         rocrate_entity_patch: Optional[dict] = None,
         skip_checks: Optional[list[str]] = (),
         rocrate_relative_root_path: Optional[str] = None,
-        metadata_only: bool = False
+        metadata_only: bool = False,
+        metadata_dict: Optional[dict] = None
 ):
     """
     Shared function to test a RO-Crate entity
@@ -101,7 +102,9 @@ def do_entity_test(
                 "abort_on_first": abort_on_first,
                 "profile_identifier": profile_identifier,
                 "skip_checks": skip_checks,
-                "rocrate_relative_root_path": rocrate_relative_root_path
+                "rocrate_relative_root_path": rocrate_relative_root_path,
+                "metadata_only": metadata_only,
+                "metadata_dict": metadata_dict
             }))
         logger.debug("Expected validation result: %s", expected_validation_result)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -117,3 +117,33 @@ def test_valid_local_multi_profile_crate():
     assert "provenance-run-crate-0.5" in profiles_ids, "Expected the 'provenance-run-crate' profile"
     assert "workflow-testing-ro-crate-0.1" in profiles_ids, \
         "Expected the 'workflow-testing-ro-crate-0.1' profile"
+
+
+def test_valid_crate_folder_with_metadata_only():
+    # Set the rocrate_uri to the WRROC paper RO-Crate
+    crate_path = ValidROC().wrroc_paper
+    logger.debug("Validating a local RO-Crate in metadata-only mode: %s", crate_path)
+
+    # Copy the ro-crate-metadata.json content only to a temporary folder
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        metadata_src = crate_path / "ro-crate-metadata.json"
+        metadata_dst = Path(tmpdirname) / "ro-crate-metadata.json"
+        shutil.copy(metadata_src, metadata_dst)
+
+        # Define shared settings object
+        settings = ValidationSettings(
+            rocrate_uri=Path(tmpdirname),
+            metadata_only=True
+        )
+
+        profiles = detect_profiles(settings)
+
+        logger.debug("Candidate profiles: %s", profiles)
+        # Check the number of detected profiles
+        assert len(profiles) == 1, "Expected a single profile"
+        # Check the detected profile
+        assert profiles[0].identifier == "ro-crate-1.1", "Expected the 'ro-crate' profile"
+
+        result = validate(settings)
+        assert result.passed(), "RO-Crate should be valid in metadata-only mode"
+

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import shutil
+import tempfile
 from pathlib import Path
 
 from rocrate_validator import log as logging
 from rocrate_validator.models import ValidationSettings
 from rocrate_validator.rocrate import ROCrateMetadata
-from rocrate_validator.services import detect_profiles, get_profiles
+from rocrate_validator.services import detect_profiles, get_profiles, validate
 from tests.ro_crates import InvalidMultiProfileROC, ValidROC
 
 # set up logging
@@ -147,3 +150,29 @@ def test_valid_crate_folder_with_metadata_only():
         result = validate(settings)
         assert result.passed(), "RO-Crate should be valid in metadata-only mode"
 
+
+def test_valid_crate_metadata_dict_with_metadata_only():
+    # Set the rocrate_uri to the WRROC paper RO-Crate
+    crate_path = ValidROC().wrroc_paper
+    logger.debug("Validating a local RO-Crate in metadata-only mode: %s", crate_path)
+
+    # Load the metadata dict from the RO-Crate
+    with open(crate_path / "ro-crate-metadata.json", "r") as f:
+        metadata_dict = json.loads(f.read())
+
+    # Define shared settings object
+    settings = ValidationSettings(
+        metadata_dict=metadata_dict
+    )
+
+    profiles = detect_profiles(settings)
+
+    logger.debug("Candidate profiles: %s", profiles)
+    # Check the number of detected profiles
+    assert len(profiles) == 1, "Expected a single profile"
+    # Check the detected profile
+    assert profiles[0].identifier == "ro-crate-1.1", "Expected the 'ro-crate' profile"
+
+    from rocrate_validator.services import validate_metadata_as_dict
+    result = validate_metadata_as_dict(metadata_dict, settings)
+    assert result.passed(), "RO-Crate should be valid in metadata-only mode"

--- a/tests/unit/test_validation_settings.py
+++ b/tests/unit/test_validation_settings.py
@@ -100,3 +100,7 @@ def test_validation_settings_metadata_only():
     assert settings.metadata_only is False
 
 
+def test_validation_settings_metadata_dict():
+    metadata = {"@graph": []}
+    settings = ValidationSettings(metadata_dict=metadata)
+    assert settings.metadata_dict == metadata

--- a/tests/unit/test_validation_settings.py
+++ b/tests/unit/test_validation_settings.py
@@ -90,3 +90,13 @@ def test_validation_settings_requirement_severity():
 def test_validation_settings_abort_on_first():
     settings = ValidationSettings(abort_on_first=True)
     assert settings.abort_on_first is True
+
+
+def test_validation_settings_metadata_only():
+    settings = ValidationSettings(metadata_only=True)
+    assert settings.metadata_only is True
+
+    settings = ValidationSettings(metadata_only=False)
+    assert settings.metadata_only is False
+
+


### PR DESCRIPTION
This pull request adds support for validating only the metadata of an RO-Crate, without requiring the full data files. 
It introduces a `--metadata-only` CLI option, propagates this flag through the validation pipeline, and updates the core logic to skip data existence validations when running in metadata-only mode. 

Additionally, a new service method, `validate_metadata_as_dict(metadata_dict: dict, ...)`, has been added. This method accepts a dictionary containing RO-Crate metadata, enabling metadata-only validation to be performed programmatically.

[ fix #101 ]