### PR TITLE
feat(cli): show requirement check via `describe profile`

### DIFF
--- a/rocrate_validator/cli/commands/profiles.py
+++ b/rocrate_validator/cli/commands/profiles.py
@@ -12,20 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 from rich.align import Align
 from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.panel import Panel
+from rich.syntax import Syntax
 from rich.table import Table
 
 from rocrate_validator import services
 from rocrate_validator.cli.commands.errors import handle_error
 from rocrate_validator.cli.main import cli, click
 from rocrate_validator.constants import DEFAULT_PROFILE_IDENTIFIER
-from rocrate_validator.models import (LevelCollection, RequirementLevel,
+from rocrate_validator.models import (LevelCollection, Profile,
+                                      RequirementCheck, RequirementLevel,
                                       Severity)
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.io_helpers.colors import get_severity_color
@@ -158,11 +162,13 @@ def list_profiles(ctx, no_paging: bool = False):  # , profiles_path: Path = DEFA
     '-v',
     '--verbose',
     is_flag=True,
-    help="Show detailed list of requirements",
+    help="Show detailed list of requirements (or, when a check identifier is given, "
+         "show the source code of the check)",
     default=False,
     show_default=True
 )
 @click.argument("profile-identifier", type=click.STRING, default=DEFAULT_PROFILE_IDENTIFIER, required=True)
+@click.argument("check-identifier", type=click.STRING, required=False, default=None)
 @click.option(
     '--no-paging',
     is_flag=True,
@@ -174,11 +180,19 @@ def list_profiles(ctx, no_paging: bool = False):  # , profiles_path: Path = DEFA
 @click.pass_context
 def describe_profile(ctx,
                      profile_identifier: str = DEFAULT_PROFILE_IDENTIFIER,
+                     check_identifier: Optional[str] = None,
                      profiles_path: Path = DEFAULT_PROFILES_PATH,
                      extra_profiles_path: Path = None,
                      verbose: bool = False, no_paging: bool = False):
     """
-    Show a profile
+    Show a profile, or — when CHECK_IDENTIFIER is given — show a single requirement check.
+
+    \b
+    The check identifier accepts either form:
+      * relative:   <requirement#>.<check#>          (e.g. "1.2")
+      * full:       <profile>_<requirement#>.<check#> (e.g. "ro-crate-1.1_1.2")
+
+    With -v on a single check, the source code of the check is shown.
     """
     # Get the console
     console = ctx.obj['console']
@@ -196,6 +210,14 @@ def describe_profile(ctx,
         # Get the profile
         profile = services.get_profile(profile_identifier, profiles_path=profiles_path,
                                        extra_profiles_path=extra_profiles_path)
+
+        # Single-check view
+        if check_identifier:
+            check = __resolve_check__(profile, check_identifier)
+            with console.pager(pager=pager, styles=not console.no_color) if enable_pager else console:
+                console.print(get_app_header_rule())
+                __describe_check__(console, profile, check, verbose=verbose)
+            return
 
         # Set the subheader title
         subheader_title = f"[bold][cyan]Profile:[/cyan] [magenta italic]{profile.identifier}[/magenta italic][/bold]"
@@ -237,6 +259,9 @@ def describe_profile(ctx,
                                         title_align="left", border_style="cyan"), (0, 1, 0, 1)))
             console.print(Padding(table, (1, 1)))
 
+    except click.ClickException:
+        # Let click format usage errors natively (e.g., BadParameter from check resolution)
+        raise
     except Exception as e:
         handle_error(e, console)
 
@@ -313,28 +338,7 @@ def __verbose_describe_profile__(profile):
             color = get_severity_color(check.severity)
             level_info = f"[{color}]{check.severity.name}[/{color}]"
             levels_list.add(level_info)
