### PR TITLE
feat(core): support offline validation and HTTP cache management

### DIFF
--- a/rocrate_validator/cli/__init__.py
+++ b/rocrate_validator/cli/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rocrate_validator.cli.commands import profiles, validate
+from rocrate_validator.cli.commands import cache, profiles, validate
 from rocrate_validator.cli.main import cli
 
-__all__ = ["cli", "profiles", "validate"]
+__all__ = ["cli", "cache", "profiles", "validate"]

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+``rocrate-validator cache`` subcommand: inspect, warm and reset the HTTP cache
+used by the validator.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from rich.table import Table
+
+from rocrate_validator.cli.commands.errors import handle_error
+from rocrate_validator.cli.main import cli, click
+from rocrate_validator.models import Profile
+from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.cache_warmup import (
+    WarmUpResult, discover_cacheable_urls_from_profiles, warm_up_urls)
+from rocrate_validator.utils.http import HttpRequester
+from rocrate_validator.utils.paths import (get_default_http_cache_path,
+                                           get_profiles_path)
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_cache_path(cache_path: Optional[Path]) -> Path:
+    """Return the effective cache path, creating the parent directory."""
+    if cache_path is None:
+        path = get_default_http_cache_path()
+    else:
+        path = Path(cache_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _reset_requester(cache_path: Path, offline: bool = False) -> None:
+    """Re-initialize the HttpRequester singleton with the given cache path."""
+    HttpRequester.reset()
+    HttpRequester.initialize_cache(
+        cache_path=str(cache_path),
+        cache_max_age=-1,
+        offline=offline,
+    )
+
+
+@cli.group("cache")
+@click.pass_context
+def cache(ctx):
+    """
+    [magenta]rocrate-validator:[/magenta] Manage the HTTP cache
+    """
+
+
+@cache.command("info")
+@click.option(
+    "--cache-path",
+    type=click.Path(),
+    default=None,
+    show_default=False,
+    help="Path to the HTTP cache directory (defaults to the user cache dir)",
+)
+@click.pass_context
+def cache_info(ctx, cache_path: Optional[Path] = None):
+    """
+    Display information about the HTTP cache.
+    """
+    console = ctx.obj['console']
+    try:
+        resolved = _resolve_cache_path(cache_path)
+        _reset_requester(resolved)
+        info = HttpRequester().cache_info()
+        table = Table(title="HTTP Cache", show_lines=False)
+        table.add_column("Property", style="bold")
+        table.add_column("Value")
+        table.add_row("Path", str(info.get("path") or resolved))
+        table.add_row("Backend", str(info.get("backend") or "—"))
+        table.add_row("Persistent", "yes" if info.get("permanent") else "no")
+        table.add_row("Offline mode", "yes" if info.get("offline") else "no")
+        table.add_row("Entries", str(info.get("entries", 0)))
+        size = info.get("size_bytes", 0) or 0
+        table.add_row("Size", _format_bytes(size))
+        console.print(table)
+    except Exception as e:
+        handle_error(e, console)
+
+
+@cache.command("reset")
+@click.option(
+    "--cache-path",
+    type=click.Path(),
+    default=None,
+    show_default=False,
+    help="Path to the HTTP cache directory (defaults to the user cache dir)",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Do not prompt for confirmation before removing cache entries",
+)
+@click.pass_context
+def cache_reset(ctx, cache_path: Optional[Path] = None, yes: bool = False):
+    """
+    Remove every entry from the HTTP cache.
+    """
+    console = ctx.obj['console']
+    interactive = ctx.obj.get('interactive', False)
+    exit_code = 0
+    try:
+        resolved = _resolve_cache_path(cache_path)
+        _reset_requester(resolved)
+        info = HttpRequester().cache_info()
+        entries = info.get("entries", 0)
+        size = _format_bytes(info.get("size_bytes", 0) or 0)
+        console.print(
+            f"[bold]HTTP cache:[/bold] {info.get('path') or resolved} "
+            f"([cyan]{entries}[/cyan] entries, {size})"
+        )
+        if entries == 0:
+            console.print("[green]Cache is already empty.[/green]")
+            return
+        if not yes:
+            if not interactive:
+                console.print(
+                    "[yellow]Use --yes to remove entries in non-interactive mode.[/yellow]"
+                )
+                exit_code = 1
+            else:
+                confirm = click.confirm(
+                    f"Remove all {entries} cached entries?", default=False
+                )
+                if not confirm:
+                    console.print("Aborted.")
+                else:
+                    HttpRequester().clear_cache()
+                    console.print("[green]HTTP cache cleared.[/green]")
+        else:
+            HttpRequester().clear_cache()
+            console.print("[green]HTTP cache cleared.[/green]")
+    except Exception as e:
+        handle_error(e, console)
+        return
+    if exit_code:
+        ctx.exit(exit_code)
+
+
+@cache.command("warm")
+@click.option(
+    "--cache-path",
+    type=click.Path(),
+    default=None,
+    show_default=False,
+    help="Path to the HTTP cache directory (defaults to the user cache dir)",
+)
+@click.option(
+    "--profiles-path",
+    type=click.Path(exists=True),
+    default=None,
+    show_default=False,
+    help="Path containing the profile definitions",
+)
+@click.option(
+    "--extra-profiles-path",
+    type=click.Path(exists=True),
+    default=None,
+    show_default=False,
+    help="Path containing additional user profile definitions",
+)
+@click.option(
+    "-p",
+    "--profile-identifier",
+    multiple=True,
+    type=click.STRING,
+    default=None,
+    show_default=False,
+    metavar="Profile-ID",
+    help="Identifier of a profile to warm (may be given multiple times)",
+)
+@click.option(
+    "--all-profiles",
+    is_flag=True,
+    default=False,
+    help="Warm cacheable URLs declared by every installed profile",
+)
+@click.option(
+    "--crate",
+    multiple=True,
+    type=click.STRING,
+    default=None,
+    metavar="URI",
+    help="URL of a remote RO-Crate to download and cache (may be given multiple times)",
+)
+@click.pass_context
+def cache_warm(
+    ctx,
+    cache_path: Optional[Path] = None,
+    profiles_path: Optional[Path] = None,
+    extra_profiles_path: Optional[Path] = None,
+    profile_identifier: Optional[List[str]] = None,
+    all_profiles: bool = False,
+    crate: Optional[List[str]] = None,
+):
+    """
+    Pre-populate the HTTP cache with resources declared by profiles and with
+    optional remote RO-Crate URLs.
+    """
+    console = ctx.obj['console']
+    exit_with_failure = False
+    try:
+        resolved_cache = _resolve_cache_path(cache_path)
+        _reset_requester(resolved_cache, offline=False)
+        profiles_dir = Path(profiles_path) if profiles_path else get_profiles_path()
+        extra_dir = Path(extra_profiles_path) if extra_profiles_path else None
+
+        requested_ids = list(profile_identifier or [])
+        urls: List[str] = []
+        profile_scope: Optional[str] = None
+
+        if all_profiles or requested_ids or not crate:
+            Profile.load_profiles(
+                profiles_path=profiles_dir,
+                extra_profiles_path=extra_dir,
+            )
+            loaded_profiles = list(Profile.all())
+            if requested_ids:
+                selected = []
+                missing = []
+                for ident in requested_ids:
+                    profile = Profile.get_by_identifier(ident)
+                    if profile is None:
+                        missing.append(ident)
+                    else:
+                        selected.append(profile)
+                if missing:
+                    console.print(
+                        f"[yellow]Profile(s) not found and skipped:[/yellow] {', '.join(missing)}"
+                    )
+                profile_scope = f"profiles: {', '.join(p.identifier for p in selected)}"
+                urls = discover_cacheable_urls_from_profiles(selected)
+            else:
+                profile_scope = "all installed profiles"
+                urls = discover_cacheable_urls_from_profiles(loaded_profiles)
+
+        results: List[WarmUpResult] = []
+        if urls:
+            console.print(
+                f"[bold]Warming cache for {profile_scope}[/bold] "
+                f"([cyan]{len(urls)}[/cyan] URL(s))..."
+            )
+            results.extend(warm_up_urls(urls))
+
+        if crate:
+            console.print(
+                f"[bold]Fetching remote RO-Crates[/bold] ([cyan]{len(crate)}[/cyan] URL(s))..."
+            )
+            results.extend(_warm_remote_crates(list(crate)))
+
+        if not results:
+            console.print("[yellow]Nothing to warm up.[/yellow]")
+            return
+
+        table = Table(title="Warm-up results", show_lines=False)
+        table.add_column("URL", overflow="fold")
+        table.add_column("Status")
+        table.add_column("Detail")
+        ok = 0
+        failed = 0
+        for r in results:
+            colour = {"ok": "green", "skipped": "cyan", "failed": "red"}.get(r.status, "white")
+            table.add_row(r.url, f"[{colour}]{r.status}[/{colour}]", r.detail or "")
+            if r.status == "ok":
+                ok += 1
+            elif r.status == "failed":
+                failed += 1
+        console.print(table)
+        console.print(
+            f"[bold]Summary:[/bold] {ok} cached, {failed} failed, "
+            f"{len(results) - ok - failed} skipped"
+        )
+        exit_with_failure = failed > 0
+    except Exception as e:
+        handle_error(e, console)
+        return
+    if exit_with_failure:
+        ctx.exit(1)
+
+
+def _warm_remote_crates(urls: List[str]) -> List[WarmUpResult]:
+    """
+    Download each remote RO-Crate URL via ``HttpRequester.fetch_fresh``
+    so that its response is stored in the cache.
+    """
+    requester = HttpRequester()
+    results: List[WarmUpResult] = []
+    for url in urls:
+        try:
+            response = requester.fetch_fresh(url, stream=True, allow_redirects=True)
+            status = getattr(response, "status_code", None)
+            if status is None:
+                results.append(WarmUpResult(url=url, status="failed", detail="no status code"))
+                continue
+            if status >= 400:
+                results.append(WarmUpResult(url=url, status="failed", detail=f"HTTP {status}"))
+                continue
+            # Consume the response body so that the cache backend stores it.
+            with tempfile.TemporaryFile() as tmp:
+                shutil.copyfileobj(response.raw, tmp)
+            results.append(WarmUpResult(url=url, status="ok", detail=f"HTTP {status}"))
+        except Exception as e:
+            logger.debug("Remote crate warm-up failed for %s: %s", url, e)
+            results.append(WarmUpResult(url=url, status="failed", detail=str(e)))
+    return results
+
+
+def _format_bytes(size: int) -> str:
+    if size <= 0:
+        return "0 B"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    idx = 0
+    value = float(size)
+    while value >= 1024 and idx < len(units) - 1:
+        value /= 1024
+        idx += 1
+    return f"{value:.2f} {units[idx]}"

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -19,8 +19,11 @@ used by the validator.
 
 from __future__ import annotations
 
+import copy as _copy
+import json
 import shutil
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
@@ -30,11 +33,9 @@ from rocrate_validator.cli.commands.errors import handle_error
 from rocrate_validator.cli.main import cli, click
 from rocrate_validator.models import Profile
 from rocrate_validator.utils import log as logging
-from rocrate_validator.utils.cache_warmup import (
-    WarmUpResult, discover_cacheable_urls_from_profiles, warm_up_urls)
+from rocrate_validator.utils.cache_warmup import WarmUpResult, discover_cacheable_urls_from_profiles, warm_up_urls
 from rocrate_validator.utils.http import HttpRequester
-from rocrate_validator.utils.paths import (get_default_http_cache_path,
-                                           get_profiles_path)
+from rocrate_validator.utils.paths import get_default_http_cache_path, get_profiles_path
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,102 @@ def cache_info(ctx, cache_path: Optional[Path] = None):
         size = info.get("size_bytes", 0) or 0
         table.add_row("Size", _format_bytes(size))
         console.print(table)
+    except Exception as e:
+        handle_error(e, console)
+
+
+@cache.command("list")
+@click.option(
+    "--cache-path",
+    type=click.Path(),
+    default=None,
+    show_default=False,
+    help="Path to the HTTP cache directory (defaults to the user cache dir)",
+)
+@click.option(
+    "--url",
+    "url_filter",
+    type=click.STRING,
+    default=None,
+    metavar="SUBSTRING",
+    help="Show only entries whose URL contains SUBSTRING (case-insensitive)",
+)
+@click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(["url", "size", "created"], case_sensitive=False),
+    default="created",
+    show_default=True,
+    help="Field to sort entries by",
+)
+@click.option(
+    "--order",
+    "sort_order",
+    type=click.Choice(["asc", "desc"], case_sensitive=False),
+    default=None,
+    show_default=False,
+    help="Sort direction (default: desc for size/created, asc for url)",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print entries as JSON (size in bytes, datetimes as ISO 8601)",
+)
+@click.pass_context
+def cache_list(
+    ctx,
+    cache_path: Optional[Path] = None,
+    url_filter: Optional[str] = None,
+    sort_by: str = "created",
+    sort_order: Optional[str] = None,
+    as_json: bool = False,
+):
+    """
+    List entries currently stored in the HTTP cache (alias: `ls`).
+    """
+    console = ctx.obj['console']
+    try:
+        resolved = _resolve_cache_path(cache_path)
+        _reset_requester(resolved)
+        entries = _collect_cache_entries(
+            url_filter=url_filter,
+            sort_by=sort_by.lower(),
+            sort_order=sort_order.lower() if sort_order else None,
+        )
+
+        if as_json:
+            click.echo(json.dumps([_entry_to_dict(e) for e in entries], indent=2))
+            return
+
+        if not entries:
+            if url_filter:
+                console.print(f"[yellow]No entries match URL filter:[/yellow] {url_filter}")
+            else:
+                console.print("[yellow]Cache is empty.[/yellow]")
+            return
+
+        table = Table(title=f"HTTP Cache entries ({len(entries)})", show_lines=False)
+        table.add_column("URL", overflow="fold")
+        table.add_column("Status", justify="right")
+        table.add_column("Size", justify="right")
+        table.add_column("Content-Type")
+        table.add_column("Created")
+        table.add_column("Expires")
+        total = 0
+        for e in entries:
+            total += e["size"]
+            table.add_row(
+                e["url"],
+                str(e["status"] if e["status"] is not None else "—"),
+                _format_bytes(e["size"]),
+                e["content_type"] or "—",
+                _format_dt(e["created_at"]),
+                _format_expires(e["expires"], e["is_expired"]),
+            )
+        console.print(table)
+        console.print(f"[bold]Total:[/bold] {len(entries)} entries, {_format_bytes(total)}")
     except Exception as e:
         handle_error(e, console)
 
@@ -389,3 +486,93 @@ def _format_bytes(size: int) -> str:
         value /= 1024
         idx += 1
     return f"{value:.2f} {units[idx]}"
