### PR TITLE
fix(validate): resolve profiles from --extra-profiles-path during validation

### DIFF
--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1638,7 +1638,10 @@ class ValidationStatistics(Subscriber):
         # extract the validation settings
         severity_validation = validation_settings.requirement_severity
         profiles: list[Profile] = Profile.load_profiles(
-            validation_settings.profiles_path, severity=severity_validation)
+            validation_settings.profiles_path,
+            extra_profiles_path=validation_settings.extra_profiles_path,
+            severity=severity_validation,
+            allow_requirement_check_override=validation_settings.allow_requirement_check_override)
         profile: Profile = Profile.find_in_list(profiles, validation_settings.profile_identifier)
         target_profile_identifier = profile.identifier
         # initialize the profiles list

--- a/tests/unit/test_cli_internals.py
+++ b/tests/unit/test_cli_internals.py
@@ -81,3 +81,22 @@ def test_compute_stats(fake_profiles_path):
                                _.requirement.profile.identifier == "a"}
 
     logger.error(stats)
+
+
+def test_compute_stats_resolves_profile_from_extra_profiles_path(fake_profiles_path):
+    # ValidationStatistics.__initialise__ used to call Profile.load_profiles
+    # without forwarding extra_profiles_path, so any profile that lived only
+    # under --extra-profiles-path raised ProfileNotFound.
+    settings = ValidationSettings.parse({
+        "profiles_path": DEFAULT_PROFILES_PATH,
+        "extra_profiles_path": fake_profiles_path,
+        "profile_identifier": "a",
+        "enable_profile_inheritance": True,
+        "allow_requirement_check_override": True,
+        "requirement_severity": "REQUIRED",
+    })
+
+    stats = ValidationStatistics.__initialise__(validation_settings=settings)
+
+    assert any(p.identifier == "a" for p in stats["profiles"]), \
+        "Profile 'a' from extra_profiles_path was not resolved by ValidationStatistics"


### PR DESCRIPTION
This PR fixes a bug where `rocrate-validator validate --extra-profiles-path <dir> -p <id>` failed with `Profile not found` whenever the selected profile lived only under the extra path, even though  `profiles list` displayed it correctly. After this change, `--extra-profiles-path` works end-to-end for `validate`.

fix #143 