-            override = None
-            # Uncomment the following lines to show the overridden checks
-            # if check.overridden_by:
-            #     logger.debug("Check %s is overridden by: %s", check.identifier, check.overridden_by)
-            #     override = "[overridden by: "
-            #     for co in check.overridden_by:
-            #         severity_color = get_severity_color(co.severity)
-            #         override += f"[bold][magenta]{co.requirement.profile.identifier}[/magenta] "\
-            #             f"[{severity_color}]{co.relative_identifier}[/{severity_color}][/bold]"
-            #         if co != check.overridden_by[-1]:
-            #             override += ", "
-            #     override += "]"
-            if check.overrides:
-                logger.debug("Check %s overrides: %s", check.identifier, check.overrides)
-                override = "[" + "overrides: "
-                for co in check.overrides:
-                    severity_color = get_severity_color(co.severity)
-                    override += f"[bold][magenta]{co.requirement.profile.identifier}[/magenta] "
-                    f"[{severity_color}]{co.relative_identifier}[/{severity_color}][/bold]"
-                    if co != check.overrides[-1]:
-                        override += ", "
-                override += "]"
+            override = __format_overrides__(check.overrides, label="overrides") if check.overrides else None
 
             description_table = Table(show_header=False, show_footer=False, show_lines=False, show_edge=False)
             if override:
@@ -367,3 +371,159 @@ def __verbose_describe_profile__(profile):
     for row in table_rows:
         table.add_row(*row)
     return table