+
+
+def _format_dt(value: Optional[datetime]) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d %H:%M:%SZ") if value.tzinfo else value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_expires(value: Optional[datetime], is_expired: bool) -> str:
+    if value is None:
+        return "never"
+    formatted = _format_dt(value)
+    return f"[red]{formatted} (expired)[/red]" if is_expired else formatted
+
+
+_DEFAULT_SORT_ORDER = {"url": "asc", "size": "desc", "created": "desc"}
+
+
+def _collect_cache_entries(
+    url_filter: Optional[str] = None,
+    sort_by: str = "size",
+    sort_order: Optional[str] = None,
+) -> List[dict]:
+    """
+    Read every cached response and return a list of plain dicts. Filtering
+    and sorting happen here so the CLI rendering paths (table / JSON) share
+    the same data shape.
+
+    ``sort_order`` is one of ``"asc"``/``"desc"`` or ``None`` to use the
+    field's natural default (URLs sort ascending; size and timestamps sort
+    descending so the largest/most recent come first).
+    """
+    cache = getattr(HttpRequester().session, "cache", None)
+    if cache is None:
+        return []
+    needle = url_filter.lower() if url_filter else None
+    entries: List[dict] = []
+    responses = getattr(cache, "responses", None) or {}
+    for key in list(responses):
+        try:
+            resp = responses[key]
+        except Exception as exc:
+            logger.debug("Skipping unreadable cache entry %s: %s", key, exc)
+            continue
+        url = getattr(resp, "url", "") or ""
+        if needle and needle not in url.lower():
+            continue
+        entries.append({
+            "key": key,
+            "url": url,
+            "status": getattr(resp, "status_code", None),
+            "size": int(getattr(resp, "size", 0) or 0),
+            "content_type": (getattr(resp, "headers", {}) or {}).get("Content-Type"),
+            "created_at": getattr(resp, "created_at", None),
+            "expires": getattr(resp, "expires", None),
+            "is_expired": bool(getattr(resp, "is_expired", False)),
+        })
+    effective_order = sort_order or _DEFAULT_SORT_ORDER.get(sort_by, "desc")
+    reverse = effective_order == "desc"
+    if sort_by == "url":
+        entries.sort(key=lambda e: e["url"].lower(), reverse=reverse)
+    elif sort_by == "created":
+        entries.sort(key=lambda e: e["created_at"] or datetime.min, reverse=reverse)
+    else:  # "size"
+        entries.sort(key=lambda e: e["size"], reverse=reverse)
+    return entries
+
+
+def _entry_to_dict(entry: dict) -> dict:
+    """JSON-safe view of an entry produced by ``_collect_cache_entries``."""
+    def _iso(value: Optional[datetime]) -> Optional[str]:
+        return value.isoformat() if value is not None else None
+    return {
+        "url": entry["url"],
+        "status": entry["status"],
+        "size_bytes": entry["size"],
+        "content_type": entry["content_type"],
+        "created_at": _iso(entry["created_at"]),
+        "expires": _iso(entry["expires"]),
+        "is_expired": entry["is_expired"],
+    }
+
+
+# Shell-style alias: `cache ls` runs the same callback as `cache list`.
+# A shallow copy gives the alias its own name and hides it from --help so
+# the command appears only once in the listing.
+_cache_ls_alias = _copy.copy(cache_list)
+_cache_ls_alias.name = "ls"
+_cache_ls_alias.hidden = True
+cache.add_command(_cache_ls_alias)

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 import copy as _copy
 import json
-import shutil
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
@@ -456,7 +454,7 @@ def _warm_remote_crates(urls: List[str]) -> List[WarmUpResult]:
     results: List[WarmUpResult] = []
     for url in urls:
         try:
-            response = requester.fetch_fresh(url, stream=True, allow_redirects=True)
+            response = requester.fetch_fresh(url, allow_redirects=True)
             status = getattr(response, "status_code", None)
             if status is None:
                 results.append(WarmUpResult(url=url, status="failed", detail="no status code"))
@@ -464,9 +462,8 @@ def _warm_remote_crates(urls: List[str]) -> List[WarmUpResult]:
             if status >= 400:
                 results.append(WarmUpResult(url=url, status="failed", detail=f"HTTP {status}"))
                 continue
