### PR TITLE
Allow do_entity_test to accept arbitrary validation settings

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -38,21 +38,24 @@ def first(c: Collection[T]) -> T:
 
 
 def do_entity_test(
-        rocrate_path: Union[Path, str],
-        requirement_severity: models.Severity,
-        expected_validation_result: bool,
-        expected_triggered_requirements: Optional[list[str]] = None,
-        expected_triggered_issues: Optional[list[str]] = None,
-        abort_on_first: bool = False,
-        profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
-        rocrate_entity_patch: Optional[dict] = None,
-        skip_checks: Optional[list[str]] = (),
-        rocrate_relative_root_path: Optional[str] = None,
-        metadata_only: bool = False,
-        metadata_dict: Optional[dict] = None
+    rocrate_path: Union[Path, str],
+    requirement_severity: models.Severity,
+    expected_validation_result: bool,
+    expected_triggered_requirements: Optional[list[str]] = None,
+    expected_triggered_issues: Optional[list[str]] = None,
+    abort_on_first: bool = False,
+    profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
+    rocrate_entity_patch: Optional[dict] = None,
+    skip_checks: Optional[list[str]] = (),
+    rocrate_relative_root_path: Optional[str] = None,
+    metadata_only: bool = False,
+    metadata_dict: Optional[dict] = None,
+    **kwargs,
 ):
     """
-    Shared function to test a RO-Crate entity
+    Shared function to test a RO-Crate entity.
+
+    Additional keyword arguments (kwargs) are passed along to initialise ValidationSettings.
     """
     # declare variables
     failed_requirements = None
@@ -95,23 +98,28 @@ def do_entity_test(
         abort_on_first = abort_on_first
 
         # validate RO-Crate
-        result: models.ValidationResult = \
-            services.validate(models.ValidationSettings(**{
-                "rocrate_uri": rocrate_path,
-                "requirement_severity": requirement_severity,
-                "abort_on_first": abort_on_first,
-                "profile_identifier": profile_identifier,
-                "skip_checks": skip_checks,
-                "rocrate_relative_root_path": rocrate_relative_root_path,
-                "metadata_only": metadata_only,
-                "metadata_dict": metadata_dict
-            }))
+        result: models.ValidationResult = services.validate(
+            models.ValidationSettings(
+                **{
+                    "rocrate_uri": rocrate_path,
+                    "requirement_severity": requirement_severity,
+                    "abort_on_first": abort_on_first,
+                    "profile_identifier": profile_identifier,
+                    "skip_checks": skip_checks,
+                    "rocrate_relative_root_path": rocrate_relative_root_path,
+                    "metadata_only": metadata_only,
+                    "metadata_dict": metadata_dict,
+                },
+                **kwargs,
+            )
+        )
         logger.debug("Expected validation result: %s", expected_validation_result)
 
         assert result.context is not None, "Validation context should not be None"
         f"Expected requirement severity to be {requirement_severity}, but got {result.context.requirement_severity}"
-        assert result.passed() == expected_validation_result, \
-            f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
+        assert (
+            result.passed() == expected_validation_result
+        ), f"RO-Crate should be {'valid' if expected_validation_result else 'invalid'}"
 
         # check requirement
         failed_requirements = [_.name for _ in result.failed_requirements]
@@ -122,24 +130,35 @@ def do_entity_test(
         # check that the expected requirements are triggered
         for expected_triggered_requirement in expected_triggered_requirements:
             if expected_triggered_requirement not in failed_requirements:
-                assert False, f"The expected requirement " \
-                    f"\"{expected_triggered_requirement}\" was not found in the failed requirements"
+                assert False, (
+                    f"The expected requirement "
+                    f'"{expected_triggered_requirement}" was not found in the failed requirements'
+                )
 
         # check requirement issues
-        detected_issues = [issue.message for issue in result.get_issues(requirement_severity)
-                           if issue.message is not None]
+        detected_issues = [
+            issue.message
+            for issue in result.get_issues(requirement_severity)
+            if issue.message is not None
+        ]
         logger.debug("Detected issues: %s", detected_issues)
         logger.debug("Expected issues: %s", expected_triggered_issues)
         for expected_issue in expected_triggered_issues:
-            if not any(expected_issue in issue for issue in detected_issues):  # support partial match
-                assert False, f"The expected issue \"{expected_issue}\" was not found in the detected issues"
+            if not any(
+                expected_issue in issue for issue in detected_issues
+            ):  # support partial match
+                assert (
+                    False
+                ), f'The expected issue "{expected_issue}" was not found in the detected issues'
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.exception(e)
             logger.debug("Failed to validate RO-Crate @ path: %s", rocrate_path)
             logger.debug("Requirement severity: %s", requirement_severity)
             logger.debug("Expected validation result: %s", expected_validation_result)
-            logger.debug("Expected triggered requirements: %s", expected_triggered_requirements)
+            logger.debug(
+                "Expected triggered requirements: %s", expected_triggered_requirements
+            )
             logger.debug("Expected triggered issues: %s", expected_triggered_issues)
             logger.debug("Failed requirements: %s", failed_requirements)
             logger.debug("Detected issues: %s", detected_issues)


### PR DESCRIPTION
Quality of life improvement :) A couple of times now I have found myself wanting to be able to pass in validation settings that aren't explicitly listed as args in `do_entity_test`. This is a small change that enables additional validation settings to be passed through easily.

An example of how I would use this: https://github.com/eScienceLab/rocrate-validator/blob/0501f2ce1d9d5f5e5d4d9503c98391c2c4758cdf/tests/integration/profiles/five-safes-crate/test_valid_5src.py#L89

Some auto-fomatting changes were also made with `black`. The lines I changed manually are just the ones where `kwargs` are mentioned.