+
+
+_CHECK_ID_RE = re.compile(r"^(?P<req>\d+)\.(?P<check>\d+)$")
+
+
+def __resolve_check__(profile: Profile, check_identifier: str) -> RequirementCheck:
+    """
+    Resolve a check identifier to a RequirementCheck instance.
+    Accepts either the relative form ``<req#>.<check#>`` or the full form
+    ``<profile>_<req#>.<check#>``.
+    """
+    raw = check_identifier.strip()
+    relative = raw
+    prefix = f"{profile.identifier}_"
+    if "_" in raw:
+        if not raw.startswith(prefix):
+            raise click.BadParameter(
+                f"Check identifier '{raw}' does not belong to profile '{profile.identifier}'.",
+                param_hint="CHECK_IDENTIFIER",
+            )
+        relative = raw[len(prefix):]
+
+    match = _CHECK_ID_RE.match(relative)
+    if not match:
+        raise click.BadParameter(
+            f"Invalid check identifier '{check_identifier}'. "
+            f"Expected '<requirement#>.<check#>' (e.g. '1.2') or "
+            f"'<profile>_<requirement#>.<check#>' (e.g. '{profile.identifier}_1.2').",
+            param_hint="CHECK_IDENTIFIER",
+        )
+    req_number = int(match.group("req"))
+    check_number = int(match.group("check"))
+
+    requirement = next(
+        (r for r in profile.requirements if not r.hidden and r.order_number == req_number),
+        None,
+    )
+    if requirement is None:
+        raise click.BadParameter(
+            f"No requirement #{req_number} in profile '{profile.identifier}'. "
+            f"Run `rocrate-validator profiles describe {profile.identifier}` to list requirements.",
+            param_hint="CHECK_IDENTIFIER",
+        )
+    check = next(
+        (c for c in requirement.get_checks() if c.order_number == check_number),
+        None,
+    )
+    if check is None:
+        raise click.BadParameter(
+            f"No check #{check_number} in requirement #{req_number} of profile "
+            f"'{profile.identifier}'. Run `rocrate-validator profiles describe "
+            f"{profile.identifier} -v` to list checks.",
+            param_hint="CHECK_IDENTIFIER",
+        )
+    return check
+
+
+def __format_overrides__(checks: list, label: str) -> str:
+    """
+    Format an "overrides" / "overridden by" Rich-styled string for a list of checks.
+    """
+    parts = []
+    for co in checks:
+        severity_color = get_severity_color(co.severity)
+        parts.append(
+            f"[bold][magenta]{co.requirement.profile.identifier}[/magenta] "
+            f"[{severity_color}]{co.relative_identifier}[/{severity_color}][/bold]"
+        )
+    return f"[bold red]{label}:[/bold red] " + ", ".join(parts)
+
+
+def __describe_check__(console, profile: Profile, check: RequirementCheck, verbose: bool = False) -> None:
+    """
+    Render a single requirement check.
+    """
+    severity_color = get_severity_color(check.severity)
+    requirement = check.requirement
+
+    header = (
+        f"[bold cyan]Profile:[/bold cyan] "
+        f"[italic magenta]{profile.identifier}[/italic magenta]\n"
+        f"[bold cyan]Identifier:[/bold cyan] "
+        f"[italic green]{check.identifier}[/italic green]\n"
+        f"[bold cyan]Name:[/bold cyan] [italic]{check.name}[/italic]\n"
+        f"[bold cyan]Severity:[/bold cyan] "
+        f"[bold {severity_color}]{check.severity.name}[/bold {severity_color}]\n"
+        f"[bold cyan]Requirement:[/bold cyan] "
+        f"[italic]#{requirement.order_number} — {requirement.name}[/italic]"
+    )
+    if requirement.path:
+        header += (
+            "\n[bold cyan]Source file:[/bold cyan] "
+            f"[italic green]{shorten_path(requirement.path)}[/italic green]"
+        )
+
+    title = f"[bold][cyan]Check:[/cyan] [magenta italic]{check.identifier}[/magenta italic][/bold]"
+    console.print(Padding(
+        Panel(header, title=title, padding=(1, 1, 1, 1), title_align="left", border_style="cyan"),
+        (0, 1, 0, 1),
+    ))
+
+    description_panel = Panel(
+        Markdown(check.description.strip()),
+        title="[bold cyan]Description[/bold cyan]",
+        title_align="left",
+        border_style="bright_black",
+        padding=(1, 1, 1, 1),
+    )
+    console.print(Padding(description_panel, (1, 1, 0, 1)))
+
+    if check.overrides:
+        overrides_text = __format_overrides__(check.overrides, label="overrides")
+        console.print(Padding(Panel(
+            overrides_text,
+            title="[bold cyan]Overrides[/bold cyan]",
+            title_align="left",
+            border_style="bright_black",
+            padding=(1, 1, 1, 1),
+        ), (1, 1, 0, 1)))
+    if check.overridden_by:
+        overridden_text = __format_overrides__(check.overridden_by, label="overridden by")
+        console.print(Padding(Panel(
+            overridden_text,
+            title="[bold cyan]Overridden by[/bold cyan]",
+            title_align="left",
+            border_style="bright_black",
+            padding=(1, 1, 1, 1),
+        ), (1, 1, 0, 1)))
+
+    if verbose:
+        snippet = check.get_source_snippet()
+        if snippet is None:
+            console.print(Padding(Panel(
+                "[italic]Source code not available for this check kind.[/italic]",
+                title="[bold cyan]Source[/bold cyan]",
+                title_align="left",
+                border_style="bright_black",
+                padding=(1, 1, 1, 1),
+            ), (1, 1, 0, 1)))
+        else:
+            source_title = f"[bold cyan]Source ({snippet.language})[/bold cyan]"
+            if snippet.source_path:
+                source_title += f': [italic green]"{snippet.source_path.name}"[/italic green]'
+            console.print(Padding(Panel(
+                Syntax(
+                    snippet.code,
+                    snippet.language,
+                    theme="ansi_dark",
+                    line_numbers=False,
+                    word_wrap=True,
+                ),
+                title=source_title,
+                title_align="left",
+                border_style="bright_black",
+                padding=(1, 1, 1, 1),
+            ), (1, 1, 1, 1)))

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1374,6 +1374,19 @@ class RequirementLoader:
         return requirements
 
 