-            # Consume the response body so that the cache backend stores it.
-            with tempfile.TemporaryFile() as tmp:
-                shutil.copyfileobj(response.raw, tmp)
+            # Touch the body so the cache backend stores the full response.
+            _ = response.content
             results.append(WarmUpResult(url=url, status="ok", detail=f"HTTP {status}"))
         except Exception as e:
             logger.debug("Remote crate warm-up failed for %s: %s", url, e)

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -242,12 +242,35 @@ def cache_warm(
             if requested_ids:
                 selected = []
                 missing = []
+                # (requested, resolved, all candidates) for tokens that matched
+                # more than one versioned profile — we warn so the user knows
+                # which one was picked and how to opt for a different version.
+                ambiguous_fallbacks = []
                 for ident in requested_ids:
                     profile = Profile.get_by_identifier(ident)
+                    if profile is None:
+                        # Mirror the fallback used by `validate`: if no exact
+                        # identifier match, treat the value as a token and
+                        # pick the highest-version profile sharing it.
+                        candidates = Profile.get_by_token(ident) or []
+                        if candidates:
+                            profile = max(candidates, key=lambda p: p.version)
+                            if len(candidates) > 1:
+                                ambiguous_fallbacks.append((ident, profile, candidates))
                     if profile is None:
                         missing.append(ident)
                     else:
                         selected.append(profile)
+                for requested, resolved, candidates in ambiguous_fallbacks:
+                    other_versions = sorted(
+                        p.identifier for p in candidates if p.identifier != resolved.identifier
+                    )
+                    console.print(
+                        f"[yellow]Note:[/yellow] '{requested}' matched multiple profiles; "
+                        f"using [cyan]{resolved.identifier}[/cyan] (highest version). "
+                        f"Pass the full identifier to pick a different one "
+                        f"(available: {', '.join(other_versions)})."
+                    )
                 if missing:
                     console.print(
                         f"[yellow]Profile(s) not found and skipped:[/yellow] {', '.join(missing)}"

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -175,7 +175,6 @@ def cache_list(
 
         table = Table(title=f"HTTP Cache entries ({len(entries)})", show_lines=False)
         table.add_column("URL", overflow="fold")
-        table.add_column("Status", justify="right")
         table.add_column("Size", justify="right")
         table.add_column("Content-Type")
         table.add_column("Created")
@@ -185,7 +184,6 @@ def cache_list(
             total += e["size"]
             table.add_row(
                 e["url"],
-                str(e["status"] if e["status"] is not None else "—"),
                 _format_bytes(e["size"]),
                 e["content_type"] or "—",
                 _format_dt(e["created_at"]),

--- a/rocrate_validator/cli/commands/cache.py
+++ b/rocrate_validator/cli/commands/cache.py
@@ -207,6 +207,15 @@ def cache_reset(ctx, cache_path: Optional[Path] = None, yes: bool = False):
     metavar="URI",
     help="URL of a remote RO-Crate to download and cache (may be given multiple times)",
 )
+@click.option(
+    "-u",
+    "--url",
+    multiple=True,
+    type=click.STRING,
+    default=None,
+    metavar="URL",
+    help="Arbitrary URL to fetch and cache (may be given multiple times)",
+)
 @click.pass_context
 def cache_warm(
     ctx,
@@ -216,12 +225,21 @@ def cache_warm(
     profile_identifier: Optional[List[str]] = None,
     all_profiles: bool = False,
     crate: Optional[List[str]] = None,
+    url: Optional[List[str]] = None,
 ):
     """
     Pre-populate the HTTP cache with resources declared by profiles and with
     optional remote RO-Crate URLs.
     """
     console = ctx.obj['console']
+    explicit_urls = list(url or [])
+    invalid_urls = [u for u in explicit_urls if not u.lower().startswith(("http://", "https://"))]
+    if invalid_urls:
+        raise click.BadParameter(
+            f"expected an http(s):// address; got: {', '.join(invalid_urls)}",
+            param_hint="'--url' / '-u'",
+        )
+
     exit_with_failure = False
     try:
         resolved_cache = _resolve_cache_path(cache_path)
@@ -233,7 +251,10 @@ def cache_warm(
         urls: List[str] = []
         profile_scope: Optional[str] = None
 
-        if all_profiles or requested_ids or not crate:
+        # Only fall back to "warm all profiles" when the user gave no other
+        # source (no -p, no --crate, no --url, no --all-profiles).
+        any_explicit_source = bool(crate or explicit_urls or requested_ids or all_profiles)
+        if all_profiles or requested_ids or not any_explicit_source:
             Profile.load_profiles(
                 profiles_path=profiles_dir,
                 extra_profiles_path=extra_dir,
@@ -294,6 +315,12 @@ def cache_warm(
                 f"[bold]Fetching remote RO-Crates[/bold] ([cyan]{len(crate)}[/cyan] URL(s))..."
             )
             results.extend(_warm_remote_crates(list(crate)))
+
+        if explicit_urls:
+            console.print(
+                f"[bold]Fetching explicit URLs[/bold] ([cyan]{len(explicit_urls)}[/cyan] URL(s))..."
+            )
+            results.extend(warm_up_urls(explicit_urls))
 
         if not results:
             console.print("[yellow]Nothing to warm up.[/yellow]")

--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -223,10 +223,22 @@ def validate_uri(ctx, param, value):
     '-nc',
     '--no-cache',
     is_flag=True,
-    help="Disable the HTTP cache",
+    help=(
+        "Disable the HTTP cache entirely: every request goes to the network "
+        "and nothing is persisted. Incompatible with [bold]--offline[/bold]."
+    ),
     default=False,
     show_default=True,
-    hidden=True
+)
+@click.option(
+    '--offline',
+    is_flag=True,
+    help=(
+        "Offline mode: HTTP requests are served only from the cache. "
+        "Pre-populate the cache with [bold]rocrate-validator cache warm[/bold]."
+    ),
+    default=False,
+    show_default=True,
 )
 @click.pass_context
 def validate(ctx,
@@ -249,7 +261,8 @@ def validate(ctx,
              output_line_width: Optional[int] = None,
              cache_max_age: int = constants.DEFAULT_HTTP_CACHE_MAX_AGE,
              cache_path: Optional[Path] = None,
-             no_cache: bool = False):
+             no_cache: bool = False,
+             offline: bool = False):
     """
     [magenta]rocrate-validator:[/magenta] Validate a RO-Crate against a profile
     """
@@ -277,9 +290,35 @@ def validate(ctx,
     logger.debug("cache_max_age: %s", cache_max_age)
     logger.debug("cache_path: %s", os.path.abspath(cache_path) if cache_path else None)
     logger.debug("no_cache: %s", no_cache)
+    logger.debug("offline: %s", offline)
+
+    # --no-cache and --offline are contradictory: offline mode requires a cache
+    # to serve requests from, while no-cache disables caching entirely.
+    if no_cache and offline:
+        raise click.UsageError(
+            "The --no-cache and --offline flags are mutually exclusive: "
+            "offline mode relies on the HTTP cache to serve resources."
+        )
 
     if rocrate_uri:
         logger.debug("rocrate_path: %s", os.path.abspath(rocrate_uri))
+
+    # Warn the user when a remote RO-Crate is about to be validated in offline mode:
+    # the cached copy (if any) will be used, and it may be out of sync with the remote.
+    if offline and isinstance(rocrate_uri, str) and rocrate_uri.split(":", 1)[0].lower() in ("http", "https", "ftp"):
+        console.print(
+            Padding(
+                Rule(
+                    "[bold yellow]WARNING:[/bold yellow] "
+                    "[bold]The target RO-Crate is remote and offline mode is enabled.[/bold]\n"
+                    "The cached version of the RO-Crate will be used if available.\n"
+                    "The cached copy may be out of sync with the version currently published remotely.",
+                    align="center",
+                    style="bold yellow",
+                ),
+                (1, 2, 0, 2),
+            )
+        )
 
     # Parse the skip_checks option
     logger.debug("skip_checks: %s", skip_checks)
@@ -314,8 +353,13 @@ def validate(ctx,
             "abort_on_first": fail_fast,
             "skip_checks": skip_checks_list,
             "metadata_only": metadata_only,
-            "cache_max_age": cache_max_age if not no_cache else -1,
-            "cache_path": cache_path
+            "cache_max_age": cache_max_age,
+            "cache_path": cache_path,
+            "offline": offline,
+            "no_cache": no_cache,
+            # When offline is requested, remote crate fetching must use the cache
+            # instead of the "disable download" short-circuit.
+            "disable_remote_crate_download": False if offline else True,
         }
 
         # Print the application header

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -93,3 +93,5 @@ DEFAULT_HTTP_CACHE_PATH_PREFIX = '/tmp/rocrate_validator_cache'
 USER_CACHE_DIR_NAME = "rocrate-validator"
 # Filename (without extension) of the persistent HTTP cache under the user cache dir
 USER_CACHE_FILE_NAME = "http_cache"
+# Environment variable to disable automatic warm-up of the HTTP cache
+AUTO_WARM_ENV_VAR = "ROCRATE_VALIDATOR_AUTO_WARM"

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -89,3 +89,7 @@ JSON_OUTPUT_FORMAT_VERSION = "0.2"
 # Http Cache Settings
 DEFAULT_HTTP_CACHE_MAX_AGE = 300  # in seconds
 DEFAULT_HTTP_CACHE_PATH_PREFIX = '/tmp/rocrate_validator_cache'
+# Directory name used under the user's cache root for the persistent HTTP cache
+USER_CACHE_DIR_NAME = "rocrate-validator"
+# Filename (without extension) of the persistent HTTP cache under the user cache dir
+USER_CACHE_FILE_NAME = "http_cache"

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -87,7 +87,7 @@ VALID_REQUIREMENT_LEVELS_TYPES = typing.Literal[
 JSON_OUTPUT_FORMAT_VERSION = "0.2"
 
 # Http Cache Settings
-DEFAULT_HTTP_CACHE_MAX_AGE = 300  # in seconds
+DEFAULT_HTTP_CACHE_MAX_AGE = -1  # in seconds; negative means "never expire"
 DEFAULT_HTTP_CACHE_PATH_PREFIX = '/tmp/rocrate_validator_cache'
 # Directory name used under the user's cache root for the persistent HTTP cache
 USER_CACHE_DIR_NAME = "rocrate-validator"

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -49,9 +49,12 @@ from rocrate_validator.errors import (DuplicateRequirementCheck,
 from rocrate_validator.events import Event, EventType, Publisher, Subscriber
 from rocrate_validator.rocrate import ROCrate
 from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.cache_warmup import auto_warm_up_for_settings
 from rocrate_validator.utils.collections import MapIndex, MultiIndexMap
+from rocrate_validator.utils.document_loader import install_document_loader
 from rocrate_validator.utils.http import HttpRequester
-from rocrate_validator.utils.paths import get_profiles_path
+from rocrate_validator.utils.paths import (get_default_http_cache_path,
+                                           get_profiles_path)
 from rocrate_validator.utils.python_helpers import \
     get_requirement_name_from_file
 from rocrate_validator.utils.uri import URI
@@ -250,7 +253,7 @@ class Profile:
         self._profile_node = None
 
         # init property to store the RDF graph of the profile specification
-        self._profile_specification_graph = None
+        self._profile_specification_graph: Optional[Graph] = None
 
         # check if the profile specification file exists
         spec_file = self.profile_specification_file_path
@@ -2397,19 +2400,63 @@ class ValidationSettings:
     metadata_dict: dict = None
     #: Verbose output
     verbose: bool = False
-    #: Cache max age in seconds
+    #: Cache max age in seconds (negative values mean "never expire")
     cache_max_age: Optional[int] = DEFAULT_HTTP_CACHE_MAX_AGE
     #: Cache path
     cache_path: Optional[Path] = None
+    #: Flag to enable offline mode: HTTP requests are served only from the cache
+    offline: bool = False
+    #: Flag to disable the HTTP cache entirely: every request hits the network
+    no_cache: bool = False
 
     def __post_init__(self):
         # if requirement_severity is a str, convert to Severity
         if isinstance(self.requirement_severity, str):
             self.requirement_severity = Severity[self.requirement_severity]
+        # Offline mode needs the cache to serve responses, so it cannot be
+        # combined with an explicit cache disable.
+        if self.offline and self.no_cache:
+            raise ValueError(
+                "Offline mode requires the HTTP cache to be enabled; "
+                "no_cache=True is incompatible with offline=True."
+            )
+        # Default to the persistent user cache whenever caching is enabled so that
+        # consecutive runs (online then offline) share the same HTTP cache: this
+        # is what lets the offline mode find the resources fetched online.
+        if self.cache_path is None and not self.no_cache:
+            default_path = get_default_http_cache_path()
+            default_path.parent.mkdir(parents=True, exist_ok=True)
+            self.cache_path = default_path
+            logger.debug("Cache path not set: defaulting to persistent user cache %s", self.cache_path)
+        if self.offline and self.cache_path is None:
+            logger.warning(
+                "Offline mode enabled without a persistent cache path: "
+                "all HTTP-backed resources will fail unless pre-populated."
+            )
+        # Reset any previously initialized singleton so new settings take effect.
+        HttpRequester.reset()
         # initialize the HTTP cache
-        HttpRequester.initialize_cache(cache_path=self.cache_path, cache_max_age=self.cache_max_age)
-        logger.debug("HTTP cache initialized at %s with max age %s seconds",
-                     self.cache_path, self.cache_max_age)
+        HttpRequester.initialize_cache(
+            cache_path=str(self.cache_path) if self.cache_path is not None else None,
+            cache_max_age=self.cache_max_age,
+            offline=self.offline,
+            no_cache=self.no_cache,
+        )
+        logger.debug(
+            "HTTP cache initialized at %s with max age %s seconds (offline=%s, no_cache=%s)",
+            self.cache_path, self.cache_max_age, self.offline, self.no_cache,
+        )
+        # Install the JSON-LD document loader so context resolution goes through the cache.
+        try:
+            install_document_loader()
+        except Exception as e:
+            logger.debug("Could not install JSON-LD document loader: %s", e)
+        # Best-effort synchronous warm-up of profile-declared URLs.
+        if not self.offline:
+            try:
+                auto_warm_up_for_settings(self)
+            except Exception as e:
+                logger.debug("Auto warm-up skipped: %s", e)
 
     def to_dict(self):
         """

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -359,6 +359,13 @@ class Profile:
         return self.label or f"Profile {self.uri}"
 
     @property
+    def profile_specification_graph(self) -> Graph:
+        """
+        The RDF graph of the profile specification.
+        """
+        return self._profile_specification_graph  # type: ignore
+
+    @property
     def profile_node(self):
         return self._profile_node
 

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -382,6 +382,13 @@ class Profile:
         return self.label or f"Profile {self.uri}"
 
     @property
+    def profile_specification_graph(self) -> Graph:
+        """
+        The RDF graph of the profile specification.
+        """
+        return self._profile_specification_graph  # type: ignore
+
+    @property
     def profile_node(self):
         return self._profile_node
 

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -60,7 +60,7 @@ from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.cache_warmup import auto_warm_up_for_settings
 from rocrate_validator.utils.collections import MapIndex, MultiIndexMap
 from rocrate_validator.utils.document_loader import install_document_loader
-from rocrate_validator.utils.http import HttpRequester
+from rocrate_validator.utils.http import HttpRequester, find_offline_cache_miss
 from rocrate_validator.utils.paths import (
     get_default_http_cache_path,
     get_profiles_path,
@@ -1179,10 +1179,13 @@ class Requirement(ABC):
                 continue
             except Exception as e:
                 # Ignore the fact that the check failed as far as the validation result is concerned.
-                logger.warning("Unexpected error during check %s.  Exception: %s", check, e)
-                logger.warning("Consider reporting this as a bug.")
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception(e)
+                if context.maybe_warn_offline_cache_miss(e):
+                    logger.debug("Offline cache miss during check %s: %s", check, e)
+                else:
+                    logger.warning("Unexpected error during check %s.  Exception: %s", check, e)
+                    logger.warning("Consider reporting this as a bug.")
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception(e)
         skipped_checks = set(self._checks) - set(checks_to_perform)
         context.result.skipped_checks.update(skipped_checks)
         logger.debug(
@@ -3131,6 +3134,8 @@ class ValidationContext:
         self._result = None
         # additional properties for the context
         self._properties = {}
+        # URLs already reported as missing from the HTTP cache during this run
+        self._offline_cache_misses_warned: set[str] = set()
 
         # initialize the ROCrate object
         if settings.metadata_dict:
@@ -3466,3 +3471,21 @@ class ValidationContext:
             if p.identifier == identifier:
                 return p
         raise ProfileNotFound(identifier)
+
+    def maybe_warn_offline_cache_miss(self, exc: BaseException) -> bool:
+        """
+        If ``exc`` (or any cause/context in its chain) is an
+        :class:`OfflineCacheMissError`, emit a single user-facing warning
+        for the missing URL — but only the first time that URL is seen
+        during this validation run — and return ``True``.
+
+        Returns ``False`` when the exception is unrelated to offline cache
+        misses, so callers can fall back to their generic handling.
+        """
+        miss = find_offline_cache_miss(exc)
+        if miss is None:
+            return False
+        if miss.url not in self._offline_cache_misses_warned:
+            self._offline_cache_misses_warned.add(miss.url)
+            logger.warning("%s", miss)
+        return True

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -57,9 +57,14 @@ from rocrate_validator.errors import (
 from rocrate_validator.events import Event, EventType, Publisher, Subscriber
 from rocrate_validator.rocrate import ROCrate
 from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.cache_warmup import auto_warm_up_for_settings
 from rocrate_validator.utils.collections import MapIndex, MultiIndexMap
+from rocrate_validator.utils.document_loader import install_document_loader
 from rocrate_validator.utils.http import HttpRequester
-from rocrate_validator.utils.paths import get_profiles_path
+from rocrate_validator.utils.paths import (
+    get_default_http_cache_path,
+    get_profiles_path,
+)
 from rocrate_validator.utils.python_helpers import (
     get_requirement_name_from_file,
 )
@@ -267,7 +272,7 @@ class Profile:
         self._profile_node = None
 
         # init property to store the RDF graph of the profile specification
-        self._profile_specification_graph = None
+        self._profile_specification_graph: Optional[Graph] = None
 
         # check if the profile specification file exists
         spec_file = self.profile_specification_file_path
@@ -2637,22 +2642,63 @@ class ValidationSettings:
     metadata_dict: dict = None
     #: Verbose output
     verbose: bool = False
-    #: Cache max age in seconds
+    #: Cache max age in seconds (negative values mean "never expire")
     cache_max_age: Optional[int] = DEFAULT_HTTP_CACHE_MAX_AGE
     #: Cache path
     cache_path: Optional[Path] = None
+    #: Flag to enable offline mode: HTTP requests are served only from the cache
+    offline: bool = False
+    #: Flag to disable the HTTP cache entirely: every request hits the network
+    no_cache: bool = False
 
     def __post_init__(self):
         # if requirement_severity is a str, convert to Severity
         if isinstance(self.requirement_severity, str):
             self.requirement_severity = Severity[self.requirement_severity]
+        # Offline mode needs the cache to serve responses, so it cannot be
+        # combined with an explicit cache disable.
+        if self.offline and self.no_cache:
+            raise ValueError(
+                "Offline mode requires the HTTP cache to be enabled; "
+                "no_cache=True is incompatible with offline=True."
+            )
+        # Default to the persistent user cache whenever caching is enabled so that
+        # consecutive runs (online then offline) share the same HTTP cache: this
+        # is what lets the offline mode find the resources fetched online.
+        if self.cache_path is None and not self.no_cache:
+            default_path = get_default_http_cache_path()
+            default_path.parent.mkdir(parents=True, exist_ok=True)
+            self.cache_path = default_path
+            logger.debug("Cache path not set: defaulting to persistent user cache %s", self.cache_path)
+        if self.offline and self.cache_path is None:
+            logger.warning(
+                "Offline mode enabled without a persistent cache path: "
+                "all HTTP-backed resources will fail unless pre-populated."
+            )
+        # Reset any previously initialized singleton so new settings take effect.
+        HttpRequester.reset()
         # initialize the HTTP cache
-        HttpRequester.initialize_cache(cache_path=self.cache_path, cache_max_age=self.cache_max_age)
-        logger.debug(
-            "HTTP cache initialized at %s with max age %s seconds",
-            self.cache_path,
-            self.cache_max_age,
+        HttpRequester.initialize_cache(
+            cache_path=str(self.cache_path) if self.cache_path is not None else None,
+            cache_max_age=self.cache_max_age,
+            offline=self.offline,
+            no_cache=self.no_cache,
         )
+        logger.debug(
+            "HTTP cache initialized at %s with max age %s seconds (offline=%s, no_cache=%s)",
+            self.cache_path, self.cache_max_age, self.offline, self.no_cache,
+        )
+        # Install the JSON-LD document loader so context resolution goes through the cache.
+        try:
+            install_document_loader()
+        except Exception as e:
+            logger.debug("Could not install JSON-LD document loader: %s", e)
+        # Best-effort synchronous warm-up of profile-declared URLs.
+        if not self.offline:
+            try:
+                auto_warm_up_for_settings(self)
+            except Exception as e:
+                logger.debug("Auto warm-up skipped: %s", e)
 
     def to_dict(self):
         """

--- a/rocrate_validator/requirements/shacl/requirements.py
+++ b/rocrate_validator/requirements/shacl/requirements.py
@@ -140,9 +140,15 @@ class SHACLRequirement(Requirement):
         try:
             runner.__do_execute_check__(shacl_context)
         except Exception as e:
-            logger.warning("Forced SHACL run for zero-shape target profile %s failed: %s", target.identifier, e)
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.exception(e)
+            if context.maybe_warn_offline_cache_miss(e):
+                logger.debug(
+                    "Forced SHACL run for zero-shape target profile %s skipped due to offline cache miss: %s",
+                    target.identifier, e,
+                )
+            else:
+                logger.warning("Forced SHACL run for zero-shape target profile %s failed: %s", target.identifier, e)
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.exception(e)
         finally:
             shacl_context.__unset_current_validation_profile__()
 

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -150,8 +150,26 @@ def __initialise_validator__(settings: Union[dict, ValidationSettings],
         logger.debug("RO-Crate is a remote RO-Crate")
         # create a temp folder to store the downloaded RO-Crate
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-            # download the remote RO-Crate
-            with HttpRequester().get(rocrate_path.uri, stream=True, allow_redirects=True) as r:
+            requester = HttpRequester()
+            offline = bool(getattr(settings, "offline", False))
+            # In offline mode, the cache is the only source of truth. Otherwise,
+            # bypass the cache to refresh the stored copy so that subsequent
+            # offline runs validate against the latest known remote state.
+            if offline:
+                response = requester.get(rocrate_path.uri, stream=True, allow_redirects=True)
+            else:
+                response = requester.fetch_fresh(rocrate_path.uri, stream=True, allow_redirects=True)
+            with response as r:
+                if r.status_code >= 400:
+                    if offline and r.status_code == 504:
+                        raise FileNotFoundError(
+                            f"Remote RO-Crate '{rocrate_path.uri}' is not available in the HTTP cache. "
+                            f"Validate it online first, or run "
+                            f"`rocrate-validator cache warm --crate '{rocrate_path.uri}'`."
+                        )
+                    raise FileNotFoundError(
+                        f"Failed to download remote RO-Crate '{rocrate_path.uri}' (status {r.status_code})."
+                    )
                 with open(tmp_file.name, 'wb') as f:
                     shutil.copyfileobj(r.raw, f)
             logger.debug("RO-Crate downloaded to temporary file: %s", tmp_file.name)

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -151,8 +151,26 @@ def __initialise_validator__(
         logger.debug("RO-Crate is a remote RO-Crate")
         # create a temp folder to store the downloaded RO-Crate
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-            # download the remote RO-Crate
-            with HttpRequester().get(rocrate_path.uri, stream=True, allow_redirects=True) as r:
+            requester = HttpRequester()
+            offline = bool(getattr(settings, "offline", False))
+            # In offline mode, the cache is the only source of truth. Otherwise,
+            # bypass the cache to refresh the stored copy so that subsequent
+            # offline runs validate against the latest known remote state.
+            if offline:
+                response = requester.get(rocrate_path.uri, stream=True, allow_redirects=True)
+            else:
+                response = requester.fetch_fresh(rocrate_path.uri, stream=True, allow_redirects=True)
+            with response as r:
+                if r.status_code >= 400:
+                    if offline and r.status_code == 504:
+                        raise FileNotFoundError(
+                            f"Remote RO-Crate '{rocrate_path.uri}' is not available in the HTTP cache. "
+                            f"Validate it online first, or run "
+                            f"`rocrate-validator cache warm --crate '{rocrate_path.uri}'`."
+                        )
+                    raise FileNotFoundError(
+                        f"Failed to download remote RO-Crate '{rocrate_path.uri}' (status {r.status_code})."
+                    )
                 with open(tmp_file.name, "wb") as f:
                     shutil.copyfileobj(r.raw, f)
             logger.debug("RO-Crate downloaded to temporary file: %s", tmp_file.name)

--- a/rocrate_validator/utils/cache_warmup.py
+++ b/rocrate_validator/utils/cache_warmup.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helpers to populate the HTTP cache with resources referenced by profile
+descriptors.
+
+Profiles describe their external resources using the W3C Profiles Vocabulary
+(``prof:hasResource`` / ``prof:hasArtifact``). The URLs declared there are the
+ones the validator needs to resolve at runtime (JSON-LD contexts, ontologies,
+schemas, ...). By discovering them dynamically we can warm the cache so that
+subsequent offline runs find every required resource locally.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence
+
+from rocrate_validator import constants
+from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.http import (OFFLINE_CACHE_MISS_STATUS,
+                                          HttpRequester)
+
+if TYPE_CHECKING:
+    from rocrate_validator.models import Profile, ValidationSettings
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+# Guard to prevent multiple warm-up attempts in the same run.
+# This is not a thread-safe mechanism.
+__profiles_loaded = False
+
+
+# SPARQL query returning every artifact URL declared in a profile descriptor.
+# We intentionally do not filter by role: any resource the profile declares is
+# considered a candidate for warm-up (Vocabulary, Constraints, Schema, ...).
+_CACHEABLE_URLS_SPARQL = """
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+SELECT DISTINCT ?artifact
+WHERE {
+    ?profile prof:hasResource ?resource .
+    ?resource prof:hasArtifact ?artifact .
+}
+"""
+
+
+@dataclass
+class WarmUpResult:
+    """Outcome of a warm-up operation."""
+    url: str
+    status: str  # "ok", "skipped", "failed"
+    detail: Optional[str] = None
+
+
+def discover_profile_cacheable_urls(profile: "Profile") -> List[str]:
+    """
+    Return the list of HTTP(S) URLs declared by ``profile`` as cacheable
+    artifacts. Returns an empty list when the profile has no declared
+    artifacts or cannot be parsed.
+    """
+    graph = profile.profile_specification_graph
+    if graph is None:
+        logger.debug(
+            "Profile %s has no specification graph loaded", getattr(profile, "identifier", "?"))
+        return []
+    urls: List[str] = []
+    try:
+        for row in graph.query(_CACHEABLE_URLS_SPARQL):
+            artifact = row.artifact
+            if artifact is None:
+                continue
+            value = str(artifact)
+            if value.lower().startswith(("http://", "https://")) and value not in urls:
+                urls.append(value)
+    except Exception as e:
+        logger.debug("Failed to query cacheable URLs for profile %s: %s",
+                     getattr(profile, "identifier", "?"), e)
+    return urls
+
+
+def discover_cacheable_urls_from_profiles(profiles: Iterable["Profile"]) -> List[str]:
+    """
+    Aggregate cacheable URLs from the given profiles, preserving order and
+    removing duplicates.
+    """
+    seen: set[str] = set()
+    result: List[str] = []
+    for profile in profiles:
+        for url in discover_profile_cacheable_urls(profile):
+            if url not in seen:
+                seen.add(url)
+                result.append(url)
+    return result
+
+
+def warm_up_urls(urls: Sequence[str]) -> List[WarmUpResult]:
+    """
+    Fetch each URL so that its response is stored in the HTTP cache.
+
+    Already-cached URLs are skipped. Failures (including HTTP errors and
+    offline cache misses) are reported but do not raise.
+    """
+    requester = HttpRequester()
+    results: List[WarmUpResult] = []
+    offline = bool(getattr(requester, "offline", False))
+    for url in urls:
+        try:
+            if requester.has_cached(url):
+                results.append(WarmUpResult(url=url, status="skipped", detail="already cached"))
+                continue
+            if offline:
+                response = requester.get(url)
+            else:
+                response = requester.fetch_fresh(url)
+            status_code = getattr(response, "status_code", None)
+            if status_code is None:
+                results.append(WarmUpResult(url=url, status="failed", detail="no status code"))
+            elif status_code == OFFLINE_CACHE_MISS_STATUS and offline:
+                results.append(WarmUpResult(url=url, status="failed", detail="offline cache miss"))
+            elif status_code >= 400:
+                results.append(WarmUpResult(url=url, status="failed", detail=f"HTTP {status_code}"))
+            else:
+                results.append(WarmUpResult(url=url, status="ok", detail=f"HTTP {status_code}"))
+        except Exception as e:
+            logger.debug("Warm-up failed for %s: %s", url, e)
+            results.append(WarmUpResult(url=url, status="failed", detail=str(e)))
+    return results
+
+
+def auto_warm_up_for_settings(settings: "ValidationSettings") -> Optional[List[WarmUpResult]]:
+    """
+    Perform a best-effort synchronous warm-up triggered by
+    ``ValidationSettings.__post_init__``.
+
+    The warm-up is skipped when:
+
+    - offline mode is enabled (nothing to fetch from the network);
+    - the cache path is not persistent (auto warm-up only makes sense when
+      the cache survives the run);
+    - the environment variable ``ROCRATE_VALIDATOR_AUTO_WARM`` is set to a
+      value disabling the feature (``0``, ``false``, ``no``, ``off``).
+    """
+    if getattr(settings, "offline", False):
+        return None
+    if getattr(settings, "cache_path", None) is None:
+        return None
+    env_value = os.environ.get(constants.AUTO_WARM_ENV_VAR, "1").strip().lower()
+    if env_value in {"0", "false", "no", "off"}:
+        logger.debug("Auto warm-up disabled via %s=%s", constants.AUTO_WARM_ENV_VAR, env_value)
+        return None
+
+    profile_identifier = getattr(settings, "profile_identifier", None)
+    if not profile_identifier:
+        return None
+
+    profile = _find_profile(profile_identifier, settings)
+    if profile is None:
+        return None
+    urls = discover_profile_cacheable_urls(profile)
+    if not urls:
+        return None
+    requester = HttpRequester()
+    urls_to_fetch = [u for u in urls if not requester.has_cached(u)]
+    if not urls_to_fetch:
+        logger.debug("Auto warm-up: all %d resources already cached for profile %s",
+                     len(urls), profile_identifier)
+        return []
+    results = warm_up_urls(urls_to_fetch)
+    ok = sum(1 for r in results if r.status == "ok")
+    logger.info("Auto warm-up: pre-loaded %d/%d resources for profile %s",
+                ok, len(urls_to_fetch), profile_identifier)
+    return results
+
+
+def _find_profile(identifier, settings) -> Optional["Profile"]:
+    """
+    Look up a loaded profile by identifier. Accepts either a string or a list
+    (the settings sometimes store a list of identifiers).
+    """
+    # Import here to avoid a circular import with models.py.
+    from rocrate_validator.models import Profile
+    from rocrate_validator.utils.paths import get_profiles_path
+
+    # Load profiles to ensure the requested one is available and its graph is parsed.
+    global __profiles_loaded
+    if not __profiles_loaded:
+        profiles_path = getattr(settings, "profiles_path", None) or get_profiles_path()
+        extra_profiles_path = getattr(settings, "extra_profiles_path", None)
+        try:
+            Profile.load_profiles(
+                profiles_path=profiles_path,
+                publicID=None,
+                extra_profiles_path=extra_profiles_path,
+            )
+            __profiles_loaded = True
+        except Exception as e:
+            logger.debug("Unable to preload profiles for auto warm-up: %s", e)
+            return None
+
+    if isinstance(identifier, (list, tuple)):
+        if not identifier:
+            return None
+        identifier = identifier[0]
+    try:
+        return Profile.get_by_identifier(identifier)
+    except Exception:
+        # Fall back to scanning all loaded profiles.
+        try:
+            for profile in Profile.all():
+                if getattr(profile, "identifier", None) == identifier:
+                    return profile
+        except Exception:
+            return None
+    return None

--- a/rocrate_validator/utils/document_loader.py
+++ b/rocrate_validator/utils/document_loader.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+JSON-LD document loader that routes remote ``@context`` resolution through
+``HttpRequester``.
+
+``rdflib``'s built-in JSON-LD parser fetches remote contexts via ``urllib``,
+which bypasses the HTTP cache managed by this project. Installing the loader
+ensures every remote context resolution benefits from the cache and honors
+offline mode.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any, Optional, Tuple
+
+from rdflib.plugins.shared.jsonld import context as jsonld_context
+from rdflib.plugins.shared.jsonld import util as jsonld_util
+
+from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.http import (OFFLINE_CACHE_MISS_STATUS,
+                                          HttpRequester, OfflineCacheMissError)
+
+logger = logging.getLogger(__name__)
+
+_install_lock = threading.Lock()
+_installed = False
+_original_source_to_json = jsonld_util.source_to_json
+
+
+def _patched_source_to_json(source, fragment_id=None, extract_all_scripts=False):
+    # Only intercept remote URL strings; let the original handle everything else.
+    if isinstance(source, str) and source.lower().startswith(("http://", "https://")):
+        try:
+            return _fetch_json_ld(source), None
+        except OfflineCacheMissError:
+            raise
+        except Exception as e:
+            logger.debug("Custom JSON-LD loader failed for %s: %s; falling back", source, e)
+    return _original_source_to_json(source, fragment_id, extract_all_scripts)
+
+
+def install_document_loader() -> bool:
+    """
+    Install the custom JSON-LD document loader. Idempotent.
+
+    Returns ``True`` when the loader is active after the call, ``False`` when
+    installation raised an unexpected error (which is logged).
+    """
+    global _installed
+
+    with _install_lock:
+        if _installed:
+            return True
+
+        try:
+            jsonld_util.source_to_json = _patched_source_to_json
+            # The context module imports source_to_json at module import time,
+            # so it must be patched separately.
+            jsonld_context.source_to_json = _patched_source_to_json  # type: ignore[attr-defined]
+        except Exception as e:
+            logger.error("Failed to install JSON-LD document loader: %s", e)
+            return False
+
+        _installed = True
+        logger.debug("JSON-LD document loader installed")
+        return True
+
+
+def uninstall_document_loader() -> bool:
+    """
+    Restore the original JSON-LD document loader. Primarily intended for tests.
+
+    Returns ``True`` when the loader is no longer active after the call,
+    ``False`` when uninstallation raised an unexpected error (which is logged).
+    """
+    global _installed
+    with _install_lock:
+        if not _installed:
+            return True
+
+        try:
+            jsonld_util.source_to_json = _original_source_to_json
+            jsonld_context.source_to_json = _original_source_to_json  # type: ignore[attr-defined]
+        except Exception as e:
+            logger.error("Failed to uninstall JSON-LD document loader: %s", e)
+            return False
+
+        _installed = False
+        return True
+
+
+def _fetch_json_ld(url: str) -> Any:
+    """
+    Fetch a JSON-LD document through ``HttpRequester``.
+
+    Raises ``OfflineCacheMissError`` when running offline and the document
+    is not available in the cache. Raises ``RuntimeError`` for other
+    non-successful responses.
+    """
+    requester = HttpRequester()
+    headers = {"Accept": "application/ld+json, application/json, */*;q=0.1"}
+    response = requester.get(url, headers=headers, allow_redirects=True)
+    status = getattr(response, "status_code", None)
+    if status == OFFLINE_CACHE_MISS_STATUS and getattr(requester, "offline", False):
+        raise OfflineCacheMissError(url)
+    if status is None or status >= 400:
+        raise RuntimeError(f"Unable to retrieve JSON-LD document from {url} (status {status})")
+    try:
+        return response.json()
+    except ValueError:
+        return json.loads(response.text)
+
+
+def resolve_remote_document(url: str) -> Tuple[Optional[dict], Optional[str]]:
+    """
+    Resolve a remote JSON-LD document, returning ``(json, content_type)``.
+
+    Exposed primarily for tests and warm-up routines that need to reuse the
+    loader's semantics (offline handling, cache integration) without wiring
+    through rdflib.
+    """
+    data = _fetch_json_ld(url)
+    return data, "application/ld+json"

--- a/rocrate_validator/utils/http.py
+++ b/rocrate_validator/utils/http.py
@@ -56,7 +56,6 @@ def _log_cache_outcome(method: str, url: str, response, *, offline: bool, forced
         # No from_cache attribute: plain requests.Session or offline fallback stub.
         outcome = "fetched from remote (no cache backend)"
 
-    # Emitted at WARNING for now, pending a downgrade to DEBUG once the feature stabilizes.
     logger.debug("CachedHttpRequester: %s %s %s", method, url, outcome)
 
 

--- a/rocrate_validator/utils/http.py
+++ b/rocrate_validator/utils/http.py
@@ -57,7 +57,7 @@ def _log_cache_outcome(method: str, url: str, response, *, offline: bool, forced
         outcome = "fetched from remote (no cache backend)"
 
     # Emitted at WARNING for now, pending a downgrade to DEBUG once the feature stabilizes.
-    logger.warning("CachedHttpRequester: %s %s %s", method, url, outcome)
+    logger.debug("CachedHttpRequester: %s %s %s", method, url, outcome)
 
 
 class OfflineCacheMissError(RuntimeError):

--- a/rocrate_validator/utils/http.py
+++ b/rocrate_validator/utils/http.py
@@ -19,7 +19,7 @@ import os
 import random
 import string
 import threading
-from typing import Optional
+from typing import Any, Optional
 
 import requests
 
@@ -30,9 +30,55 @@ from rocrate_validator.utils import log as logging
 logger = logging.getLogger(__name__)
 
 
+# HTTP status code used to signal a cache miss in offline mode.
+# 504 is what requests_cache uses when only_if_cached is set and
+# no cached response is available.
+OFFLINE_CACHE_MISS_STATUS = 504
+
+
+def _log_cache_outcome(method: str, url: str, response, *, offline: bool, forced_refresh: bool = False) -> None:
+    """
+    Emit a standardized ``CachedHttpRequester: ...`` message describing whether ``url`` was
+    served from the HTTP cache or fetched from the remote server.
+    """
+    from_cache = getattr(response, "from_cache", None)
+    status = getattr(response, "status_code", None)
+
+    if offline and status == OFFLINE_CACHE_MISS_STATUS:
+        outcome = "not available in HTTP cache (offline cache miss)"
+    elif from_cache is True:
+        outcome = "served from HTTP cache"
+    elif forced_refresh:
+        outcome = "fetched from remote (cache refresh)"
+    elif from_cache is False:
+        outcome = "fetched from remote"
+    else:
+        # No from_cache attribute: plain requests.Session or offline fallback stub.
+        outcome = "fetched from remote (no cache backend)"
+
+    # Emitted at WARNING for now, pending a downgrade to DEBUG once the feature stabilizes.
+    logger.warning("CachedHttpRequester: %s %s %s", method, url, outcome)
+
+
+class OfflineCacheMissError(RuntimeError):
+    """Raised when an HTTP resource is not available in the cache while offline."""
+
+    def __init__(self, url: str):
+        super().__init__(
+            f"Resource '{url}' is not available in the HTTP cache and "
+            f"the validator is running in offline mode. Run online once, or use "
+            f"`rocrate-validator cache warm` to pre-populate the cache."
+        )
+        self.url = url
+
+
 class HttpRequester:
     """
-    A singleton class to handle HTTP requests
+    A singleton class to handle HTTP requests.
+
+    The session is backed by ``requests_cache`` when available. The requester
+    supports an offline mode in which only cached responses are served
+    (cache misses yield a 504 response instead of hitting the network).
     """
     _instance = None
     _lock = threading.Lock()
@@ -50,7 +96,9 @@ class HttpRequester:
 
     def __init__(self,
                  cache_max_age: int = constants.DEFAULT_HTTP_CACHE_MAX_AGE,
-                 cache_path: Optional[str] = None):
+                 cache_path: Optional[str] = None,
+                 offline: bool = False,
+                 no_cache: bool = False):
         logger.debug(f"Initializing instance of {self.__class__.__name__} {self}")
         # check if the instance is already initialized
         if not hasattr(self, "_initialized"):
@@ -66,6 +114,8 @@ class HttpRequester:
                     except ValueError:
                         raise TypeError("cache_max_age must be an integer")
                     self.cache_path_prefix = cache_path
+                    self.offline = bool(offline)
+                    self.no_cache = bool(no_cache)
                     # flag to indicate if the cache is permanent or temporary
                     self.permanent_cache = cache_path is not None
                     # initialize the session
@@ -83,7 +133,7 @@ class HttpRequester:
         # check if requests_cache is installed
         # and set up the cached session
         try:
-            if cache_max_age >= 0:
+            if not self.no_cache:
                 from requests_cache import CachedSession
 
                 # If cache_path is not provided, use the default path prefix
@@ -96,15 +146,25 @@ class HttpRequester:
                 else:
                     logger.debug(f"Using provided cache path: {cache_path}")
                     self.permanent_cache = True
+                # Negative cache_max_age means "never expire" (as documented in the CLI);
+                # offline mode also forces never-expire so stale entries remain usable.
+                expire_after = -1 if (self.offline or cache_max_age < 0) else cache_max_age
                 # Initialize the session with a cache
                 self.session = CachedSession(
                     # Cache name with random suffix
-                    cache_name=cache_path,
-                    expire_after=cache_max_age,  # Cache expiration time in seconds
+                    cache_name=str(cache_path),
+                    expire_after=expire_after,  # Cache expiration time in seconds
                     backend='sqlite',  # Use SQLite backend
                     allowable_methods=('GET',),  # Cache GET
                     allowable_codes=(200, 302, 404)  # Cache responses with these status codes
                 )
+                # Apply offline policy: only return cached responses.
+                if self.offline:
+                    try:
+                        self.session.settings.only_if_cached = True
+                    except AttributeError:
+                        # Older requests_cache versions expose the flag on the session directly.
+                        setattr(self.session, "only_if_cached", True)
         except ImportError:
             logger.warning("requests_cache is not installed. Using requests instead.")
         except Exception as e:
@@ -114,8 +174,15 @@ class HttpRequester:
         # use requests instead of requests_cache
         # and create a new session
         if not self.session:
-            logger.debug("Cache disabled: using requests instead of requests_cache")
-            self.session = requests.Session()
+            if self.offline:
+                logger.warning(
+                    "Offline mode requested but requests_cache is not available: "
+                    "HTTP requests will be blocked."
+                )
+                self.session = _OfflineFallbackSession()
+            else:
+                logger.debug("Cache disabled: using requests instead of requests_cache")
+                self.session = requests.Session()
 
     def __del__(self):
         """
@@ -127,7 +194,7 @@ class HttpRequester:
 
     def cleanup(self):
         """
-        Destructor to clean up the cache file used by CachedSession.
+        Remove the SQLite cache file when the cache is marked as temporary.
         """
         logger.debug(f"Deleting instance of {self.__class__.__name__}")
         if self.session and hasattr(self.session, 'cache') and self.session.cache:
@@ -142,23 +209,202 @@ class HttpRequester:
 
     def __getattr__(self, name):
         """
-        Delegate HTTP methods to the session object.
+        Delegate HTTP methods to the session object, wrapping the call with
+        cache-outcome logging.
 
         :param name: The name of the method to call.
-        :return: The method from the session object.
+        :return: A callable that proxies to the session method.
         """
         if name.upper() in {"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"}:
-            return getattr(self.session, name.lower())
+            method = name.lower()
+            session_method = getattr(self.session, method)
+
+            def _wrapped(url, *args, **kwargs):
+                response = session_method(url, *args, **kwargs)
+                _log_cache_outcome(method.upper(), url, response, offline=self.offline)
+                return response
+
+            return _wrapped
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+
+    def fetch_fresh(self, url: str, **kwargs) -> requests.Response:
+        """
+        Fetch ``url`` bypassing the HTTP cache and store the fresh response.
+
+        Used for resources that must always reflect the current remote state
+        while still being available offline afterwards (e.g., a remote RO-Crate
+        whose cached copy must be refreshed on every online run).
+
+        In offline mode, the cache is consulted as usual (no network traffic).
+
+        :param url: The URL to fetch.
+        :return: The HTTP response.
+        """
+        if self.offline:
+            response = self.session.get(url, **kwargs)
+        else:
+            # ``force_refresh=True`` tells requests_cache to bypass the cache
+            # entirely and overwrite the stored entry with the new response.
+            # Older requests_cache versions only understand ``refresh=True``
+            # (revalidation), and plain ``requests.Session`` accepts neither.
+            response = None
+            for flag in ("force_refresh", "refresh"):
+                try:
+                    response = self.session.get(url, **{flag: True}, **kwargs)
+                    break
+                except TypeError:
+                    continue
+            if response is None:
+                response = self.session.get(url, **kwargs)
+        _log_cache_outcome("GET", url, response, offline=self.offline, forced_refresh=not self.offline)
+        return response
+
+    def has_cached(self, url: str) -> bool:
+        """
+        Check whether ``url`` is already present in the HTTP cache.
+
+        Returns ``False`` when the underlying session does not implement a cache.
+        """
+        cache = getattr(self.session, "cache", None)
+        if cache is None:
+            return False
+        contains = getattr(cache, "contains", None)
+        try:
+            if contains is not None:
+                return bool(contains(url=url))
+            # Fallback for older requests_cache versions.
+            return bool(cache.has_url(url))
+        except Exception as e:
+            logger.debug("Cache lookup failed for %s: %s", url, e)
+            return False
+
+    def clear_cache(self) -> None:
+        """
+        Remove every entry from the HTTP cache.
+        """
+        cache = getattr(self.session, "cache", None)
+        if cache is None:
+            logger.debug("No cache backend to clear")
+            return
+        try:
+            cache.clear()
+            logger.info("HTTP cache cleared")
+        except Exception as e:
+            logger.error("Failed to clear HTTP cache: %s", e)
+            raise
+
+    def cache_info(self) -> dict[str, Any]:
+        """
+        Return metadata about the current HTTP cache backend.
+        """
+        info: dict[str, Any] = {
+            "backend": None,
+            "path": None,
+            "permanent": getattr(self, "permanent_cache", False),
+            "offline": getattr(self, "offline", False),
+            "entries": 0,
+            "size_bytes": 0,
+        }
+        cache = getattr(self.session, "cache", None)
+        if cache is None:
+            return info
+        info["backend"] = cache.__class__.__name__
+        cache_name = getattr(cache, "cache_name", None) or getattr(cache, "db_path", None)
+        if cache_name:
+            info["path"] = f"{cache_name}.sqlite" if not str(cache_name).endswith(".sqlite") else str(cache_name)
+        try:
+            info["entries"] = len(cache.responses)
+        except Exception:
+            try:
+                info["entries"] = sum(1 for _ in cache.urls())
+            except Exception as e:
+                logger.debug("Unable to count cache entries: %s", e)
+        if info["path"] and os.path.exists(info["path"]):
+            try:
+                info["size_bytes"] = os.path.getsize(info["path"])
+            except OSError:
+                pass
+        return info
 
     @classmethod
     def initialize_cache(cls,
                          cache_max_age: int = constants.DEFAULT_HTTP_CACHE_MAX_AGE,
-                         cache_path: Optional[str] = None) -> HttpRequester:
+                         cache_path: Optional[str] = None,
+                         offline: bool = False,
+                         no_cache: bool = False) -> HttpRequester:
         """
         Initialize the HttpRequester singleton with cache settings.
 
-        :param max_age: The maximum age of the cache in seconds.
+        :param cache_max_age: Maximum age of cached responses in seconds.
+            Negative values mean "never expire".
         :param cache_path: The path to the cache directory.
+        :param offline: When ``True``, only cached responses are served.
+        :param no_cache: When ``True``, disable the HTTP cache entirely and
+            use a plain ``requests.Session``. Incompatible with ``offline``.
         """
-        return cls(cache_max_age=cache_max_age, cache_path=cache_path)
+        return cls(cache_max_age=cache_max_age, cache_path=cache_path,
+                   offline=offline, no_cache=no_cache)
+
+    @classmethod
+    def reset(cls) -> None:
+        """
+        Drop the singleton instance. Primarily intended for tests and the
+        ``cache`` CLI subcommand that reconfigures the cache on the fly.
+        """
+        with cls._lock:
+            instance = cls._instance
+            if instance is not None:
+                try:
+                    session = getattr(instance, "session", None)
+                    if session is not None and hasattr(session, "close"):
+                        session.close()
+                except Exception as e:
+                    logger.debug("Error closing previous session: %s", e)
+                if getattr(instance, "permanent_cache", True) is False:
+                    try:
+                        instance.cleanup()
+                    except Exception as e:
+                        logger.debug("Error cleaning up previous cache: %s", e)
+            cls._instance = None
+
+
+class _OfflineFallbackSession:
+    """
+    Minimal session used when offline mode is requested but no HTTP cache
+    backend is available. Every request yields a 504 response to signal a
+    cache miss, mirroring the behavior of ``requests_cache`` in offline mode.
+    """
+
+    cache = None
+
+    def _offline_response(self, url: str) -> requests.Response:
+        response = requests.Response()
+        response.status_code = OFFLINE_CACHE_MISS_STATUS
+        response.reason = "Offline: no HTTP cache backend available"
+        response.url = url
+        # response._content = b""
+        return response
+
+    def get(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def head(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def post(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def put(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def delete(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def options(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def patch(self, url, **_kwargs):
+        return self._offline_response(url)
+
+    def close(self):
+        pass

--- a/rocrate_validator/utils/http.py
+++ b/rocrate_validator/utils/http.py
@@ -71,6 +71,22 @@ class OfflineCacheMissError(RuntimeError):
         self.url = url
 
 
+def find_offline_cache_miss(exc: BaseException) -> Optional[OfflineCacheMissError]:
+    """
+    Walk the chain of an exception (``__cause__``/``__context__``) looking
+    for an :class:`OfflineCacheMissError`. Returns the first match, or
+    ``None`` if the chain does not contain one.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, OfflineCacheMissError):
+            return current
+        current = current.__cause__ or current.__context__
+    return None
+
+
 class HttpRequester:
     """
     A singleton class to handle HTTP requests.

--- a/rocrate_validator/utils/paths.py
+++ b/rocrate_validator/utils/paths.py
@@ -72,6 +72,33 @@ def get_profiles_path() -> Path:
     return Path(CURRENT_DIR).parent / constants.DEFAULT_PROFILES_PATH
 
 
+def get_user_cache_dir() -> Path:
+    """
+    Get the user-level cache directory for rocrate-validator.
+
+    Honors the XDG Base Directory Specification:
+    - Uses ``$XDG_CACHE_HOME/rocrate-validator`` when ``XDG_CACHE_HOME`` is set
+    - Falls back to ``~/.cache/rocrate-validator`` otherwise
+
+    :return: The path to the cache directory (not guaranteed to exist)
+    """
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / constants.USER_CACHE_DIR_NAME
+
+
+def get_default_http_cache_path() -> Path:
+    """
+    Get the default persistent HTTP cache path under the user cache directory.
+
+    The returned path is the cache *name* expected by ``requests_cache``
+    (i.e., without the ``.sqlite`` suffix added by the backend).
+
+    :return: The default persistent HTTP cache name path
+    """
+    return get_user_cache_dir() / constants.USER_CACHE_FILE_NAME
+
+
 def list_matching_file_paths(
         directory: str = '.',
         serialization_format: constants.RDF_SERIALIZATION_FORMATS_TYPES = "turtle") -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@
 # and add it to the system path
 import os
 
+import pytest
 from pytest import fixture
 
 from rocrate_validator.utils import log as logging
@@ -46,6 +47,41 @@ check_local_data_entity_existence = \
 assert check_local_data_entity_existence, \
     "Unable to find the requirement 'Data Entity: REQUIRED resource availability'"
 SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER = check_local_data_entity_existence.identifier
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _session_isolated_xdg(tmp_path_factory):
+    """
+    Redirect the XDG user cache to a per-session temporary directory so that
+    tests do not write to, or read from, the developer's real ~/.cache. The
+    directory is shared across tests in the same session so that HTTP responses
+    fetched by one test remain available to subsequent ones (mirroring the
+    behavior users see in practice and preserving the HTTP-cache hit pattern
+    the existing test suite relies on).
+    """
+    xdg_dir = tmp_path_factory.mktemp("rocrate_validator_xdg")
+    previous_xdg = os.environ.get("XDG_CACHE_HOME")
+    os.environ["XDG_CACHE_HOME"] = str(xdg_dir)
+    try:
+        yield xdg_dir
+    finally:
+        if previous_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = previous_xdg
+
+
+@pytest.fixture(autouse=True)
+def _per_test_auto_warm(monkeypatch):
+    """
+    Disable the synchronous HTTP cache auto warm-up by default so tests do not
+    hit the network unexpectedly. Tests that exercise the warm-up opt in by
+    setting the environment variable before instantiating ValidationSettings.
+    """
+    monkeypatch.setenv(
+        "ROCRATE_VALIDATOR_AUTO_WARM",
+        os.environ.get("ROCRATE_VALIDATOR_AUTO_WARM", "0"),
+    )
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,30 @@ SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER = check_local_data_entity_exis
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _session_wide_terminal():
+    """
+    Force Rich (and other ``os.get_terminal_size`` consumers) to render with
+    a wide terminal. ``click.testing.CliRunner`` captures stdout into a
+    StringIO, so Rich falls back to its 80-column default and truncates
+    table cells / wraps panel rows — breaking ``"substring" in result.output``
+    assertions in a non-deterministic way. Setting ``COLUMNS`` early keeps
+    the rendered output predictable across machines and CI.
+    """
+    previous_columns = os.environ.get("COLUMNS")
+    previous_lines = os.environ.get("LINES")
+    os.environ["COLUMNS"] = "200"
+    os.environ["LINES"] = "50"
+    try:
+        yield
+    finally:
+        for name, prev in (("COLUMNS", previous_columns), ("LINES", previous_lines)):
+            if prev is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = prev
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _session_isolated_xdg(tmp_path_factory):
     """
     Redirect the XDG user cache to a per-session temporary directory so that

--- a/tests/integration/test_offline_mode.py
+++ b/tests/integration/test_offline_mode.py
@@ -1,0 +1,407 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for offline mode, auto warm-up and the cache CLI."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+import urllib3
+from click.testing import CliRunner
+
+from rocrate_validator.cli.main import cli
+from rocrate_validator.models import ValidationSettings
+from rocrate_validator.utils.http import (OFFLINE_CACHE_MISS_STATUS,
+                                          HttpRequester)
+from tests.conftest import SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER
+from tests.ro_crates import ValidROC
+
+
+def _urllib3_response(payload: bytes = b'{"@context": {}}',
+                      status: int = 200,
+                      content_type: str = "application/ld+json") -> urllib3.HTTPResponse:
+    return urllib3.HTTPResponse(
+        body=io.BytesIO(payload),
+        headers={
+            "Content-Type": content_type,
+            "Content-Length": str(len(payload)),
+        },
+        status=status,
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+@pytest.fixture
+def network_interceptor(monkeypatch):
+    """
+    Intercept every outbound HTTP call and record the requested URLs so tests
+    can assert whether the cache was actually consulted.
+    """
+    from requests.adapters import HTTPAdapter
+
+    recorder = {"calls": []}
+
+    def fake_send(self, request, **kwargs):
+        recorder["calls"].append(request.url)
+        return self.build_response(request, _urllib3_response())
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+    return recorder
+
+
+@pytest.fixture(autouse=True)
+def _clean_singleton(monkeypatch):
+    monkeypatch.setenv("ROCRATE_VALIDATOR_AUTO_WARM", "0")
+    HttpRequester.reset()
+    yield
+    HttpRequester.reset()
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_offline_flag_configures_cache(tmp_path):
+    settings = ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+        cache_path=tmp_path / "cache",
+    )
+    info = HttpRequester().cache_info()
+    assert info["offline"] is True
+    assert info["permanent"] is True
+    assert settings.offline is True
+
+
+def test_offline_default_path_is_persistent(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+        cache_path=None,
+    )
+    info = HttpRequester().cache_info()
+    assert info["offline"] is True
+    assert info["permanent"] is True
+    assert str(tmp_path / "xdg") in str(info["path"])
+
+
+def test_offline_cache_miss_yields_504_response(tmp_path):
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+        cache_path=tmp_path / "cache",
+    )
+    response = HttpRequester().get("https://example.org/never")
+    assert response.status_code == OFFLINE_CACHE_MISS_STATUS
+
+
+def test_online_then_offline_share_default_cache(tmp_path, network_interceptor, monkeypatch):
+    """Reproduce the common user workflow: validate online without passing a
+    cache path, then validate offline without passing a cache path. Both runs
+    must share the same persistent XDG cache so the offline run finds every
+    resource fetched online.
+    """
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    url = "https://example.org/ctx"
+
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=False,
+        cache_max_age=60,
+    )
+    online_info = HttpRequester().cache_info()
+    assert online_info["permanent"] is True
+    assert str(tmp_path / "xdg") in str(online_info["path"])
+    HttpRequester().get(url)
+    assert HttpRequester().has_cached(url) is True
+
+    HttpRequester.reset()
+
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+    )
+    offline_info = HttpRequester().cache_info()
+    assert offline_info["path"] == online_info["path"]
+    assert HttpRequester().has_cached(url) is True
+    response = HttpRequester().get(url)
+    assert response.status_code == 200
+
+
+def test_offline_reuses_cached_response(tmp_path, network_interceptor):
+    cache_path = tmp_path / "cache"
+    # First: online run populates the cache.
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=False,
+        cache_path=cache_path,
+        cache_max_age=60,
+    )
+    url = "https://example.org/context"
+    response = HttpRequester().get(url)
+    assert response.status_code == 200
+    assert HttpRequester().has_cached(url) is True
+    pre_calls = len(network_interceptor["calls"])
+
+    # Second: offline run must not hit the network but still get the cached doc.
+    HttpRequester.reset()
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+        cache_path=cache_path,
+    )
+    response = HttpRequester().get(url)
+    assert response.status_code == 200
+    assert response.content == b'{"@context": {}}'
+    # No new network traffic in offline mode.
+    assert len(network_interceptor["calls"]) == pre_calls
+
+
+def test_no_cache_disables_cache_backend(tmp_path, network_interceptor):
+    """no_cache=True must skip the cache and hit the network every call."""
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=False,
+        no_cache=True,
+    )
+    requester = HttpRequester()
+    info = requester.cache_info()
+    assert info["backend"] is None
+    assert requester.has_cached("https://example.org/any") is False
+    # Two identical requests must both hit the network.
+    requester.get("https://example.org/any")
+    requester.get("https://example.org/any")
+    assert network_interceptor["calls"].count("https://example.org/any") == 2
+
+
+def test_negative_cache_max_age_means_never_expire(tmp_path, network_interceptor):
+    """cache_max_age<0 must enable the cache with no expiration."""
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=False,
+        cache_max_age=-1,
+        cache_path=tmp_path / "cache",
+    )
+    requester = HttpRequester()
+    info = requester.cache_info()
+    assert info["backend"] is not None
+    url = "https://example.org/any"
+    requester.get(url)
+    # Second call must be served from the cache.
+    requester.get(url)
+    assert network_interceptor["calls"].count(url) == 1
+
+
+def test_offline_with_disabled_cache_raises():
+    with pytest.raises(ValueError, match="Offline mode requires the HTTP cache"):
+        ValidationSettings(
+            rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+            offline=True,
+            no_cache=True,
+        )
+
+
+def test_cli_no_cache_and_offline_rejected(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "validate",
+            str(ValidROC().wrroc_paper_long_date),
+            "--no-paging",
+            "--no-cache",
+            "--offline",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_cli_no_cache_disables_cache_backend(cli_runner, tmp_path, network_interceptor):
+    """The --no-cache flag must skip the cache and hit the network on every call."""
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "validate",
+            str(ValidROC().wrroc_paper_long_date),
+            "--no-paging",
+            "--no-cache",
+            "--skip-checks", SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
+        ],
+    )
+    # The validation itself may pass or fail depending on upstream checks; we
+    # only require that no cache file was written (ephemeral session).
+    assert "Traceback" not in result.output, result.output
+    info = HttpRequester().cache_info()
+    assert info["backend"] is None
+
+
+def test_cli_cache_info(cli_runner, tmp_path):
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "info", "--cache-path", str(tmp_path / "cache")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "HTTP Cache" in result.output or "Entries" in result.output
+
+
+def test_cli_cache_reset_noninteractive_requires_yes(cli_runner, tmp_path, network_interceptor):
+    cache_path = tmp_path / "cache"
+    # Populate the cache so the reset has something to do.
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=60)
+    HttpRequester().get("https://example.org/ctx")
+    assert HttpRequester().cache_info()["entries"] >= 1
+    HttpRequester.reset()
+
+    # Without --yes in non-interactive mode, reset must abort.
+    result = cli_runner.invoke(
+        cli,
+        ["-y", "cache", "reset", "--cache-path", str(cache_path)],
+    )
+    assert result.exit_code == 1, result.output
+    # Cache should still contain the entry.
+    HttpRequester.reset()
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=3600)
+    assert HttpRequester().cache_info()["entries"] >= 1
+
+
+def test_cli_cache_reset_yes_clears_entries(cli_runner, tmp_path, network_interceptor):
+    cache_path = tmp_path / "cache"
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=60)
+    HttpRequester().get("https://example.org/ctx")
+    HttpRequester().get("https://example.org/other")
+    assert HttpRequester().cache_info()["entries"] >= 2
+    HttpRequester.reset()
+
+    result = cli_runner.invoke(
+        cli,
+        ["-y", "cache", "reset", "--cache-path", str(cache_path), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+
+    HttpRequester.reset()
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=-1)
+    assert HttpRequester().cache_info()["entries"] == 0
+
+
+def test_cli_cache_warm_populates_profile_urls(cli_runner, tmp_path, network_interceptor):
+    cache_path = tmp_path / "cache"
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "cache", "warm",
+            "--cache-path", str(cache_path),
+            "--profile-identifier", "ro-crate-1.1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert any("w3id.org" in c for c in network_interceptor["calls"]), \
+        f"No expected URL fetched. Calls: {network_interceptor['calls']}"
+    # The URL must now be cached for offline use.
+    HttpRequester.reset()
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=3600, offline=True)
+    assert HttpRequester().has_cached("https://w3id.org/ro/crate/1.1/context") is True
+
+
+def test_cli_cache_warm_crate_caches_remote_archive(cli_runner, tmp_path, network_interceptor):
+    cache_path = tmp_path / "cache"
+    crate_url = "https://example.org/my-crate.zip"
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "cache", "warm",
+            "--cache-path", str(cache_path),
+            "--crate", crate_url,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    HttpRequester.reset()
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=3600, offline=True)
+    assert HttpRequester().has_cached(crate_url) is True
+
+
+def test_cli_validate_offline_warns_when_remote(cli_runner, tmp_path, network_interceptor):
+    """In offline mode with a remote URI the validator must emit a warning."""
+    # Pre-populate the cache so the remote crate resolves in offline mode.
+    cache_path = tmp_path / "cache"
+    HttpRequester.initialize_cache(cache_path=str(cache_path), cache_max_age=60)
+    HttpRequester().get("https://example.org/fake-crate.zip")
+    HttpRequester.reset()
+
+    # We intentionally do not actually run the full validation here; the CLI
+    # will fail because the cached body is not a valid ZIP, but the warning is
+    # emitted before that point.
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "validate",
+            "https://example.org/fake-crate.zip",
+            "--no-paging",
+            "--offline",
+            "--cache-path", str(cache_path),
+        ],
+    )
+    assert "offline mode is enabled" in result.output.lower() \
+        or "cached version" in result.output.lower(), result.output
+
+
+def test_cli_validate_offline_on_local_crate_succeeds(cli_runner, tmp_path):
+    """Validating a local crate in offline mode must work without network access."""
+    cache_path = tmp_path / "cache"
+    result = cli_runner.invoke(
+        cli,
+        [
+            "-y",
+            "validate",
+            str(ValidROC().wrroc_paper_long_date),
+            "--no-paging",
+            "--offline",
+            "--cache-path", str(cache_path),
+            "--skip-checks", SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER,
+        ],
+    )
+    # The validation may report issues for locally missing contexts; what we
+    # require is that no uncaught network-related exception aborts the run.
+    assert result.exit_code in (0, 1), result.output
+    assert "Traceback" not in result.output
+
+
+def test_auto_warm_up_skipped_when_offline(tmp_path, network_interceptor, monkeypatch):
+    """Auto warm-up must not run when offline mode is active."""
+    monkeypatch.setenv("ROCRATE_VALIDATOR_AUTO_WARM", "1")
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=True,
+        cache_path=tmp_path / "cache",
+    )
+    assert network_interceptor["calls"] == []
+
+
+def test_auto_warm_up_disabled_via_env(tmp_path, network_interceptor, monkeypatch):
+    monkeypatch.setenv("ROCRATE_VALIDATOR_AUTO_WARM", "0")
+    ValidationSettings(
+        rocrate_uri=str(ValidROC().wrroc_paper_long_date),
+        offline=False,
+        cache_path=tmp_path / "cache",
+    )
+    assert network_interceptor["calls"] == []

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -243,6 +243,68 @@ def test_warm_url_combined_with_profile_warms_both(
 
 
 # ====================================================================
+# cache warm: --crate (remote RO-Crate)
+# ====================================================================
+@pytest.fixture
+def mock_network_gzip(monkeypatch):
+    """
+    Same as ``mock_network``, but returns a ``Content-Encoding: gzip`` body.
+    This encoded response is required to reproduce the warm-crate bug.
+    """
+    import gzip
+
+    from requests.adapters import HTTPAdapter
+
+    body = gzip.compress(b'{"@context": "https://w3id.org/ro/crate/1.2/context"}')
+
+    def fake_send(self, request, **kwargs):
+        raw = urllib3.HTTPResponse(
+            body=io.BytesIO(body),
+            headers={
+                "Content-Type": "application/json",
+                "Content-Encoding": "gzip",
+                "Content-Length": str(len(body)),
+            },
+            status=200,
+            preload_content=False,
+            decode_content=False,
+        )
+        return self.build_response(request, raw)
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+
+def test_warm_crate_caches_remote_metadata(cli_runner, mock_network_gzip, tmp_cache):
+    """
+    Regression: ``cache warm --crate <url>`` must consume the body via
+    ``response.content`` rather than streaming ``response.raw``.
+
+    With ``stream=True`` + ``shutil.copyfileobj(response.raw, ...)`` the warm-up
+    crashed with urllib3's "Calling read(decode_content=False) is not supported
+    after read(decode_content=True) was called": requests_cache buffers the
+    streamed body (decode_content=True) to store it, after which a raw read
+    (decode_content=False) is rejected. The body must therefore be touched in a
+    way that goes through the already-decoded content.
+    """
+    url = "https://example.org/ro-crate/ro-crate-metadata.json"
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "--crate", url],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Fetching remote RO-Crates" in result.output
+    assert "Summary: 1 cached, 0 failed, 0 skipped" in result.output
+
+    # The fetched crate must actually be retrievable from the cache afterwards.
+    listed = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache)],
+    )
+    assert listed.exit_code == 0, listed.output
+    assert "ro-crate-metadata.json" in listed.output
+
+
+# ====================================================================
 # cache list / ls
 # ====================================================================
 def _warm_some(cli_runner, tmp_cache, urls):

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CLI tests for the ``rocrate-validator cache`` subcommands:
+
+* ``cache warm`` profile-token fallback (mirrors ``validate``).
+* ``cache warm -u/--url`` arbitrary URL warming.
+* ``cache list`` / ``cache ls`` entry listing with filter/sort/--json.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+import urllib3
+from click.testing import CliRunner
+
+from rocrate_validator.cli.main import cli
+from rocrate_validator.models import Profile
+from rocrate_validator.utils.http import HttpRequester
+
+
+# ---------- shared fixtures ----------
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_requester():
+    HttpRequester.reset()
+    yield
+    HttpRequester.reset()
+
+
+@pytest.fixture
+def mock_network(monkeypatch):
+    """Route every outbound HTTP call to a fake successful response."""
+    from requests.adapters import HTTPAdapter
+
+    def fake_send(self, request, **kwargs):
+        raw = urllib3.HTTPResponse(
+            body=io.BytesIO(b'{"ok": true}'),
+            headers={"Content-Type": "application/json", "Content-Length": "12"},
+            status=200,
+            preload_content=False,
+            decode_content=False,
+        )
+        return self.build_response(request, raw)
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+
+@pytest.fixture
+def tmp_cache(tmp_path):
+    """Path passed via ``--cache-path`` to keep tests off the user cache."""
+    return tmp_path / "cache"
+
+
+def _make_profile_stub(identifier: str, version: str, token: str):
+    """Lightweight stand-in for a Profile used only by token fallback tests."""
+
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    stub.identifier = identifier
+    stub.version = version
+    stub.token = token
+    return stub
+
+
+# ====================================================================
+# cache warm: profile-token fallback
+# ====================================================================
+def test_warm_token_resolves_to_single_versioned_profile(
+    cli_runner,
+    mock_network,
+    tmp_cache,
+    monkeypatch,
+):
+    """`-p process-run-crate` should resolve to the only versioned variant."""
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "-p", "process-run-crate"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "process-run-crate-0.5" in result.output
+    # Single-version token must resolve silently — no "Note:" line.
+    assert "Note:" not in result.output
+    assert "not found and skipped" not in result.output
+
+
+def test_warm_token_with_multiple_versions_emits_note(
+    cli_runner,
+    mock_network,
+    tmp_cache,
+    monkeypatch,
+):
+    """When a token matches more than one version, the picked identifier and
+    the alternatives must appear in a one-line Note."""
+    candidates = [
+        _make_profile_stub("fakeprof-0.1", "0.1", "fakeprof"),
+        _make_profile_stub("fakeprof-0.2", "0.2", "fakeprof"),
+    ]
+
+    real_by_id = Profile.get_by_identifier
+    real_by_token = Profile.get_by_token
+
+    def fake_by_id(ident):
+        if ident == "fakeprof":
+            return None
+        return real_by_id(ident)
+
+    def fake_by_token(tok):
+        if tok == "fakeprof":
+            return candidates
+        return real_by_token(tok)
+
+    monkeypatch.setattr(Profile, "get_by_identifier", staticmethod(fake_by_id))
+    monkeypatch.setattr(Profile, "get_by_token", staticmethod(fake_by_token))
+    # Skip URL discovery entirely — the test cares about the resolver, not
+    # what's warmed.
+    monkeypatch.setattr(
+        "rocrate_validator.cli.commands.cache.discover_cacheable_urls_from_profiles",
+        lambda profiles: [],
+    )
+
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "-p", "fakeprof"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Note:" in result.output
+    assert "fakeprof-0.2" in result.output  # picked (highest version)
+    assert "fakeprof-0.1" in result.output  # listed as alternative
+
+
+def test_warm_unknown_profile_still_reported_as_missing(
+    cli_runner,
+    mock_network,
+    tmp_cache,
+):
+    """A profile id that matches neither identifier nor token must end up
+    in the existing 'Profile(s) not found and skipped' message."""
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "-p", "definitely-not-a-profile"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "not found and skipped" in result.output
+    assert "definitely-not-a-profile" in result.output
+
+
+# ====================================================================
+# cache warm: -u / --url
+# ====================================================================
+def test_warm_url_alone_does_not_fall_back_to_all_profiles(
+    cli_runner,
+    mock_network,
+    tmp_cache,
+    monkeypatch,
+):
+    """``cache warm -u <url>`` with no -p must warm only the URL — not every
+    installed profile (which is the default when no explicit source is
+    given)."""
+    seen = {"profile_calls": 0}
+
+    def fake_discover(profiles):
+        seen["profile_calls"] += 1
+        return []
+
+    monkeypatch.setattr(
+        "rocrate_validator.cli.commands.cache.discover_cacheable_urls_from_profiles",
+        fake_discover,
+    )
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "-u", "https://example.org/a"],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["profile_calls"] == 0
+    assert "Fetching explicit URLs" in result.output
+    assert "https://example.org/a" in result.output
+
+
+def test_warm_url_invalid_value_is_rejected(cli_runner, tmp_cache):
+    """Non-http(s) values must trip Click's parameter validation and exit 2."""
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "warm", "--cache-path", str(tmp_cache), "-u", "notaurl"],
+    )
+    assert result.exit_code == 2
+    assert "http(s)" in result.output
+    assert "notaurl" in result.output
+
+
+def test_warm_url_combined_with_profile_warms_both(
+    cli_runner,
+    mock_network,
+    tmp_cache,
+    monkeypatch,
+):
+    """``-p <profile> -u <url>`` must warm the profile URLs *and* the extra
+    URL in the same invocation."""
+    # Make the profile contribute a single deterministic URL.
+    monkeypatch.setattr(
+        "rocrate_validator.cli.commands.cache.discover_cacheable_urls_from_profiles",
+        lambda profiles: ["https://example.org/from-profile"],
+    )
+    result = cli_runner.invoke(
+        cli,
+        [
+            "cache",
+            "warm",
+            "--cache-path",
+            str(tmp_cache),
+            "-p",
+            "ro-crate-1.1",
+            "-u",
+            "https://example.org/explicit",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Warming cache for profiles" in result.output
+    assert "Fetching explicit URLs" in result.output
+    assert "https://example.org/from-profile" in result.output
+    assert "https://example.org/explicit" in result.output
+
+
+# ====================================================================
+# cache list / ls
+# ====================================================================
+def _warm_some(cli_runner, tmp_cache, urls):
+    args = ["cache", "warm", "--cache-path", str(tmp_cache)]
+    for u in urls:
+        args += ["-u", u]
+    return cli_runner.invoke(cli, args)
+
+
+def test_list_reports_empty_cache(cli_runner, tmp_cache):
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Cache is empty" in result.output
+
+
+def test_list_shows_warmed_entries(cli_runner, mock_network, tmp_cache):
+    urls = [
+        "https://example.org/alpha",
+        "https://example.org/beta",
+        "https://example.org/gamma",
+    ]
+    warm = _warm_some(cli_runner, tmp_cache, urls)
+    assert warm.exit_code == 0, warm.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache)],
+    )
+    assert result.exit_code == 0, result.output
+    for u in urls:
+        # URLs are wrapped/folded in the Rich table, so check a stable token.
+        assert u.rsplit("/", 1)[1] in result.output
+    assert "Total:" in result.output
+
+
+def test_list_url_filter_narrows_results(cli_runner, mock_network, tmp_cache):
+    urls = [
+        "https://example.org/keep-me",
+        "https://example.org/other",
+    ]
+    _warm_some(cli_runner, tmp_cache, urls)
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--url", "keep-me"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "keep-me" in result.output
+    # The filter is case-insensitive substring on URL; "other" must be absent.
+    assert "/other" not in result.output
+
+
+def test_list_filter_with_no_match_message(cli_runner, mock_network, tmp_cache):
+    _warm_some(cli_runner, tmp_cache, ["https://example.org/only"])
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--url", "no-such-fragment"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "No entries match" in result.output
+
+
+def test_list_json_output_is_well_formed(cli_runner, mock_network, tmp_cache):
+    urls = [
+        "https://example.org/a",
+        "https://example.org/b",
+    ]
+    _warm_some(cli_runner, tmp_cache, urls)
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert {e["url"] for e in payload} == set(urls)
+    sample = payload[0]
+    # Every entry must carry the documented fields.
+    assert {"url", "status", "size_bytes", "content_type", "created_at", "expires", "is_expired"} <= set(sample)
+    assert isinstance(sample["size_bytes"], int)
+
+
+def test_list_sort_by_url_asc_then_desc(cli_runner, mock_network, tmp_cache):
+    """`--sort url` defaults to asc; `--order desc` must reverse it."""
+    _warm_some(
+        cli_runner,
+        tmp_cache,
+        [
+            "https://example.org/c",
+            "https://example.org/a",
+            "https://example.org/b",
+        ],
+    )
+
+    asc = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--sort", "url", "--json"],
+    )
+    assert asc.exit_code == 0, asc.output
+    asc_urls = [e["url"] for e in json.loads(asc.output)]
+    assert asc_urls == sorted(asc_urls)
+
+    desc = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--sort", "url", "--order", "desc", "--json"],
+    )
+    assert desc.exit_code == 0, desc.output
+    desc_urls = [e["url"] for e in json.loads(desc.output)]
+    assert desc_urls == sorted(desc_urls, reverse=True)
+
+
+def test_list_default_sort_is_created_desc(cli_runner, mock_network, tmp_cache):
+    """No --sort flag: entries come back ordered by created_at, most recent
+    first (the documented default)."""
+    _warm_some(
+        cli_runner,
+        tmp_cache,
+        [
+            "https://example.org/first",
+            "https://example.org/second",
+            "https://example.org/third",
+        ],
+    )
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    created = [e["created_at"] for e in json.loads(result.output)]
+    # Each entry has a timestamp (mocked response goes through requests_cache);
+    # the sequence must be monotonically non-increasing.
+    assert all(a >= b for a, b in zip(created, created[1:]))
+
+
+def test_list_invalid_order_is_rejected(cli_runner, tmp_cache):
+    result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--order", "sideways"],
+    )
+    assert result.exit_code == 2
+    assert "'sideways'" in result.output
+
+
+def test_ls_alias_runs_the_same_command(cli_runner, mock_network, tmp_cache):
+    _warm_some(cli_runner, tmp_cache, ["https://example.org/x"])
+    list_result = cli_runner.invoke(
+        cli,
+        ["cache", "list", "--cache-path", str(tmp_cache), "--json"],
+    )
+    ls_result = cli_runner.invoke(
+        cli,
+        ["cache", "ls", "--cache-path", str(tmp_cache), "--json"],
+    )
+    assert list_result.exit_code == ls_result.exit_code == 0
+    assert json.loads(list_result.output) == json.loads(ls_result.output)

