### PR TITLE
fix(shacl): correct severity resolution for flat shapes

### DIFF
--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -2250,17 +2250,21 @@ class ValidationResult:
     @property
     def failed_requirements(self) -> Collection[Requirement]:
         """
-        Get the requirements that failed
+        Get the requirements that failed at or above the configured `requirement_severity`.
         """
-        return set(issue.check.requirement for issue in self._issues)
+        min_severity = self.context.requirement_severity
+        return set(issue.check.requirement for issue in self._issues
+                   if issue.severity >= min_severity)
 
     #  --- Checks ---
     @property
     def failed_checks(self) -> Collection[RequirementCheck]:
         """
-        Get the checks that failed
+        Get the checks that failed at or above the configured `requirement_severity`.
         """
-        return set(issue.check for issue in self._issues)
+        min_severity = self.context.requirement_severity
+        return set(issue.check for issue in self._issues
+                   if issue.severity >= min_severity)
 
     def get_failed_checks_by_requirement(self, requirement: Requirement) -> Collection[RequirementCheck]:
         """

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -282,6 +282,18 @@ class SHACLCheck(RequirementCheck):
             if requirementCheck is None:
                 logger.warning("No check instance found for shape: %s", shape.key)
                 continue
+            # Drop violations whose check severity is below the requested
+            # `requirement_severity`: pyshacl still emits sh:ValidationResult
+            # nodes for sh:Warning / sh:Info, but they are not actionable at a
+            # stricter validation level.
+            if requirementCheck.severity < shacl_context.settings.requirement_severity:
+                logger.debug(
+                    "Dropping violation for check %s: severity %s below requested %s",
+                    requirementCheck.identifier,
+                    requirementCheck.severity,
+                    shacl_context.settings.requirement_severity,
+                )
+                continue
             if (
                 not shacl_context.settings.skip_checks
                 or requirementCheck.identifier not in shacl_context.settings.skip_checks

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -23,6 +23,7 @@ from rocrate_validator.models import (
     Requirement,
     RequirementCheck,
     RequirementCheckValidationEvent,
+    RequirementLevel,
     SkipRequirementCheck,
     ValidationContext,
 )
@@ -105,12 +106,27 @@ class SHACLCheck(RequirementCheck):
             return self._shape.parent.description
         return f"Check for {self._shape.name}" if self._shape.name else "SHACL validation check"
 
-    def __compute_requirement_level__(self) -> LevelCollection:
+    def __compute_requirement_level__(self) -> RequirementLevel:
         if self._shape and self._shape.get_declared_level():
             return self._shape.get_declared_level()
         if self.requirement and self.requirement.requirement_level_from_path:
             return self.requirement.requirement_level_from_path
+        # When the shape file lives in the profile root and the NodeShape
+        # itself does not declare sh:severity, derive the level from the
+        # most severe nested PropertyShape instead of defaulting to REQUIRED.
+        derived = self.__derive_level_from_properties__()
+        if derived:
+            return derived
         return LevelCollection.REQUIRED
+
+    def __derive_level_from_properties__(self) -> Optional[RequirementLevel]:
+        properties = getattr(self._shape, "properties", None)
+        if not properties:
+            return None
+        declared_levels = [lvl for lvl in (p.get_declared_level() for p in properties) if lvl]
+        if not declared_levels:
+            return None
+        return max(declared_levels, key=lambda lvl: lvl.severity.value)
 
     @property
     def level(self) -> str:

--- a/tests/unit/requirements/test_shacl_checks.py
+++ b/tests/unit/requirements/test_shacl_checks.py
@@ -17,17 +17,20 @@ import logging
 from rdflib import BNode, Graph, Namespace, URIRef
 
 from rocrate_validator.constants import SHACL_NS
+from rocrate_validator.models import LevelCollection
 from rocrate_validator.requirements.shacl.checks import SHACLCheck
-from rocrate_validator.requirements.shacl.models import Shape, ShapesRegistry
+from rocrate_validator.requirements.shacl.models import (NodeShape,
+                                                         PropertyShape, Shape,
+                                                         ShapesRegistry)
 from rocrate_validator.requirements.shacl.utils import resolve_parent_shape
 
 logger = logging.getLogger(__name__)
 
 
 class MockRequirement:
-    def __init__(self):
+    def __init__(self, requirement_level_from_path=None):
         self.profile = None
-        self.requirement_level_from_path = None
+        self.requirement_level_from_path = requirement_level_from_path
 
 
 class MockParentShape:
@@ -220,3 +223,98 @@ def test_resolve_parent_shape_with_property_bnode():
 
     assert result is not None, "Should resolve parent shape for property BNode"
     assert result.key == shape.key
+
+
+def _make_property(graph: Graph, severity_term: str = None) -> PropertyShape:
+    """Build a PropertyShape on a fresh BNode, optionally setting sh:severity."""
+    prop = PropertyShape(BNode(), graph)
+    if severity_term is not None:
+        prop.severity = severity_term
+    return prop
+
+
+def test_derive_level_picks_most_stringent_declared_property_severity():
+    """
+    Flat NodeShape with no declared severity inherits the highest severity
+    declared by its nested properties.
+    """
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.add_property(_make_property(g, f"{SHACL_NS}Info"))
+    shape.add_property(_make_property(g, f"{SHACL_NS}Warning"))
+    shape.add_property(_make_property(g, f"{SHACL_NS}Info"))
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.RECOMMENDED
+
+
+def test_derive_level_with_uniform_property_severity():
+    """When every property declares the same severity, derive that severity."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.add_property(_make_property(g, f"{SHACL_NS}Info"))
+    shape.add_property(_make_property(g, f"{SHACL_NS}Info"))
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.OPTIONAL
+
+
+def test_derive_level_ignores_properties_without_declared_severity():
+    """Properties without sh:severity are skipped; only declared ones drive the result."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.add_property(_make_property(g))  # no severity declared
+    shape.add_property(_make_property(g, f"{SHACL_NS}Warning"))
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.RECOMMENDED
+
+
+def test_derive_level_falls_back_to_required_when_no_property_declares_severity():
+    """If no nested property declares a severity, fall back to REQUIRED."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.add_property(_make_property(g))
+    shape.add_property(_make_property(g))
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.REQUIRED
+
+
+def test_shape_declared_severity_takes_precedence_over_derivation():
+    """An explicit severity on the NodeShape wins over property-based derivation."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.severity = f"{SHACL_NS}Warning"
+    shape.add_property(_make_property(g, f"{SHACL_NS}Violation"))
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.RECOMMENDED
+
+
+def test_path_based_level_takes_precedence_over_derivation():
+    """When the requirement file is in a must/should/may folder the path level wins."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+    shape.add_property(_make_property(g, f"{SHACL_NS}Info"))
+
+    check = SHACLCheck(
+        MockRequirement(requirement_level_from_path=LevelCollection.SHOULD), shape
+    )
+
+    assert check.level == LevelCollection.SHOULD
+
+
+def test_derive_level_for_node_shape_without_properties():
+    """A NodeShape with no nested properties falls back to REQUIRED."""
+    g = Graph()
+    shape = NodeShape(URIRef("http://example.org/NodeShape"), g)
+
+    check = SHACLCheck(MockRequirement(), shape)
+
+    assert check.level == LevelCollection.REQUIRED


### PR DESCRIPTION
This PR fixes how `requirement_severity` is resolved and applied during SHACL validation when shapes are organized in a flat layout (i.e. shape files placed directly under the profile root, without `must/`/`should/`/`may/` subfolders):

- Derive a NodeShape's requirement level from its nested PropertyShapes' `sh:severity` when the shape itself doesn't declare one, instead of defaulting to `REQUIRED`. Explicit shape severity and path-based level still win.
- Discard SHACL results below the configured `requirement_severity` as soon as they are read from pyshacl, so the rest of `ValidationResult` (issues, failed requirements, failed checks, counts) consistently reflects only violations at or above the threshold.

[related to #157]