+@dataclass(frozen=True)
+class SourceSnippet:
+    """
+    A snippet of source code backing a :class:`RequirementCheck`.
+    :ivar language: language tag for syntax highlighting (e.g. ``"python"``, ``"turtle"``).
+    :ivar code: the source code as text.
+    :ivar source_path: path to the file the snippet was extracted from, when available.
+    """
+    language: str
+    code: str
+    source_path: Optional[Path] = None
+
+
 @total_ordering
 class RequirementCheck(ABC):
 
@@ -1471,6 +1484,14 @@ class RequirementCheck(ABC):
     @abstractmethod
     def execute_check(self, context: ValidationContext) -> bool:
         raise NotImplementedError()
+
+    def get_source_snippet(self) -> Optional[SourceSnippet]:
+        """
+        Return the source code that implements this check, or ``None`` if the
+        backing source cannot be extracted for this check kind.
+        Concrete subclasses should override this method.
+        """
+        return None
 
     def to_dict(self, with_requirement: bool = True, with_profile: bool = True) -> dict:
         result = {

--- a/rocrate_validator/requirements/python/__init__.py
+++ b/rocrate_validator/requirements/python/__init__.py
@@ -21,7 +21,7 @@ from rocrate_validator.utils import log as logging
 from rocrate_validator.models import (LevelCollection, Profile, Requirement,
                                       RequirementCheck, RequirementLevel,
                                       RequirementLoader, Severity,
-                                      ValidationContext)
+                                      SourceSnippet, ValidationContext)
 from rocrate_validator.utils.python_helpers import get_classes_from_file
 
 # set up logging
@@ -62,6 +62,19 @@ class PyFunctionCheck(RequirementCheck):
                          self.requirement.identifier, self.requirement.profile.identifier)
             return True
         return self._check_function(self, context)
+
+    def get_source_snippet(self) -> Optional[SourceSnippet]:
+        try:
+            code = inspect.getsource(self._check_function)
+        except (OSError, TypeError) as e:
+            logger.debug("Unable to read source for check %s: %s", self.identifier, e)
+            return None
+        source_file = inspect.getsourcefile(self._check_function)
+        return SourceSnippet(
+            language="python",
+            code=code,
+            source_path=Path(source_file) if source_file else None,
+        )
 
 
 class PyRequirement(Requirement):

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -199,12 +199,12 @@ class SHACLCheck(RequirementCheck):
                     shacl.target,
                 )
                 for predicate in target_predicates:
-                    for triple in graph.triples((owner.node, predicate, None)):
+                    for triple in owner.graph.triples((owner.node, predicate, None)):
                         subgraph.add(triple)
                         # follow BNode objects (e.g. sh:target referencing an inline SPARQL target)
                         _, _, obj = triple
                         if isinstance(obj, BNode):
-                            subgraph += build_node_subgraph(graph, obj)
+                            subgraph += build_node_subgraph(owner.graph, obj)
                 # link the owner to the property so the relationship is preserved in the serialization
                 subgraph.add((owner.node, shacl.property, self._shape.node))
 

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -16,7 +16,7 @@ import json
 from timeit import default_timer as timer
 from typing import Optional
 
-from rdflib import Literal, Namespace
+from rdflib import RDF, BNode, Literal, Namespace
 
 from rocrate_validator.constants import SHACL_NS
 from rocrate_validator.errors import ROCrateMetadataNotFoundError
@@ -28,10 +28,11 @@ from rocrate_validator.models import (
     RequirementCheckValidationEvent,
     RequirementLevel,
     SkipRequirementCheck,
+    SourceSnippet,
     ValidationContext,
 )
 from rocrate_validator.requirements.shacl.models import Shape, ShapesRegistry