--- a/tests/unit/test_cache_warmup.py
+++ b/tests/unit/test_cache_warmup.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for profile URL discovery and cache warm-up."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+import urllib3
+
+from rocrate_validator.models import Profile
+from rocrate_validator.utils.cache_warmup import (
+    auto_warm_up_for_settings, discover_cacheable_urls_from_profiles,
+    discover_profile_cacheable_urls, warm_up_urls)
+from rocrate_validator.utils.http import HttpRequester
+from rocrate_validator.utils.paths import get_profiles_path
+
+
+PROFILE_TTL_TEMPLATE = """
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix role: <http://www.w3.org/ns/dx/prof/role/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://example.org/profiles/sample>
+    a prof:Profile ;
+    rdfs:label "Sample profile" ;
+    prof:hasResource [
+        a prof:ResourceDescriptor ;
+        prof:hasRole role:Vocabulary ;
+        prof:hasArtifact <https://example.org/ctx/v1> ;
+    ] ;
+    prof:hasResource [
+        a prof:ResourceDescriptor ;
+        prof:hasRole role:Specification ;
+        prof:hasArtifact <https://example.org/spec/v1/index.html> ;
+    ] ;
+    prof:hasResource [
+        a prof:ResourceDescriptor ;
+        prof:hasArtifact "not-a-url" ;
+    ] ;
+    prof:hasToken "sample" ;
+.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_requester():
+    HttpRequester.reset()
+    yield
+    HttpRequester.reset()
+
+
+@pytest.fixture
+def sample_profile(tmp_path):
+    profile_dir = tmp_path / "sample"
+    profile_dir.mkdir()
+    (profile_dir / "profile.ttl").write_text(PROFILE_TTL_TEMPLATE)
+    return Profile(
+        profiles_base_path=tmp_path,
+        profile_path=profile_dir,
+    )
+
+
+@pytest.fixture
+def mock_network(monkeypatch):
+    from requests.adapters import HTTPAdapter
+
+    def fake_send(self, request, **kwargs):
+        raw = urllib3.HTTPResponse(
+            body=io.BytesIO(b'{"ok": true}'),
+            headers={"Content-Type": "application/json", "Content-Length": "12"},
+            status=200,
+            preload_content=False,
+            decode_content=False,
+        )
+        return self.build_response(request, raw)
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+
+def test_discover_urls_returns_all_declared_artifacts(sample_profile):
+    urls = discover_profile_cacheable_urls(sample_profile)
+    # Both declared roles are included; the non-URL artifact is dropped.
+    assert "https://example.org/ctx/v1" in urls
+    assert "https://example.org/spec/v1/index.html" in urls
+    assert all(u.lower().startswith("http") for u in urls)
+    assert len(urls) == 2
+
+
+def test_discover_urls_on_multiple_profiles_deduplicates(sample_profile, tmp_path):
+    other_dir = tmp_path / "sample_other"
+    other_dir.mkdir()
+    (other_dir / "profile.ttl").write_text(
+        PROFILE_TTL_TEMPLATE
+        .replace("<https://example.org/profiles/sample>",
+                 "<https://example.org/profiles/other>")
+        .replace('prof:hasToken "sample"', 'prof:hasToken "other"')
+    )
+    other_profile = Profile(profiles_base_path=tmp_path, profile_path=other_dir)
+    aggregated = discover_cacheable_urls_from_profiles([sample_profile, other_profile])
+    # Both profiles share the same two artifacts; the result should be deduped.
+    assert len(aggregated) == 2
+
+
+def test_warm_up_urls_skips_already_cached(tmp_path, mock_network):
+    HttpRequester.initialize_cache(
+        cache_path=str(tmp_path / "cache"),
+        cache_max_age=60,
+    )
+    urls = ["https://example.org/a", "https://example.org/b"]
+    first = warm_up_urls(urls)
+    assert [r.status for r in first] == ["ok", "ok"]
+    second = warm_up_urls(urls)
+    assert [r.status for r in second] == ["skipped", "skipped"]
+
+
+def test_warm_up_reports_offline_cache_miss(tmp_path):
+    HttpRequester.initialize_cache(
+        cache_path=str(tmp_path / "cache"),
+        cache_max_age=-1,
+        offline=True,
+    )
+    results = warm_up_urls(["https://example.org/missing"])
+    assert results[0].status == "failed"
+    assert "offline" in (results[0].detail or "").lower()
+
+
+def test_auto_warm_up_noop_when_offline(tmp_path):
+    class _Settings:
+        offline = True
+        cache_path = tmp_path / "cache"
+        profile_identifier = "ro-crate-1.1"
+        profiles_path = get_profiles_path()
+        extra_profiles_path = None
+
+    assert auto_warm_up_for_settings(_Settings()) is None
+
+
+def test_auto_warm_up_disabled_via_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("ROCRATE_VALIDATOR_AUTO_WARM", "0")
+
+    class _Settings:
+        offline = False
+        cache_path = tmp_path / "cache"
+        profile_identifier = "ro-crate-1.1"
+        profiles_path = get_profiles_path()
+        extra_profiles_path = None
+
+    assert auto_warm_up_for_settings(_Settings()) is None
+
+
+def test_auto_warm_up_noop_when_no_cache_path():
+    class _Settings:
+        offline = False
+        cache_path = None
+        profile_identifier = "ro-crate-1.1"
+        profiles_path = get_profiles_path()
+        extra_profiles_path = None
+
+    assert auto_warm_up_for_settings(_Settings()) is None

--- a/tests/unit/test_cache_warmup.py
+++ b/tests/unit/test_cache_warmup.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import io
-from pathlib import Path
 
 import pytest
 import urllib3
@@ -28,7 +27,6 @@ from rocrate_validator.utils.cache_warmup import (
     discover_profile_cacheable_urls, warm_up_urls)
 from rocrate_validator.utils.http import HttpRequester
 from rocrate_validator.utils.paths import get_profiles_path
-
 
 PROFILE_TTL_TEMPLATE = """
 @prefix dct: <http://purl.org/dc/terms/> .

