### PR TITLE
#146 Wrap sys.stdout in nullcontext to avoid close on ctx exit

### DIFF
--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Optional
 
@@ -472,7 +473,7 @@ def validate(ctx,
                     console.print(f"\n{' '*2}📋 [bold]The validation report in JSON format: [/bold]\n")
 
             # Generate the JSON output and write it to the specified output file or to stdout
-            with open(output_file, "w", encoding="utf-8") if output_file else sys.stdout as f:
+            with open(output_file, "w", encoding="utf-8") if output_file else nullcontext(sys.stdout) as f:
                 out = Console(width=output_line_width, file=f)
                 out.register_formatter(JSONOutputFormatter())
                 out.print(results)


### PR DESCRIPTION
Closes #146 

Wraps `sys.stdout` in `contextlib.nullcontext` when this is used as a context argument, so avoids `close()` being called on this when the context exits and further writes raising `ValueError: I/O operation on closed file.`