-from rocrate_validator.requirements.shacl.utils import make_uris_relative, resolve_parent_shape
+from rocrate_validator.requirements.shacl.utils import build_node_subgraph, make_uris_relative, resolve_parent_shape
 from rocrate_validator.requirements.shacl.validator import (
     SHACLValidationAlreadyProcessed,
     SHACLValidationContext,
@@ -174,6 +175,58 @@ class SHACLCheck(RequirementCheck):
     @property
     def severity(self) -> str:
         return self.level.severity
+
+    def get_source_snippet(self) -> Optional[SourceSnippet]:
+        if self._shape is None:
+            return None
+        try:
+            graph = self._shape.graph
+            # build a subgraph containing all the triples related to the shape
+            subgraph = build_node_subgraph(graph, self._shape.node)
+            # identify the owner of the shape
+            owner = self._shape
+            while getattr(owner, "parent", None) is not None:
+                owner = owner.parent
+            # if the shape is not a root shape, include the triples linking the owner to the shape
+            if owner is not self._shape:
+                shacl = Namespace(SHACL_NS)
+                target_predicates = (
+                    RDF.type,
+                    shacl.targetClass,
+                    shacl.targetNode,
+                    shacl.targetSubjectsOf,
+                    shacl.targetObjectsOf,
+                    shacl.target,
+                )
+                for predicate in target_predicates:
+                    for triple in graph.triples((owner.node, predicate, None)):
+                        subgraph.add(triple)
+                        # follow BNode objects (e.g. sh:target referencing an inline SPARQL target)
+                        _, _, obj = triple
+                        if isinstance(obj, BNode):
+                            subgraph += build_node_subgraph(graph, obj)
+                # link the owner to the property so the relationship is preserved in the serialization
+                subgraph.add((owner.node, shacl.property, self._shape.node))
+
+            # copy bindings so the serialized snippet uses the same prefix declarations as the source file
+            for prefix, namespace in graph.namespaces():
+                subgraph.bind(prefix, namespace, replace=True)
+            # serialize the subgraph to Turtle format
+            code = subgraph.serialize(format="turtle")
+        except Exception as e:
+            logger.debug("Unable to serialize SHACL shape for check %s: %s", self.identifier, e)
+            return None
+        # if the code is bytes, decode it to string
+        if isinstance(code, bytes):
+            code = code.decode("utf-8")
+        # use the shape source file as the source path for the snippet if available
+        source_path = self.requirement.path if self.requirement else None
+        # build the source snippet for the check
+        return SourceSnippet(
+            language="turtle",
+            code=code,
+            source_path=source_path,
+        )
 
     def execute_check(self, context: ValidationContext):
         logger.debug("Starting check %s", self)

--- a/rocrate_validator/requirements/shacl/utils.py
+++ b/rocrate_validator/requirements/shacl/utils.py
@@ -21,10 +21,10 @@ from typing import TYPE_CHECKING, Optional, Union
 from rdflib import RDF, BNode, Graph, Namespace
 from rdflib.term import Node
 
-from rocrate_validator.utils import log as logging
-from rocrate_validator.constants import RDF_SYNTAX_NS, SHACL_NS
+from rocrate_validator.constants import SHACL_NS
 from rocrate_validator.errors import BadSyntaxError
 from rocrate_validator.models import Severity
+from rocrate_validator.utils import log as logging
 
 if TYPE_CHECKING:
     from rocrate_validator.requirements.shacl.models import Shape
@@ -34,24 +34,23 @@ logger = logging.getLogger(__name__)
 
 
 def build_node_subgraph(graph: Graph, node: Node) -> Graph:
-    shape_graph = Graph()
-    shape_graph += graph.triples((node, None, None))
-
-    # add BNodes
-    for _, _, o in shape_graph:
-        shape_graph += graph.triples((o, None, None))
-
-    # Use the triples method to get all triples that are part of a list
-    RDF = Namespace(RDF_SYNTAX_NS)
-    first_predicate = RDF.first
-    rest_predicate = RDF.rest
-    shape_graph += graph.triples((None, first_predicate, None))
-    shape_graph += graph.triples((None, rest_predicate, None))
-    for _, _, object in shape_graph:
-        shape_graph += graph.triples((object, None, None))
-
-    # return the subgraph
-    return shape_graph
+    """
+    Build a subgraph with every triple reachable from ``node`` by following BNode objects.
+    """
+    subgraph = Graph()
+    visited: set = set()
+    stack: list = [node]
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        for triple in graph.triples((current, None, None)):
+            subgraph.add(triple)
+            _, _, obj = triple
+            if isinstance(obj, BNode) and obj not in visited:
+                stack.append(obj)
+    return subgraph
 
 
 def map_severity(shacl_severity: str) -> Severity:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,10 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from pytest import fixture
 
+from rocrate_validator import services
+from rocrate_validator.requirements.python import PyFunctionCheck
+from rocrate_validator.requirements.shacl.checks import SHACLCheck
+
 from rocrate_validator.utils import log as logging
 from rocrate_validator.cli.main import cli
 from rocrate_validator.utils.versioning import get_version
@@ -157,3 +161,143 @@ def test_extra_profiles_list(cli_runner: CliRunner, fake_profiles_path: Path):
     assert result.exit_code == 0
     # assert "Available profiles:" in result.output
     assert "Profile A" in result.output  # Check for a known extra profile
+
+
+# Profile used for `profiles describe` tests.
+_DESCRIBE_TEST_PROFILE = "ro-crate-1.1"
+
+
+def _first_visible_check():
+    """Return the first non-hidden (Python-backed) check of the test profile."""
+    profile = services.get_profile(_DESCRIBE_TEST_PROFILE)
+    for requirement in profile.requirements:
+        if requirement.hidden:
+            continue
+        for check in requirement.get_checks():
+            if isinstance(check, PyFunctionCheck):
+                return profile, requirement, check
+    raise RuntimeError("No Python-backed check found in test profile")
+
+
+def _first_shacl_check():
+    """Return the first non-hidden SHACL-backed check of the test profile."""
+    profile = services.get_profile(_DESCRIBE_TEST_PROFILE)
+    for requirement in profile.requirements:
+        if requirement.hidden:
+            continue
+        for check in requirement.get_checks():
+            if isinstance(check, SHACLCheck):
+                return profile, requirement, check
+    raise RuntimeError("No SHACL-backed check found in test profile")
+
+
+def test_profiles_describe_default(cli_runner: CliRunner):
+    """The default describe view (no check id) shows the profile compact view."""
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, "--no-paging"])
+    assert result.exit_code == 0
+    assert _DESCRIBE_TEST_PROFILE in result.output
+    assert "Profile Requirements" in result.output
+
+
+def test_profiles_describe_verbose(cli_runner: CliRunner):
+    """The verbose describe view (no check id) shows individual check identifiers."""
+    _, _, check = _first_visible_check()
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, "-v", "--no-paging"])
+    assert result.exit_code == 0
+    assert check.identifier in result.output
+
+
+def test_describe_check_relative_id(cli_runner: CliRunner):
+    """Resolving a check by '<req#>.<check#>' renders the single-check view."""
+    _, requirement, check = _first_visible_check()
+    relative = f"{requirement.order_number}.{check.order_number}"
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, relative, "--no-paging"])
+    assert result.exit_code == 0, result.output
+    assert check.identifier in result.output
+    assert check.severity.name in result.output
+
+
+def test_describe_check_full_id(cli_runner: CliRunner):
+    """Resolving a check by full '<profile>_<req#>.<check#>'."""
+    _, _, check = _first_visible_check()
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, check.identifier, "--no-paging"])
+    assert result.exit_code == 0, result.output
+    assert check.identifier in result.output
+
+
+def test_describe_check_unknown(cli_runner: CliRunner):
+    """An out-of-range check id produces a usage error with a hint."""
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, "99.99", "--no-paging"])
+    assert result.exit_code == 2
+    assert "No requirement #99" in result.output
+
+
+def test_describe_check_bad_format(cli_runner: CliRunner):
+    """A non-numeric check id is rejected with a format hint."""
+    result = cli_runner.invoke(cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, "not-an-id", "--no-paging"])
+    assert result.exit_code == 2
+    assert "Invalid check identifier" in result.output
+
+
+def test_describe_check_profile_mismatch(cli_runner: CliRunner):
+    """A full id whose prefix doesn't match the requested profile is rejected."""
+    result = cli_runner.invoke(
+        cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, "some-other-profile_1.1", "--no-paging"]
+    )
+    assert result.exit_code == 2
+    assert "does not belong to profile" in result.output
+
+
+def test_describe_check_verbose_python(cli_runner: CliRunner):
+    """Verbose single-check view on a Python-backed check shows the function source."""
+    _, requirement, check = _first_visible_check()
+    relative = f"{requirement.order_number}.{check.order_number}"
+    result = cli_runner.invoke(
+        cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, relative, "-v", "--no-paging"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Source" in result.output
+    # The decorated check function is what gets serialized
+    assert "@check" in result.output
+
+
+def test_describe_check_verbose_shacl(cli_runner: CliRunner):
+    """Verbose single-check view on a SHACL-backed check shows turtle source."""
+    _, requirement, check = _first_shacl_check()
+    relative = f"{requirement.order_number}.{check.order_number}"
+    result = cli_runner.invoke(
+        cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, relative, "-v", "--no-paging"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Source" in result.output
+    # SHACL serialized as turtle should contain a sh: prefix and a NodeShape/PropertyShape declaration
+    assert "sh:" in result.output
+
+
+def test_describe_check_verbose_shacl_includes_target(cli_runner: CliRunner):
+    """For nested PropertyShape checks, the snippet must include the owning NodeShape's target."""
+    profile = services.get_profile(_DESCRIBE_TEST_PROFILE)
+    nested = None
+    for requirement in profile.requirements:
+        if requirement.hidden:
+            continue
+        for check in requirement.get_checks():
+            if isinstance(check, SHACLCheck) and getattr(check._shape, "parent", None) is not None:
+                nested = (requirement, check)
+                break
+        if nested:
+            break
+    if nested is None:
+        # No nested PropertyShape check available in this profile; nothing to assert here.
+        return
+    requirement, check = nested
+    relative = f"{requirement.order_number}.{check.order_number}"
+    result = cli_runner.invoke(
+        cli, ["profiles", "describe", _DESCRIBE_TEST_PROFILE, relative, "-v", "--no-paging"]
+    )
+    assert result.exit_code == 0, result.output
+    # The snippet must surface the owning shape's target declaration so the user can see
+    # what the property check applies to.
+    assert any(t in result.output for t in ("sh:targetClass", "sh:targetNode",
+                                            "sh:targetSubjectsOf", "sh:targetObjectsOf",
+                                            "sh:target "))


### PR DESCRIPTION
This PR extends the existing `describe profile` CLI command with the ability to inspect a single requirement check and, optionally, display its underlying source code — either the SHACL shape or the Python function implementing the check.

### CLI usage
```bash

# Existing behavior — describe a whole profile
rocrate-validator profiles describe <PROFILE_IDENTIFIER>
rocrate-validator profiles describe <PROFILE_IDENTIFIER> -v

# New — describe a single check (relative identifier: <requirement#>.<check#>)
rocrate-validator profiles describe <PROFILE_IDENTIFIER> <REQ#>.<CHECK#>

# New — describe a single check (fully-qualified identifier)
rocrate-validator profiles describe <PROFILE_IDENTIFIER> <PROFILE_IDENTIFIER>_<REQ#>.<CHECK#>

# New — describe a single check and show its source code (SHACL Turtle or Python)
rocrate-validator profiles describe <PROFILE_IDENTIFIER> <REQ#>.<CHECK#> -v
```

#### Examples:
```
rocrate-validator profiles describe ro-crate-1.1 1.2
rocrate-validator profiles describe ro-crate-1.1 ro-crate-1.1_1.2
rocrate-validator profiles describe ro-crate-1.1 1.2 -v
```

[fix #99]