--- a/tests/unit/test_document_loader.py
+++ b/tests/unit/test_document_loader.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the JSON-LD document loader."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+import urllib3
+
+from rocrate_validator.utils import document_loader
+from rocrate_validator.utils.document_loader import (install_document_loader,
+                                                     resolve_remote_document,
+                                                     uninstall_document_loader)
+from rocrate_validator.utils.http import HttpRequester, OfflineCacheMissError
+
+
+def _urllib3_response(payload: bytes = b'{"@context": {"name": "https://schema.org/name"}}',
+                      status: int = 200) -> urllib3.HTTPResponse:
+    return urllib3.HTTPResponse(
+        body=io.BytesIO(payload),
+        headers={
+            "Content-Type": "application/ld+json",
+            "Content-Length": str(len(payload)),
+        },
+        status=status,
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+@pytest.fixture
+def mock_network(monkeypatch):
+    from requests.adapters import HTTPAdapter
+
+    def fake_send(self, request, **kwargs):
+        raw = _urllib3_response()
+        return self.build_response(request, raw)
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    uninstall_document_loader()
+    HttpRequester.reset()
+    yield
+    uninstall_document_loader()
+    HttpRequester.reset()
+
+
+def test_install_is_idempotent(tmp_path):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=-1)
+    assert install_document_loader() is True
+    assert install_document_loader() is True
+    assert document_loader._installed is True
+
+
+def test_install_returns_false_on_error(tmp_path, monkeypatch):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=-1)
+    from rdflib.plugins.shared.jsonld import util as jsonld_util
+
+    class _FrozenModule:
+        def __setattr__(self, _name, _value):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(document_loader, "jsonld_util", _FrozenModule())
+    assert install_document_loader() is False
+    assert document_loader._installed is False
+    # Original module must remain untouched on failure.
+    assert jsonld_util.source_to_json is document_loader._original_source_to_json
+
+
+def test_uninstall_returns_true_when_not_installed():
+    assert uninstall_document_loader() is True
+
+
+def test_uninstall_returns_false_on_error(tmp_path, monkeypatch):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=-1)
+    assert install_document_loader() is True
+
+    class _FrozenModule:
+        def __setattr__(self, _name, _value):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(document_loader, "jsonld_util", _FrozenModule())
+    assert uninstall_document_loader() is False
+    assert document_loader._installed is True
+
+
+def test_resolve_remote_document_uses_http_requester(tmp_path, mock_network):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=60)
+    payload, content_type = resolve_remote_document("https://example.org/context")
+    assert payload == {"@context": {"name": "https://schema.org/name"}}
+    assert content_type == "application/ld+json"
+    assert HttpRequester().has_cached("https://example.org/context") is True
+
+
+def test_resolve_raises_offline_cache_miss(tmp_path):
+    HttpRequester.initialize_cache(
+        cache_path=str(tmp_path / "cache"),
+        cache_max_age=-1,
+        offline=True,
+    )
+    with pytest.raises(OfflineCacheMissError):
+        resolve_remote_document("https://example.org/never-cached")
+
+
+def test_patched_source_to_json_routes_http_urls(tmp_path, mock_network):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=60)
+    install_document_loader()
+    from rdflib.plugins.shared.jsonld import util as jsonld_util
+    doc, _ = jsonld_util.source_to_json("https://example.org/context")
+    assert doc == {"@context": {"name": "https://schema.org/name"}}
+
+
+def test_patched_source_to_json_ignores_non_http(tmp_path):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=60)
+    install_document_loader()
+    from rdflib.plugins.shared.jsonld import util as jsonld_util
+    file_path = tmp_path / "context.jsonld"
+    file_path.write_text('{"@context": {"foo": "https://example.org/foo"}}')
+    doc, _ = jsonld_util.source_to_json(str(file_path))
+    assert doc == {"@context": {"foo": "https://example.org/foo"}}
+
+
+def test_resolve_maps_http_error_to_runtime(tmp_path, monkeypatch):
+    HttpRequester.initialize_cache(cache_path=str(tmp_path / "cache"), cache_max_age=60)
+
+    class _StubResponse:
+        status_code = 500
+        text = ""
+
+        def json(self):
+            raise ValueError
+
+    monkeypatch.setattr(
+        HttpRequester(),
+        "get",
+        lambda *_, **__: _StubResponse(),
+    )
+    with pytest.raises(RuntimeError):
+        resolve_remote_document("https://example.org/broken")

--- a/tests/unit/test_http_requester_offline.py
+++ b/tests/unit/test_http_requester_offline.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HttpRequester offline-mode extensions."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+import urllib3
+
+from rocrate_validator.utils import http as http_module
+from rocrate_validator.utils.http import (OFFLINE_CACHE_MISS_STATUS,
+                                          HttpRequester)
+
+
+def _build_urllib3_response(body: bytes = b'{"ok": true}',
+                            status: int = 200,
+                            content_type: str = "application/json") -> urllib3.HTTPResponse:
+    return urllib3.HTTPResponse(
+        body=io.BytesIO(body),
+        headers={"Content-Type": content_type, "Content-Length": str(len(body))},
+        status=status,
+        preload_content=False,
+        decode_content=False,
+    )
+
+
+@pytest.fixture
+def mock_network(monkeypatch):
+    """Route every outbound HTTP call to a fake urllib3 response."""
+    from requests.adapters import HTTPAdapter
+
+    def fake_send(self, request, **kwargs):
+        raw = _build_urllib3_response()
+        response = self.build_response(request, raw)
+        return response
+
+    monkeypatch.setattr(HTTPAdapter, "send", fake_send)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    HttpRequester.reset()
+    yield
+    HttpRequester.reset()
+
+
+def _initialize(cache_path, offline=False, cache_max_age=-1):
+    HttpRequester.reset()
+    return HttpRequester.initialize_cache(
+        cache_path=str(cache_path),
+        cache_max_age=cache_max_age,
+        offline=offline,
+    )
+
+
+def test_initialize_offline_sets_only_if_cached(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=True)
+    assert requester.offline is True
+    assert getattr(requester.session.settings, "only_if_cached", False) is True
+
+
+def test_offline_cache_miss_returns_504(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=True)
+    response = requester.get("https://example.org/missing")
+    assert response.status_code == OFFLINE_CACHE_MISS_STATUS
+
+
+def test_online_unknown_url_is_not_cached(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    assert requester.has_cached("https://example.org/anything") is False
+
+
+def test_has_cached_returns_true_after_successful_fetch(tmp_path, mock_network):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    url = "https://example.org/ctx"
+    assert requester.has_cached(url) is False
+    response = requester.get(url)
+    assert response.status_code == 200
+    assert requester.has_cached(url) is True
+
+
+def test_offline_serves_cached_response_populated_online(tmp_path, mock_network):
+    cache_path = tmp_path / "cache"
+    requester = _initialize(cache_path, offline=False, cache_max_age=60)
+    url = "https://example.org/ctx"
+    requester.get(url)
+    HttpRequester.reset()
+    # Re-open the cache in offline mode and confirm the hit.
+    requester = _initialize(cache_path, offline=True)
+    response = requester.get(url)
+    assert response.status_code == 200
+    assert response.content == b'{"ok": true}'
+
+
+def test_fetch_fresh_bypasses_cache_when_online(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    session_mock = MagicMock()
+    fresh_response = MagicMock()
+    fresh_response.status_code = 200
+    fresh_response.from_cache = False
+    session_mock.get.return_value = fresh_response
+    requester.session = session_mock
+    result = requester.fetch_fresh("https://example.org/fresh", allow_redirects=True)
+    assert result is fresh_response
+    session_mock.get.assert_called_once()
+    kwargs = session_mock.get.call_args.kwargs
+    assert kwargs.get("force_refresh") is True
+    assert kwargs.get("allow_redirects") is True
+
+
+def test_fetch_fresh_falls_back_when_force_refresh_unsupported(tmp_path):
+    """Older requests_cache versions lack force_refresh; fall back to refresh."""
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+
+    class _LegacySession:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def get(self, url, **kwargs):
+            self.calls.append(kwargs)
+            if "force_refresh" in kwargs:
+                raise TypeError("unexpected keyword argument 'force_refresh'")
+            fake = MagicMock()
+            fake.status_code = 200
+            fake.from_cache = False
+            return fake
+
+    legacy = _LegacySession()
+    requester.session = legacy
+    response = requester.fetch_fresh("https://example.org/fresh")
+    assert response.status_code == 200
+    assert len(legacy.calls) == 2
+    assert "refresh" in legacy.calls[1]
+
+
+def test_fetch_fresh_in_offline_does_not_refresh(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=True)
+    session_mock = MagicMock()
+    cached_response = MagicMock()
+    cached_response.status_code = 200
+    cached_response.from_cache = True
+    session_mock.get.return_value = cached_response
+    requester.session = session_mock
+    result = requester.fetch_fresh("https://example.org/x")
+    assert result is cached_response
+    assert "force_refresh" not in session_mock.get.call_args.kwargs
+    assert "refresh" not in session_mock.get.call_args.kwargs
+
+
+def test_clear_cache_empties_backend(tmp_path, mock_network):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    requester.get("https://example.org/a")
+    requester.get("https://example.org/b")
+    assert requester.cache_info()["entries"] >= 2
+    requester.clear_cache()
+    assert requester.cache_info()["entries"] == 0
+
+
+def test_cache_info_reports_metadata(tmp_path):
+    cache_path = tmp_path / "cache"
+    requester = _initialize(cache_path, offline=False, cache_max_age=60)
+    info = requester.cache_info()
+    assert info["backend"] == "SQLiteCache"
+    assert info["path"].endswith(".sqlite")
+    assert info["permanent"] is True
+    assert info["offline"] is False
+    assert info["entries"] == 0
+
+
+class _RecordCollector:
+    """Context manager that attaches a capturing handler to the http logger."""
+
+    def __init__(self):
+        self.records: list = []
+
+    def __enter__(self):
+        import logging as _logging
+
+        from rocrate_validator.utils import http as http_module
+        self.records.clear()
+        self.handler = _logging.Handler()
+        self.handler.setLevel(_logging.WARNING)
+        self.handler.emit = lambda record: self.records.append(record)  # type: ignore[assignment]
+        # Force initialization of the underlying logger via the proxy.
+        http_module.logger.warning  # noqa: B018
+        self._target = http_module.logger._instance
+        self._target.addHandler(self.handler)
+        self._previous_level = self._target.level
+        self._target.setLevel(_logging.WARNING)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._target.removeHandler(self.handler)
+        self._target.setLevel(self._previous_level)
+        return False
+
+    def messages(self) -> list[str]:
+        return [r.getMessage() for r in self.records]
+
+
+def test_offline_prefix_logs_remote_then_cache(tmp_path, mock_network):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    with _RecordCollector() as collector:
+        requester.get("https://example.org/ctx")
+        requester.get("https://example.org/ctx")
+    messages = [m for m in collector.messages() if "CachedHttpRequester:" in m]
+    assert any("fetched from remote" in m for m in messages)
+    assert any("served from HTTP cache" in m for m in messages)
+
+
+def test_offline_prefix_logs_cache_miss_in_offline_mode(tmp_path):
+    requester = _initialize(tmp_path / "cache", offline=True)
+    with _RecordCollector() as collector:
+        requester.get("https://example.org/unknown")
+    messages = [m for m in collector.messages() if "CachedHttpRequester:" in m]
+    assert any("not available in HTTP cache" in m for m in messages)
+
+
+def test_offline_prefix_logs_fetch_fresh_as_refresh(tmp_path, mock_network):
+    requester = _initialize(tmp_path / "cache", offline=False, cache_max_age=60)
+    # Populate the cache first.
+    requester.get("https://example.org/x")
+    with _RecordCollector() as collector:
+        requester.fetch_fresh("https://example.org/x")
+    messages = [m for m in collector.messages() if "CachedHttpRequester:" in m]
+    assert any("cache refresh" in m for m in messages)
+
+
+def test_offline_without_requests_cache_uses_fallback_session(tmp_path, monkeypatch):
+    """When requests_cache is unavailable, offline mode falls back to a 504 stub."""
+    original_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "requests_cache" or (fromlist and "CachedSession" in fromlist and name.endswith("requests_cache")):
+            raise ImportError("simulated missing dependency")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        requester = _initialize(tmp_path / "cache", offline=True)
+    assert isinstance(requester.session, http_module._OfflineFallbackSession)
+    response = requester.get("https://example.org/whatever")
+    assert response.status_code == OFFLINE_CACHE_MISS_STATUS

--- a/tests/unit/test_http_requester_offline.py
+++ b/tests/unit/test_http_requester_offline.py
@@ -194,14 +194,14 @@ class _RecordCollector:
         from rocrate_validator.utils import http as http_module
         self.records.clear()
         self.handler = _logging.Handler()
-        self.handler.setLevel(_logging.WARNING)
+        self.handler.setLevel(_logging.DEBUG)
         self.handler.emit = lambda record: self.records.append(record)  # type: ignore[assignment]
         # Force initialization of the underlying logger via the proxy.
         http_module.logger.warning  # noqa: B018
         self._target = http_module.logger._instance
         self._target.addHandler(self.handler)
         self._previous_level = self._target.level
-        self._target.setLevel(_logging.WARNING)
+        self._target.setLevel(_logging.DEBUG)
         return self
 
     def __exit__(self, exc_type, exc, tb):

--- a/tests/unit/test_offline_cache_miss_warning.py
+++ b/tests/unit/test_offline_cache_miss_warning.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rocrate_validator import models as models_module
+from rocrate_validator.models import ValidationContext
+from rocrate_validator.utils.http import OfflineCacheMissError, find_offline_cache_miss
+
+
+# ---------- find_offline_cache_miss ----------
+def test_find_offline_cache_miss_direct():
+    exc = OfflineCacheMissError("https://example.org/x")
+    assert find_offline_cache_miss(exc) is exc
+
+
+def test_find_offline_cache_miss_walks_cause_chain():
+    inner = OfflineCacheMissError("https://example.org/x")
+    try:
+        try:
+            raise inner
+        except OfflineCacheMissError as e:
+            raise RuntimeError("wrapped") from e
+    except Exception as outer:
+        found = find_offline_cache_miss(outer)
+    assert found is inner
+
+
+def test_find_offline_cache_miss_walks_context_chain():
+    # `raise` inside `except` without `from` populates __context__.
+    try:
+        try:
+            raise OfflineCacheMissError("https://example.org/y")
+        except OfflineCacheMissError:
+            raise RuntimeError("wrapped via context")
+    except Exception as outer:
+        found = find_offline_cache_miss(outer)
+    assert isinstance(found, OfflineCacheMissError)
+    assert found.url == "https://example.org/y"
+
+
+def test_find_offline_cache_miss_returns_none_for_unrelated():
+    assert find_offline_cache_miss(ValueError("nope")) is None
+
+
+def test_find_offline_cache_miss_handles_cyclic_chain():
+    # Two exceptions referencing each other must not loop forever.
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__context__ = b
+    b.__context__ = a
+    assert find_offline_cache_miss(a) is None
+
+
+# ---------- ValidationContext.maybe_warn_offline_cache_miss ----------
+@pytest.fixture
+def bare_context():
+    """A ValidationContext with only the state needed by the dedup helper."""
+    ctx = ValidationContext.__new__(ValidationContext)
+    ctx._offline_cache_misses_warned = set()
+    return ctx
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """
+    Replace the module-level logger in ``rocrate_validator.models`` with a
+    MagicMock. The project's custom logger sets ``propagate=False``, so
+    pytest's ``caplog`` does not see its records — observing the mock is
+    both simpler and more precise.
+    """
+    fake = MagicMock()
+    monkeypatch.setattr(models_module, "logger", fake)
+    return fake
+
+
+def test_maybe_warn_returns_false_for_unrelated_exception(bare_context, mock_logger):
+    assert bare_context.maybe_warn_offline_cache_miss(ValueError("nope")) is False
+    mock_logger.warning.assert_not_called()
+
+
+def test_maybe_warn_emits_once_per_url(bare_context, mock_logger):
+    url = "https://example.org/ctx"
+    for _ in range(3):
+        assert bare_context.maybe_warn_offline_cache_miss(OfflineCacheMissError(url)) is True
+    assert mock_logger.warning.call_count == 1
+    # The bare miss exception is logged via "%s" so it stringifies and the
+    # URL appears verbatim in the formatted message.
+    args, _ = mock_logger.warning.call_args
+    assert url in str(args[1])
+
+
+def test_maybe_warn_emits_once_per_distinct_url(bare_context, mock_logger):
+    url_a = "https://example.org/a"
+    url_b = "https://example.org/b"
+    bare_context.maybe_warn_offline_cache_miss(OfflineCacheMissError(url_a))
+    bare_context.maybe_warn_offline_cache_miss(OfflineCacheMissError(url_b))
+    bare_context.maybe_warn_offline_cache_miss(OfflineCacheMissError(url_a))
+    assert mock_logger.warning.call_count == 2
+    logged = " ".join(str(call.args[1]) for call in mock_logger.warning.call_args_list)
+    assert url_a in logged
+    assert url_b in logged
+
+
+def test_maybe_warn_dedups_when_miss_is_wrapped(bare_context, mock_logger):
+    url = "https://example.org/ctx"
+    try:
+        raise RuntimeError("wrapped") from OfflineCacheMissError(url)
+    except RuntimeError as wrapped_exc:
+        wrapped = wrapped_exc
+    # First call: direct miss; warning emitted.
+    assert bare_context.maybe_warn_offline_cache_miss(OfflineCacheMissError(url)) is True
+    # Second call: same URL but reached via a wrapper exception. Must still
+    # be recognized through the __cause__ chain and dedup'd against the first.
+    assert bare_context.maybe_warn_offline_cache_miss(wrapped) is True
+    assert mock_logger.warning.call_count == 1


### PR DESCRIPTION
## Summary
Introduce an **offline validation mode** that lets users validate RO-Crates without network access, relying on a persistent local HTTP cache for every resource the validator needs to resolve.

## What changes
- **Offline mode** — a new option on the validator (exposed as `--offline` on the CLI) serves every HTTP-backed resource from a local cache, failing clearly when a resource has never been fetched.
- **Persistent HTTP cache** — the validator now uses a stable, user-level cache location (XDG-aware) so online and offline runs share the same store.
- **Transparent caching of remote contexts** — remote JSON-LD `@context` fetches performed by rdflib go through the same cache, which previously bypassed it.
- **Cache pre-population (warm-up)** — the validator can discover the external resources declared by the active profiles and prefetch them, both automatically (when online) and on demand.
- **Cache management CLI** — a new `rocrate-validator cache` command group lets users inspect, reset and pre-populate the cache.

## User-facing changes
- `validate --offline` / `validate --no-cache` flags.
- new `rocrate-validator cache info|reset|warm` subcommand.

[fix #114 #115]