### PR TITLE
fix(shacl): correct property subgraph and zero-shape profile evaluation

### DIFF
--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -102,13 +102,13 @@ class Severity(enum.Enum):
 @total_ordering
 @dataclass
 class RequirementLevel:
-
     """
     Represents a requirement level.
 
     A requirement has a name and a severity level of type :class:`.Severity`.
     It implements the comparison operators to allow ordering of the requirement levels.
     """
+
     name: str
     severity: Severity
 
@@ -130,7 +130,7 @@ class RequirementLevel:
         return hash((self.name, self.severity))
 
     def __repr__(self) -> str:
-        return f'RequirementLevel(name={self.name}, severity={self.severity})'
+        return f"RequirementLevel(name={self.name}, severity={self.severity})"
 
     def __str__(self) -> str:
         return self.name
@@ -157,36 +157,39 @@ class LevelCollection:
         are to be interpreted as described in **RFC 2119**.
 
     """
+
     #: The requirement level OPTIONAL is mapped to the OPTIONAL severity level
-    OPTIONAL = RequirementLevel('OPTIONAL', Severity.OPTIONAL)
+    OPTIONAL = RequirementLevel("OPTIONAL", Severity.OPTIONAL)
     #: The requirement level MAY is mapped to the OPTIONAL severity level
-    MAY = RequirementLevel('MAY', Severity.OPTIONAL)
+    MAY = RequirementLevel("MAY", Severity.OPTIONAL)
     #: The requirement level REQUIRED is mapped to the REQUIRED severity level
-    REQUIRED = RequirementLevel('REQUIRED', Severity.REQUIRED)
+    REQUIRED = RequirementLevel("REQUIRED", Severity.REQUIRED)
     #: The requirement level SHOULD is mapped to the RECOMMENDED severity level
-    SHOULD = RequirementLevel('SHOULD', Severity.RECOMMENDED)
+    SHOULD = RequirementLevel("SHOULD", Severity.RECOMMENDED)
     #: The requirement level SHOULD NOT is mapped to the RECOMMENDED severity level
-    SHOULD_NOT = RequirementLevel('SHOULD_NOT', Severity.RECOMMENDED)
+    SHOULD_NOT = RequirementLevel("SHOULD_NOT", Severity.RECOMMENDED)
     #: The requirement level RECOMMENDED is mapped to the RECOMMENDED severity level
-    RECOMMENDED = RequirementLevel('RECOMMENDED', Severity.RECOMMENDED)
+    RECOMMENDED = RequirementLevel("RECOMMENDED", Severity.RECOMMENDED)
 
     #: The requirement level MUST is mapped to the REQUIRED severity level
-    MUST = RequirementLevel('MUST', Severity.REQUIRED)
+    MUST = RequirementLevel("MUST", Severity.REQUIRED)
     #: The requirement level MUST_NOT is mapped to the REQUIRED severity level
-    MUST_NOT = RequirementLevel('MUST_NOT', Severity.REQUIRED)
+    MUST_NOT = RequirementLevel("MUST_NOT", Severity.REQUIRED)
     #: The requirement level SHALL is mapped to the REQUIRED severity level
-    SHALL = RequirementLevel('SHALL', Severity.REQUIRED)
+    SHALL = RequirementLevel("SHALL", Severity.REQUIRED)
     #: The requirement level SHALL_NOT is mapped to the REQUIRED severity level
-    SHALL_NOT = RequirementLevel('SHALL_NOT', Severity.REQUIRED)
+    SHALL_NOT = RequirementLevel("SHALL_NOT", Severity.REQUIRED)
 
     def __init__(self):
         raise NotImplementedError(f"{type(self)} can't be instantiated")
 
     @staticmethod
     def all() -> list[RequirementLevel]:
-        return [level for name, level in inspect.getmembers(LevelCollection)
-                if not inspect.isroutine(level)
-                and not inspect.isdatadescriptor(level) and not name.startswith('__')]
+        return [
+            level
+            for name, level in inspect.getmembers(LevelCollection)
+            if not inspect.isroutine(level) and not inspect.isdatadescriptor(level) and not name.startswith("__")
+        ]
 
     @staticmethod
     def get(name: str) -> RequirementLevel:
@@ -198,7 +201,6 @@ class LevelCollection:
 
 @total_ordering
 class Profile:
-
     """
     RO-Crate Validator profile.
 
@@ -206,19 +208,25 @@ class Profile:
     """
 
     # store the map of profiles: profile URI -> Profile instance
-    __profiles_map: MultiIndexMap = \
-        MultiIndexMap("uri", indexes=[
-            MapIndex("name"), MapIndex("token", unique=False), MapIndex("identifier", unique=True),
-            MapIndex("token_path", unique=False)
-        ])
+    __profiles_map: MultiIndexMap = MultiIndexMap(
+        "uri",
+        indexes=[
+            MapIndex("name"),
+            MapIndex("token", unique=False),
+            MapIndex("identifier", unique=True),
+            MapIndex("token_path", unique=False),
+        ],
+    )
 
-    def __init__(self,
-                 profiles_base_path: Path,
-                 profile_path: Path,
-                 requirements: Optional[list[Requirement]] = None,
-                 identifier: str = None,
-                 publicID: Optional[str] = None,
-                 severity: Severity = Severity.REQUIRED):
+    def __init__(
+        self,
+        profiles_base_path: Path,
+        profile_path: Path,
+        requirements: Optional[list[Requirement]] = None,
+        identifier: str = None,
+        publicID: Optional[str] = None,
+        severity: Severity = Severity.REQUIRED,
+    ):
         """
         Initialize the Profile instance
 
@@ -283,11 +291,10 @@ class Profile:
                 if existing_profile.path != profile_path:
                     # if the profile already exists, log a warning
                     logger.warning(
-                        "Profile with identifier %s at %s is being overridden "
-                        "by the profile loaded from %s.",
+                        "Profile with identifier %s at %s is being overridden by the profile loaded from %s.",
                         existing_profile.identifier,
                         existing_profile.path,
-                        profile_path
+                        profile_path,
                     )
                     # add the existing profile as an override
                     self.__add_override__(existing_profile)
@@ -295,17 +302,24 @@ class Profile:
             # add the profile to the profiles map
             self.__profiles_map.add(
                 self._profile_node.toPython(),
-                self, token=self.token,
-                name=self.name, identifier=self.identifier,
-                token_path=self.__extract_token_from_path__()
+                self,
+                token=self.token,
+                name=self.name,
+                identifier=self.identifier,
+                token_path=self.__extract_token_from_path__(),
             )  # add the profile to the profiles map
         else:
             raise ProfileSpecificationError(
-                message=f"Profile specification file {spec_file} must contain exactly one profile")
+                message=f"Profile specification file {spec_file} must contain exactly one profile"
+            )
 
     def __get_specification_property__(
-            self, property: str, namespace: Namespace,
-            pop_first: bool = True, as_Python_object: bool = True) -> Union[str, list[Union[str, URIRef]]]:
+        self,
+        property: str,
+        namespace: Namespace,
+        pop_first: bool = True,
+        as_Python_object: bool = True,
+    ) -> Union[str, list[Union[str, URIRef]]]:
         assert self._profile_specification_graph is not None, "Profile specification graph not loaded"
         values = list(self._profile_specification_graph.objects(self._profile_node, namespace[property]))
         if values and as_Python_object:
@@ -493,23 +507,22 @@ class Profile:
         The list of requirements of the profile.
         """
         if not self._requirements:
-            self._requirements = \
-                RequirementLoader.load_requirements(self, severity=self.severity)
+            self._requirements = RequirementLoader.load_requirements(self, severity=self.severity)
         return self._requirements
 
-    def get_requirements(
-            self, severity: Severity = Severity.REQUIRED,
-            exact_match: bool = False) -> list[Requirement]:
+    def get_requirements(self, severity: Severity = Severity.REQUIRED, exact_match: bool = False) -> list[Requirement]:
         """
         Get the requirements of the profile with the given severity level.
         If the exact_match flag is set to `True`, only the requirements with the exact severity level
         are returned; otherwise, the requirements with severity level greater than or equal to
         the given severity level are returned.
         """
-        return [requirement for requirement in self.requirements
-                if (not exact_match and
-                    (not requirement.severity_from_path or requirement.severity_from_path >= severity)) or
-                (exact_match and requirement.severity_from_path == severity)]
+        return [
+            requirement
+            for requirement in self.requirements
+            if (not exact_match and (not requirement.severity_from_path or requirement.severity_from_path >= severity))
+            or (exact_match and requirement.severity_from_path == severity)
+        ]
 
     def get_requirement(self, name: str) -> Optional[Requirement]:
         """
@@ -564,9 +577,7 @@ class Profile:
         self._requirements.remove(requirement)
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, Profile) \
-            and self.identifier == other.identifier \
-            and self.path == other.path
+        return isinstance(other, Profile) and self.identifier == other.identifier and self.path == other.path
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, Profile):
@@ -582,10 +593,9 @@ class Profile:
 
     def __repr__(self) -> str:
         return (
-            f'Profile(identifier={self.identifier}, '
-            f'name={self.name}, '
-            f'path={self.path}, ' if self.path else ''
-            f'requirements={self.requirements})'
+            f"Profile(identifier={self.identifier}, name={self.name}, path={self.path}, "
+            if self.path
+            else f"requirements={self.requirements})"
         )
 
     def __str__(self) -> str:
@@ -596,7 +606,7 @@ class Profile:
             "identifier": self.identifier,
             "uri": self.uri,
             "name": self.name,
-            "description": self.description
+            "description": self.description,
         }
 
     @staticmethod
@@ -610,12 +620,16 @@ class Profile:
         return None
 
     def __get_consistent_version__(self, candidate_token: str) -> str:
-        candidates = {_ for _ in [
-            self.__get_specification_property__("version", SCHEMA_ORG_NS),
-            self.__extract_version_from_token__(candidate_token),
-            self.__extract_version_from_token__(str(self.path.relative_to(self._profiles_base_path))),
-            self.__extract_version_from_token__(str(self.uri))
-        ] if _ is not None}
+        candidates = {
+            _
+            for _ in [
+                self.__get_specification_property__("version", SCHEMA_ORG_NS),
+                self.__extract_version_from_token__(candidate_token),
+                self.__extract_version_from_token__(str(self.path.relative_to(self._profiles_base_path))),
+                self.__extract_version_from_token__(str(self.uri)),
+            ]
+            if _ is not None
+        }
         if len(candidates) > 1:
             raise ProfileSpecificationError(f"Inconsistent versions found: {candidates}")
         logger.debug("Candidate versions: %s", candidates)
@@ -630,7 +644,7 @@ class Profile:
         # Remove the base path from the identifier
         identifier = identifier.replace(f"{base_path}/", "")
         # Replace slashes with hyphens
-        identifier = identifier.replace('/', '-')
+        identifier = identifier.replace("/", "-")
         return identifier
 
     def __init_token_version__(self) -> Tuple[str, str, str]:
@@ -652,10 +666,13 @@ class Profile:
         return candidate_token, version
 
     @classmethod
-    def __load_profile_path__(cls, profiles_base_path: str,
-                              profile_path: Union[str, Path],
-                              publicID: Optional[str] = None,
-                              severity:  Severity = Severity.REQUIRED) -> Profile:
+    def __load_profile_path__(
+        cls,
+        profiles_base_path: str,
+        profile_path: Union[str, Path],
+        publicID: Optional[str] = None,
+        severity: Severity = Severity.REQUIRED,
+    ) -> Profile:
         # if the path is a string, convert it to a Path
         if isinstance(profile_path, str):
             profile_path = Path(profile_path)
@@ -663,14 +680,21 @@ class Profile:
         if not profile_path.is_dir():
             raise InvalidProfilePath(profile_path)
         # create a new profile
-        profile = Profile(profiles_base_path=profiles_base_path,
-                          profile_path=profile_path, publicID=publicID, severity=severity)
+        profile = Profile(
+            profiles_base_path=profiles_base_path,
+            profile_path=profile_path,
+            publicID=publicID,
+            severity=severity,
+        )
         logger.debug("Loaded profile: %s", profile)
         return profile
 
     @classmethod
-    def __load_profiles_paths__(cls, profiles_path: Union[str, Path] = None,
-                                extra_profiles_path: Union[str, Path] = None) -> list[Tuple[Path, Path]]:
+    def __load_profiles_paths__(
+        cls,
+        profiles_path: Union[str, Path] = None,
+        extra_profiles_path: Union[str, Path] = None,
+    ) -> list[Tuple[Path, Path]]:
         """
         Load the paths of the profiles from the given profiles path and extra profiles path.
 
@@ -698,33 +722,47 @@ class Profile:
             if not root_profile_directory.is_dir():
                 raise InvalidProfilePath(root_profile_directory)
             # if the path is a directory, get the profile directories
-            result.extend([(root_profile_directory, p.parent)
-                          for p in root_profile_directory.rglob('*.*') if p.name == PROFILE_SPECIFICATION_FILE])
+            result.extend(
+                [
+                    (root_profile_directory, p.parent)
+                    for p in root_profile_directory.rglob("*.*")
+                    if p.name == PROFILE_SPECIFICATION_FILE
+                ]
+            )
         # return the list of profile directories
         return result
 
     @classmethod
-    def load_profiles(cls,
-                      profiles_path: Union[str, Path],
-                      extra_profiles_path: Union[str, Path] = None,
-                      publicID: Optional[str] = None,
-                      severity:  Severity = Severity.REQUIRED,
-                      allow_requirement_check_override: bool = True) -> list[Profile]:
+    def load_profiles(
+        cls,
+        profiles_path: Union[str, Path],
+        extra_profiles_path: Union[str, Path] = None,
+        publicID: Optional[str] = None,
+        severity: Severity = Severity.REQUIRED,
+        allow_requirement_check_override: bool = True,
+    ) -> list[Profile]:
         # initialize the profiles list
         profiles = []
         # calculate the list of profiles path as the subdirectories of the profiles path
         # where the profile specification file is present
-        profiles_paths = cls.__load_profiles_paths__(profiles_path,
-                                                     extra_profiles_path)
+        profiles_paths = cls.__load_profiles_paths__(profiles_path, extra_profiles_path)
 
         # iterate through the directories and load the profiles
         for root_profile_path, profile_path in profiles_paths:
-            logger.debug("Checking profile path: %s %s %r", profile_path,
-                         profile_path.is_dir(), IGNORED_PROFILE_DIRECTORIES)
+            logger.debug(
+                "Checking profile path: %s %s %r",
+                profile_path,
+                profile_path.is_dir(),
+                IGNORED_PROFILE_DIRECTORIES,
+            )
             # check if the profile path is a directory and not in the ignored directories
             if profile_path.is_dir() and profile_path not in IGNORED_PROFILE_DIRECTORIES:
                 profile = Profile.__load_profile_path__(
-                    root_profile_path, profile_path, publicID=publicID, severity=severity)
+                    root_profile_path,
+                    profile_path,
+                    publicID=publicID,
+                    severity=severity,
+                )
                 # if the profile overrides another profile,
                 # remove the overridden profiles from the list of profiles
                 # to avoid duplicates and ensure that the most specific profile is used
@@ -760,7 +798,10 @@ class Profile:
         #  order profiles according to the number of profiles they depend on:
         # i.e, first the profiles that do not depend on any other profile
         # then the profiles that depend on the previous ones, and so on
-        return sorted(profiles, key=lambda x: f"{len(x.inherited_profiles)}_{x.identifier}")
+        return sorted(
+            profiles,
+            key=lambda x: f"{len(x.inherited_profiles)}_{x.identifier}",
+        )
 
     @classmethod
     def get_by_identifier(cls, identifier: str) -> Profile:
@@ -838,8 +879,7 @@ class Profile:
         return cls.__profiles_map.values()
 
     @classmethod
-    def find_in_list(cls, profiles: Collection[Profile],
-                     profile_identifier: str) -> Optional[Profile]:
+    def find_in_list(cls, profiles: Collection[Profile], profile_identifier: str) -> Optional[Profile]:
         """
         Find a profile with the given identifier in the given list of profiles
 
@@ -852,8 +892,10 @@ class Profile:
         :return: the profile if found, None otherwise
         :rtype: Optional[Profile]
         """
-        profile = next((p for p in profiles if p.identifier == profile_identifier), None) or \
-            next((p for p in profiles if str(p.identifier).replace(f"-{p.version}", '') == profile_identifier), None)
+        profile = next((p for p in profiles if p.identifier == profile_identifier), None) or next(
+            (p for p in profiles if str(p.identifier).replace(f"-{p.version}", "") == profile_identifier),
+            None,
+        )
         if not profile:
             raise ProfileNotFound(profile_identifier)
         return profile
@@ -875,12 +917,14 @@ class Requirement(ABC):
     A requirement is a named set of checks that can be used to validate an RO-Crate.
     """
 
-    def __init__(self,
-                 profile: Profile,
-                 name: str = "",
-                 description: Optional[str] = None,
-                 path: Optional[Path] = None,
-                 initialize_checks: bool = True):
+    def __init__(
+        self,
+        profile: Profile,
+        name: str = "",
+        description: Optional[str] = None,
+        path: Optional[Path] = None,
+        initialize_checks: bool = True,
+    ):
         """
         Initialize the Requirement instance
 
@@ -956,7 +1000,10 @@ class Requirement(ABC):
             try:
                 self._level_from_path = LevelCollection.get(self._path.parent.name)
             except ValueError:
-                logger.debug("The requirement level could not be determined from the path: %s", self._path)
+                logger.debug(
+                    "The requirement level could not be determined from the path: %s",
+                    self._path,
+                )
         return self._level_from_path
 
     @property
@@ -966,8 +1013,9 @@ class Requirement(ABC):
     @property
     def description(self) -> str:
         if not self._description:
-            self._description = self.__class__.__doc__.strip(
-            ) if self.__class__.__doc__ else f"Profile Requirement {self.name}"
+            self._description = (
+                self.__class__.__doc__.strip() if self.__class__.__doc__ else f"Profile Requirement {self.name}"
+            )
         return self._description
 
     @property
@@ -1014,45 +1062,74 @@ class Requirement(ABC):
 
         :meta private:
         """
-        logger.debug("Validating Requirement %s with %s checks", self.name, len(self._checks))
+        logger.debug(
+            "Validating Requirement %s with %s checks",
+            self.name,
+            len(self._checks),
+        )
 
-        logger.debug("Running %s checks for Requirement '%s'", len(self._checks), self.name)
+        logger.debug(
+            "Running %s checks for Requirement '%s'",
+            len(self._checks),
+            self.name,
+        )
         all_passed = True
         checks_to_perform = [
-            _ for _ in self._checks
-            if not context.settings.skip_checks
-            or _.identifier not in context.settings.skip_checks
+            _
+            for _ in self._checks
+            if not context.settings.skip_checks or _.identifier not in context.settings.skip_checks
         ]
         for check in checks_to_perform:
             try:
                 if check.overridden and not check.requirement.profile.identifier == context.profile_identifier:
-                    logger.debug("Skipping check '%s' because overridden by '%r'",
-                                 check.identifier, [_.identifier for _ in check.overridden_by])
+                    logger.debug(
+                        "Skipping check '%s' because overridden by '%r'",
+                        check.identifier,
+                        [_.identifier for _ in check.overridden_by],
+                    )
                     continue
                 # Determine whether to skip event notification for inherited profiles
                 skip_event_notify = False
-                if check.requirement.profile.identifier != context.profile_identifier and \
-                        context.settings.disable_inherited_profiles_issue_reporting:
-                    logger.debug("Inherited profiles reporting disabled. "
-                                 "Skipping requirement %s as it belongs to an inherited profile %s",
-                                 check.requirement.identifier, check.requirement.profile.identifier)
+                if (
+                    check.requirement.profile.identifier != context.profile_identifier
+                    and context.settings.disable_inherited_profiles_issue_reporting
+                ):
+                    logger.debug(
+                        "Inherited profiles reporting disabled. "
+                        "Skipping requirement %s as it belongs to an inherited profile %s",
+                        check.requirement.identifier,
+                        check.requirement.profile.identifier,
+                    )
                     skip_event_notify = True
                 # Notify the start of the check execution if not skip_event_notify is set to True
                 if not skip_event_notify:
-                    context.validator.notify(RequirementCheckValidationEvent(
-                        EventType.REQUIREMENT_CHECK_VALIDATION_START, check))
+                    context.validator.notify(
+                        RequirementCheckValidationEvent(EventType.REQUIREMENT_CHECK_VALIDATION_START, check)
+                    )
                 # Execute the check
                 check_result = check.execute_check(context)
                 logger.debug("Result of check %s: %s", check.identifier, check_result)
                 context.result._add_executed_check(check, check_result)
                 # Notify the end of the check execution if not skip_event_notify is set to True
                 if not skip_event_notify:
-                    context.validator.notify(RequirementCheckValidationEvent(
-                        EventType.REQUIREMENT_CHECK_VALIDATION_END, check, validation_result=check_result))
-                logger.debug("Ran check '%s'. Got result %s", check.identifier, check_result)
+                    context.validator.notify(
+                        RequirementCheckValidationEvent(
+                            EventType.REQUIREMENT_CHECK_VALIDATION_END,
+                            check,
+                            validation_result=check_result,
+                        )
+                    )
+                logger.debug(
+                    "Ran check '%s'. Got result %s",
+                    check.identifier,
+                    check_result,
+                )
                 # Ensure the check result is a boolean
                 if not isinstance(check_result, bool):
-                    logger.warning("Ignoring the check %s as it returned the value %r instead of a boolean", check.name)
+                    logger.warning(
+                        "Ignoring the check %s as it returned the value %r instead of a boolean",
+                        check.name,
+                    )
                     raise RuntimeError(f"Ignoring invalid result from check {check.name}")
                 # Aggregate the check result
                 all_passed = all_passed and check_result
@@ -1070,15 +1147,17 @@ class Requirement(ABC):
                     logger.exception(e)
         skipped_checks = set(self._checks) - set(checks_to_perform)
         context.result.skipped_checks.update(skipped_checks)
-        logger.debug("Checks for Requirement '%s' completed. Checks passed? %s", self.name, all_passed)
+        logger.debug(
+            "Checks for Requirement '%s' completed. Checks passed? %s",
+            self.name,
+            all_passed,
+        )
         return all_passed
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Requirement):
             raise TypeError(f"Cannot compare {type(self)} with {type(other)}")
-        return self.name == other.name \
-            and self.description == other.description \
-            and self.path == other.path
+        return self.name == other.name and self.description == other.description and self.path == other.path
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
@@ -1089,16 +1168,20 @@ class Requirement(ABC):
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, Requirement):
             raise ValueError(f"Cannot compare Requirement with {type(other)}")
-        return (self._order_number, self.name) < (other._order_number, other.name)
+        return (self._order_number, self.name) < (
+            other._order_number,
+            other.name,
+        )
 
     def __repr__(self):
         return (
-            f'ProfileRequirement('
-            f'_order_number={self._order_number}, '
-            f'name={self.name}, '
-            f'description={self.description}'
-            f', path={self.path}, ' if self.path else ''
-            ')'
+            f"ProfileRequirement("
+            f"_order_number={self._order_number}, "
+            f"name={self.name}, "
+            f"description={self.description}"
+            f", path={self.path}, "
+            if self.path
+            else ")"
         )
 
     def __str__(self) -> str:
@@ -1109,7 +1192,7 @@ class Requirement(ABC):
             "identifier": self.identifier,
             "name": self.name,
             "description": self.description,
-            "order": self.order_number
+            "order": self.order_number,
         }
         if with_profile:
             result["profile"] = self.profile.to_dict()
@@ -1268,12 +1351,14 @@ class RequirementLoader:
 @total_ordering
 class RequirementCheck(ABC):
 
-    def __init__(self,
-                 requirement: Requirement,
-                 name: str,
-                 level: Optional[RequirementLevel] = LevelCollection.REQUIRED,
-                 description: Optional[str] = None,
-                 hidden: Optional[bool] = None):
+    def __init__(
+        self,
+        requirement: Requirement,
+        name: str,
+        level: Optional[RequirementLevel] = LevelCollection.REQUIRED,
+        description: Optional[str] = None,
+        hidden: Optional[bool] = None,
+    ):
         self._requirement: Requirement = requirement
         self._order_number = 0
         self._name = name
@@ -1317,9 +1402,7 @@ class RequirementCheck(ABC):
 
     @property
     def level(self) -> RequirementLevel:
-        return self._level or \
-            self.requirement.requirement_level_from_path or \
-            LevelCollection.REQUIRED
+        return self._level or self.requirement.requirement_level_from_path or LevelCollection.REQUIRED
 
     @property
     def severity(self) -> Severity:
@@ -1364,7 +1447,7 @@ class RequirementCheck(ABC):
             "order": self.order_number,
             "name": self.name,
             "description": self.description,
-            "severity": self.severity.name
+            "severity": self.severity.name,
         }
         if with_requirement:
             result["requirement"] = self.requirement.to_dict(with_profile=with_profile, with_checks=False)
@@ -1378,7 +1461,10 @@ class RequirementCheck(ABC):
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, RequirementCheck):
             raise ValueError(f"Cannot compare RequirementCheck with {type(other)}")
-        return (self.requirement, self.identifier) < (other.requirement, other.identifier)
+        return (self.requirement, self.identifier) < (
+            other.requirement,
+            other.identifier,
+        )
 
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
@@ -1394,12 +1480,14 @@ class CheckIssue:
     during the validation process.
     """
 
-    def __init__(self,
-                 check: RequirementCheck,
-                 message: Optional[str] = None,
-                 violatingProperty: Optional[str] = None,
-                 violatingEntity: Optional[str] = None,
-                 value: Optional[str] = None):
+    def __init__(
+        self,
+        check: RequirementCheck,
+        message: Optional[str] = None,
+        violatingProperty: Optional[str] = None,
+        violatingEntity: Optional[str] = None,
+        value: Optional[str] = None,
+    ):
         self._message = message
         self._check: RequirementCheck = check
         self._violatingProperty = violatingProperty
@@ -1464,9 +1552,7 @@ class CheckIssue:
         return self._propertyValue
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, CheckIssue) and \
-            self._check == other._check and \
-            self._message == other._message
+        return isinstance(other, CheckIssue) and self._check == other._check and self._message == other._message
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, CheckIssue):
@@ -1477,34 +1563,43 @@ class CheckIssue:
         return hash((self._check, self._message))
 
     def __repr__(self) -> str:
-        return f'CheckIssue(severity={self.severity}, check={self.check}, message={self.message})'
+        return f"CheckIssue(severity={self.severity}, check={self.check}, message={self.message})"
 
     def __str__(self) -> str:
-        return f"Issue of severity {self.severity.name} with check \"{self.check.identifier}\": {self.message}"
+        return f'Issue of severity {self.severity.name} with check "{self.check.identifier}": {self.message}'
 
-    def to_dict(self, with_check: bool = True,
-                with_requirement: bool = True, with_profile: bool = True) -> dict:
+    def to_dict(
+        self,
+        with_check: bool = True,
+        with_requirement: bool = True,
+        with_profile: bool = True,
+    ) -> dict:
         result = {
             "severity": self.severity.name,
             "message": self.message,
             "violatingEntity": self.violatingEntity,
             "violatingProperty": self.violatingProperty,
-            "violatingPropertyValue": self.violatingPropertyValue
+            "violatingPropertyValue": self.violatingPropertyValue,
         }
         if with_check:
             result["check"] = self.check.to_dict(with_requirement=with_requirement, with_profile=with_profile)
         return result
 
-    def to_json(self,
-                with_checks: bool = True,
-                with_requirements: bool = True,
-                with_profile: bool = True) -> str:
+    def to_json(
+        self,
+        with_checks: bool = True,
+        with_requirements: bool = True,
+        with_profile: bool = True,
+    ) -> str:
         return json.dumps(
             self.to_dict(
                 with_check=with_checks,
                 with_requirement=with_requirements,
-                with_profile=with_profile
-            ), indent=4, cls=CustomEncoder)
+                with_profile=with_profile,
+            ),
+            indent=4,
+            cls=CustomEncoder,
+        )
 
 
 class ValidationStatisticsListener(Protocol):
@@ -1521,9 +1616,12 @@ class ValidationStatistics(Subscriber):
     Computes and stores statistical metrics about the RO-Crate validation process.
     """
 
-    def __init__(self, settings: Union[dict, ValidationSettings],
-                 context: Optional[ValidationContext] = None,
-                 skip_initialization: bool = False):
+    def __init__(
+        self,
+        settings: Union[dict, ValidationSettings],
+        context: Optional[ValidationContext] = None,
+        skip_initialization: bool = False,
+    ):
         if isinstance(settings, dict):
             settings = ValidationSettings.parse(settings)
         self._settings = settings
@@ -1717,7 +1815,8 @@ class ValidationStatistics(Subscriber):
             validation_settings.profiles_path,
             extra_profiles_path=validation_settings.extra_profiles_path,
             severity=severity_validation,
-            allow_requirement_check_override=validation_settings.allow_requirement_check_override)
+            allow_requirement_check_override=validation_settings.allow_requirement_check_override,
+        )
         profile: Profile = Profile.find_in_list(profiles, validation_settings.profile_identifier)
         target_profile_identifier = profile.identifier
         # initialize the profiles list
@@ -1734,7 +1833,11 @@ class ValidationStatistics(Subscriber):
         requirements: set[Requirement] = set()
 
         # Initialize the counters
-        for severity in (Severity.REQUIRED, Severity.RECOMMENDED, Severity.OPTIONAL):
+        for severity in (
+            Severity.REQUIRED,
+            Severity.RECOMMENDED,
+            Severity.OPTIONAL,
+        ):
             checks_by_severity[severity] = set()
 
         # Process the requirements and checks
@@ -1748,26 +1851,23 @@ class ValidationStatistics(Subscriber):
                     continue
 
                 requirement_checks_count = 0
-                for severity in (Severity.REQUIRED, Severity.RECOMMENDED, Severity.OPTIONAL):
+                for severity in (
+                    Severity.REQUIRED,
+                    Severity.RECOMMENDED,
+                    Severity.OPTIONAL,
+                ):
                     logger.debug(
-                        f"Checking requirement: {requirement} severity: {severity} {severity < severity_validation}")
+                        f"Checking requirement: {requirement} severity: {severity} {severity < severity_validation}"
+                    )
                     # skip requirements with lower severity
                     if severity < severity_validation:
                         continue
                     # count the checks
                     requirement_checks = [
                         _
-                        for _ in requirement.get_checks_by_level(
-                            LevelCollection.get(severity.name)
-                        )
-                        if (
-                            not validation_settings.skip_checks
-                            or _.identifier not in validation_settings.skip_checks
-                        )
-                        and (
-                            not _.overridden
-                            or _.requirement.profile.identifier == target_profile_identifier
-                        )
+                        for _ in requirement.get_checks_by_level(LevelCollection.get(severity.name))
+                        if (not validation_settings.skip_checks or _.identifier not in validation_settings.skip_checks)
+                        and (not _.overridden or _.requirement.profile.identifier == target_profile_identifier)
                     ]
                     num_checks = len(requirement_checks)
                     requirement_checks_count += num_checks
@@ -1787,7 +1887,11 @@ class ValidationStatistics(Subscriber):
                     requirements.add(requirement)
 
         # log processed requirements
-        logger.debug("Processed requirements %r: %r", len(processed_requirements), processed_requirements)
+        logger.debug(
+            "Processed requirements %r: %r",
+            len(processed_requirements),
+            processed_requirements,
+        )
 
         # Prepare the result
         result = {
@@ -1805,7 +1909,7 @@ class ValidationStatistics(Subscriber):
             "finished_at": None,
             "validated_profiles": [],
             "validated_requirements": [],
-            "validated_checks": []
+            "validated_checks": [],
         }
         logger.debug(result)
         return result
@@ -1823,9 +1927,10 @@ class ValidationStatistics(Subscriber):
             logger.debug("Requirement check validation start")
         elif event.event_type == EventType.REQUIREMENT_CHECK_VALIDATION_END:
             target_profile = ctx.target_validation_profile
-            if not event.requirement_check.requirement.hidden and \
-                    (not event.requirement_check.overridden
-                     or target_profile.identifier == event.requirement_check.requirement.profile.identifier):
+            if not event.requirement_check.requirement.hidden and (
+                not event.requirement_check.overridden
+                or target_profile.identifier == event.requirement_check.requirement.profile.identifier
+            ):
                 if event.validation_result is not None:
                     if event.validation_result:
                         self._stats["passed_checks"].append(event.requirement_check)
@@ -1834,10 +1939,15 @@ class ValidationStatistics(Subscriber):
                     self._stats["validated_checks"].append(event.requirement_check)
                     self.notify_listeners()
                 else:
-                    logger.debug("Requirement check validation result is None: %s",
-                                 event.requirement_check.identifier)
+                    logger.debug(
+                        "Requirement check validation result is None: %s",
+                        event.requirement_check.identifier,
+                    )
             else:
-                logger.debug("Skipping requirement check validation: %s", event.requirement_check.identifier)
+                logger.debug(
+                    "Skipping requirement check validation: %s",
+                    event.requirement_check.identifier,
+                )
         elif event.event_type == EventType.REQUIREMENT_VALIDATION_END:
             if not event.requirement.hidden:
                 if event.validation_result:
@@ -1863,12 +1973,10 @@ class ValidationStatistics(Subscriber):
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "finished_at": self.finished_at.isoformat() if self.finished_at else None,
             "duration": self.duration,
-
             # Profile details
             "profile": self.profile.identifier if self.profile else None,
             "profiles": [p.identifier for p in self.profiles],
             "severity": self.severity.name if self.severity else None,
-
             # Computed totals
             "total_requirements": self.total_requirements,
             "total_passed_requirements": len(self.passed_requirements),
@@ -1877,43 +1985,45 @@ class ValidationStatistics(Subscriber):
             "total_passed_checks": len(self.passed_checks),
             "total_failed_checks": len(self.failed_checks),
             "total_checks_by_severity": {k.name: len(v) for k, v in self.checks_by_severity.items()},
-
             # Requirements involved
             "requirements": {
                 "count": self.total_requirements,
                 "passed": {
                     "count": len(self.passed_requirements),
-                    "percentage": (len(self.passed_requirements) / self.total_requirements * 100)
-                    if self.total_requirements > 0 else 0.0,
-                    "identifiers": sorted([r.identifier for r in self.passed_requirements])
+                    "percentage": (
+                        (len(self.passed_requirements) / self.total_requirements * 100)
+                        if self.total_requirements > 0
+                        else 0.0
+                    ),
+                    "identifiers": sorted([r.identifier for r in self.passed_requirements]),
                 },
                 "failed": {
                     "count": len(self.failed_requirements),
-                    "percentage": (len(self.failed_requirements) / self.total_requirements * 100)
-                    if self.total_requirements > 0 else 0.0,
-                    "identifiers": sorted([r.identifier for r in self.failed_requirements])
+                    "percentage": (
+                        (len(self.failed_requirements) / self.total_requirements * 100)
+                        if self.total_requirements > 0
+                        else 0.0
+                    ),
+                    "identifiers": sorted([r.identifier for r in self.failed_requirements]),
                 },
-                "identifiers": sorted([r.identifier for r in self.requirements])
+                "identifiers": sorted([r.identifier for r in self.requirements]),
             },
-
             # Checks involved
             "checks": {
                 "count": self.total_checks,
                 "passed": {
                     "count": len(self.passed_checks),
-                    "percentage": (len(self.passed_checks) / self.total_checks * 100)
-                    if self.total_checks > 0 else 0.0,
-                    "identifiers": sorted([c.identifier for c in self.passed_checks])
+                    "percentage": (len(self.passed_checks) / self.total_checks * 100) if self.total_checks > 0 else 0.0,
+                    "identifiers": sorted([c.identifier for c in self.passed_checks]),
                 },
                 "failed": {
                     "count": len(self.failed_checks),
-                    "percentage": (len(self.failed_checks) / self.total_checks * 100)
-                    if self.total_checks > 0 else 0.0,
-                    "identifiers": sorted([c.identifier for c in self.failed_checks])
+                    "percentage": (len(self.failed_checks) / self.total_checks * 100) if self.total_checks > 0 else 0.0,
+                    "identifiers": sorted([c.identifier for c in self.failed_checks]),
                 },
                 "identifiers": sorted([c.identifier for c in self.checks]),
-                "by_severity": {k.name: len(v) for k, v in self._stats.get("checks_by_severity", {}).items()}
-            }
+                "by_severity": {k.name: len(v) for k, v in self._stats.get("checks_by_severity", {}).items()},
+            },
         }
 
     def to_json(self) -> str:
@@ -1953,10 +2063,8 @@ class AggregatedValidationStatistics:
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "finished_at": self.finished_at.isoformat() if self.finished_at else None,
             "duration": self.duration,
-
             # Profiles involved
             "profiles": [p.identifier for p in self.profiles],
-
             # Computed totals
             "total_requirements": self.total_requirements,
             "total_passed_requirements": len(self.passed_requirements),
@@ -1965,40 +2073,43 @@ class AggregatedValidationStatistics:
             "total_passed_checks": len(self.passed_checks),
             "total_failed_checks": len(self.failed_checks),
             "total_checks_by_severity": {k.name: len(v) for k, v in self.checks_by_severity.items()},
-
             # Requirements involved
             "requirements": {
                 "count": self.total_requirements,
                 "passed": {
                     "count": len(self.passed_requirements),
-                    "percentage": (len(self.passed_requirements) / self.total_requirements * 100)
-                    if self.total_requirements > 0 else 0.0,
-                    "identifiers": [r.identifier for r in self.passed_requirements]
+                    "percentage": (
+                        (len(self.passed_requirements) / self.total_requirements * 100)
+                        if self.total_requirements > 0
+                        else 0.0
+                    ),
+                    "identifiers": [r.identifier for r in self.passed_requirements],
                 },
                 "failed": {
                     "count": len(self.failed_requirements),
-                    "percentage": (len(self.failed_requirements) / self.total_requirements * 100)
-                    if self.total_requirements > 0 else 0.0,
-                    "identifiers": [r.identifier for r in self.failed_requirements]
+                    "percentage": (
+                        (len(self.failed_requirements) / self.total_requirements * 100)
+                        if self.total_requirements > 0
+                        else 0.0
+                    ),
+                    "identifiers": [r.identifier for r in self.failed_requirements],
                 },
-                "identifiers": [r.identifier for r in self.requirements]
+                "identifiers": [r.identifier for r in self.requirements],
             },
             # Checks involved
             "checks": {
                 "count": self.total_checks,
                 "passed": {
                     "count": len(self.passed_checks),
-                    "percentage": (len(self.passed_checks) / self.total_checks * 100)
-                    if self.total_checks > 0 else 0.0,
-                    "identifiers": [c.identifier for c in self.passed_checks]
+                    "percentage": (len(self.passed_checks) / self.total_checks * 100) if self.total_checks > 0 else 0.0,
+                    "identifiers": [c.identifier for c in self.passed_checks],
                 },
                 "failed": {
                     "count": len(self.failed_checks),
-                    "percentage": (len(self.failed_checks) / self.total_checks * 100)
-                    if self.total_checks > 0 else 0.0,
-                    "identifiers": [c.identifier for c in self.failed_checks]
+                    "percentage": (len(self.failed_checks) / self.total_checks * 100) if self.total_checks > 0 else 0.0,
+                    "identifiers": [c.identifier for c in self.failed_checks],
                 },
-                "identifiers": [c.identifier for c in self.checks]
+                "identifiers": [c.identifier for c in self.checks],
             },
         }
 
@@ -2116,7 +2227,7 @@ class AggregatedValidationStatistics:
             "passed_checks": set(),
             "started_at": None,
             "finished_at": None,
-            "duration": 0.0
+            "duration": 0.0,
         }
 
         # Aggregate statistics from each ValidationStatistics instance
@@ -2137,10 +2248,12 @@ class AggregatedValidationStatistics:
             result["passed_checks"].update(stats.passed_checks)
 
             # Aggregate started_at and finished_at
-            result["started_at"] = min(result["started_at"], stats.started_at) \
-                if result["started_at"] else stats.started_at
-            result["finished_at"] = max(result["finished_at"], stats.finished_at) \
-                if result["finished_at"] else stats.finished_at
+            result["started_at"] = (
+                min(result["started_at"], stats.started_at) if result["started_at"] else stats.started_at
+            )
+            result["finished_at"] = (
+                max(result["finished_at"], stats.finished_at) if result["finished_at"] else stats.finished_at
+            )
             # Aggregate duration
             result["duration"] += stats.duration or 0.0
 
@@ -2148,8 +2261,9 @@ class AggregatedValidationStatistics:
         result["profiles"] = sorted(result["profiles"], key=lambda p: p.identifier)
         result["requirements"] = sorted(result["requirements"], key=lambda r: r.identifier)
         result["checks"] = sorted(result["checks"], key=lambda c: c.identifier)
-        result["checks_by_severity"] = {k: sorted(v, key=lambda c: c.identifier)
-                                        for k, v in result["checks_by_severity"].items()}
+        result["checks_by_severity"] = {
+            k: sorted(v, key=lambda c: c.identifier) for k, v in result["checks_by_severity"].items()
+        }
         result["failed_requirements"] = sorted(result["failed_requirements"], key=lambda r: r.identifier)
         result["failed_checks"] = sorted(result["failed_checks"], key=lambda c: c.identifier)
         result["passed_requirements"] = sorted(result["passed_requirements"], key=lambda r: r.identifier)
@@ -2217,6 +2331,7 @@ class ValidationResult:
         The validation statistics
         """
         return self._statistics
+
     # --- Checks ---
 
     @property
@@ -2277,9 +2392,7 @@ class ValidationResult:
         min_severity = min_severity or self.context.requirement_severity
         return [issue for issue in self._issues if issue.severity >= min_severity]
 
-    def get_issues_by_check(self,
-                            check: RequirementCheck,
-                            min_severity: Severity = None) -> list[CheckIssue]:
+    def get_issues_by_check(self, check: RequirementCheck, min_severity: Severity = None) -> list[CheckIssue]:
         """
         Get the issues found during the validation for a specific check
         with a severity greater than or equal to `min_severity`
@@ -2304,12 +2417,14 @@ class ValidationResult:
         min_severity = min_severity or self.context.requirement_severity
         return not any(issue.severity >= min_severity for issue in self._issues)
 
-    def add_issue(self,
-                  message: str,
-                  check: RequirementCheck,
-                  violatingEntity: Optional[str] = None,
-                  violatingProperty: Optional[str] = None,
-                  violatingPropertyValue: Optional[str] = None) -> CheckIssue:
+    def add_issue(
+        self,
+        message: str,
+        check: RequirementCheck,
+        violatingEntity: Optional[str] = None,
+        violatingProperty: Optional[str] = None,
+        violatingPropertyValue: Optional[str] = None,
+    ) -> CheckIssue:
         """
         Add an issue to the validation result
 
@@ -2320,8 +2435,13 @@ class ValidationResult:
             violatingProperty(Optional[str]): The property that caused the issue (if any)
             violatingPropertyValue(Optional[str]): The value of the violatingProperty (if any)
         """
-        c = CheckIssue(check, message, violatingProperty=violatingProperty,
-                       violatingEntity=violatingEntity, value=violatingPropertyValue)
+        c = CheckIssue(
+            check,
+            message,
+            violatingProperty=violatingProperty,
+            violatingEntity=violatingEntity,
+            value=violatingPropertyValue,
+        )
         bisect.insort(self._issues, c)
         return c
 
@@ -2348,13 +2468,14 @@ class ValidationResult:
         return [check for check in self.failed_checks if check.requirement == requirement]
 
     def get_failed_checks_by_requirement_and_severity(
-            self, requirement: Requirement, severity: Severity) -> Collection[RequirementCheck]:
+        self, requirement: Requirement, severity: Severity
+    ) -> Collection[RequirementCheck]:
         """
         Get the checks that failed for a specific requirement and severity
         """
-        return [check for check in self.failed_checks
-                if check.requirement == requirement
-                and check.severity == severity]
+        return [
+            check for check in self.failed_checks if check.requirement == requirement and check.severity == severity
+        ]
 
     def __str__(self) -> str:
         return f"Validation result: passed={len(self.failed_checks) == 0}, {len(self._issues)} issues"
@@ -2371,17 +2492,20 @@ class ValidationResult:
         """
         Convert the ValidationResult to a dictionary
         """
-        allowed_properties = ["profile_identifier", "enable_profile_inheritance",
-                              "requirement_severity", "abort_on_first"]
-        validation_settings = {key: value for key, value in self.validation_settings.to_dict().items()
-                               if key in allowed_properties}
+        allowed_properties = [
+            "profile_identifier",
+            "enable_profile_inheritance",
+            "requirement_severity",
+            "abort_on_first",
+        ]
+        validation_settings = {
+            key: value for key, value in self.validation_settings.to_dict().items() if key in allowed_properties
+        }
         result = {
-            "meta": {
-                "version": JSON_OUTPUT_FORMAT_VERSION
-            },
+            "meta": {"version": JSON_OUTPUT_FORMAT_VERSION},
             "validation_settings": validation_settings,
             "passed": self.passed(self.context.settings.requirement_severity),
-            "issues": [issue.to_dict() for issue in self.issues]
+            "issues": [issue.to_dict() for issue in self.issues],
         }
         # add validator version to the settings
         result["validation_settings"]["rocrate_validator_version"] = __version__
@@ -2423,6 +2547,7 @@ class ValidationSettings:
 
     It includes the following attributes:
     """
+
     #: The URI of the RO-Crate
     rocrate_uri: URI
     #: The relative root path of the RO-Crate
@@ -2480,20 +2605,23 @@ class ValidationSettings:
             self.requirement_severity = Severity[self.requirement_severity]
         # initialize the HTTP cache
         HttpRequester.initialize_cache(cache_path=self.cache_path, cache_max_age=self.cache_max_age)
-        logger.debug("HTTP cache initialized at %s with max age %s seconds",
-                     self.cache_path, self.cache_max_age)
+        logger.debug(
+            "HTTP cache initialized at %s with max age %s seconds",
+            self.cache_path,
+            self.cache_max_age,
+        )
 
     def to_dict(self):
         """
         Convert the ValidationSettings to a dictionary
         """
         result = asdict(self)
-        result['rocrate_uri'] = str(self.rocrate_uri)
-        result.pop('metadata_dict', None)  # exclude metadata_dict from the dict representation
+        result["rocrate_uri"] = str(self.rocrate_uri)
+        result.pop("metadata_dict", None)  # exclude metadata_dict from the dict representation
         # Remove disable_crate_download from the dict representation
-        result.pop('disable_remote_crate_download', None)
+        result.pop("disable_remote_crate_download", None)
         # Remove requirement_severity_only from the dict representation
-        result.pop('requirement_severity_only', None)
+        result.pop("requirement_severity_only", None)
         return result
 
     @property
@@ -2540,8 +2668,12 @@ class ValidationSettings:
 
 
 class ValidationEvent(Event):
-    def __init__(self, event_type: EventType,
-                 validation_result: Optional[ValidationResult] = None, message: Optional[str] = None):
+    def __init__(
+        self,
+        event_type: EventType,
+        validation_result: Optional[ValidationResult] = None,
+        message: Optional[str] = None,
+    ):
         super().__init__(event_type, message)
         self._validation_result = validation_result
 
@@ -2551,8 +2683,16 @@ class ValidationEvent(Event):
 
 
 class ProfileValidationEvent(Event):
-    def __init__(self, event_type: EventType, profile: Profile, message: Optional[str] = None):
-        assert event_type in (EventType.PROFILE_VALIDATION_START, EventType.PROFILE_VALIDATION_END)
+    def __init__(
+        self,
+        event_type: EventType,
+        profile: Profile,
+        message: Optional[str] = None,
+    ):
+        assert event_type in (
+            EventType.PROFILE_VALIDATION_START,
+            EventType.PROFILE_VALIDATION_END,
+        )
         super().__init__(event_type, message)
         self._profile = profile
 
@@ -2579,12 +2719,17 @@ class ProfileValidationEvent(Event):
 
 
 class RequirementValidationEvent(Event):
-    def __init__(self,
-                 event_type: EventType,
-                 requirement: Requirement,
-                 validation_result: Optional[bool] = None,
-                 message: Optional[str] = None):
-        assert event_type in (EventType.REQUIREMENT_VALIDATION_START, EventType.REQUIREMENT_VALIDATION_END)
+    def __init__(
+        self,
+        event_type: EventType,
+        requirement: Requirement,
+        validation_result: Optional[bool] = None,
+        message: Optional[str] = None,
+    ):
+        assert event_type in (
+            EventType.REQUIREMENT_VALIDATION_START,
+            EventType.REQUIREMENT_VALIDATION_END,
+        )
         super().__init__(event_type, message)
         self._requirement = requirement
         self._validation_result = validation_result
@@ -2616,10 +2761,17 @@ class RequirementValidationEvent(Event):
 
 
 class RequirementCheckValidationEvent(Event):
-    def __init__(self, event_type: EventType,
-                 requirement_check: RequirementCheck,
-                 validation_result: Optional[bool] = None, message: Optional[str] = None):
-        assert event_type in (EventType.REQUIREMENT_CHECK_VALIDATION_START, EventType.REQUIREMENT_CHECK_VALIDATION_END)
+    def __init__(
+        self,
+        event_type: EventType,
+        requirement_check: RequirementCheck,
+        validation_result: Optional[bool] = None,
+        message: Optional[str] = None,
+    ):
+        assert event_type in (
+            EventType.REQUIREMENT_CHECK_VALIDATION_START,
+            EventType.REQUIREMENT_CHECK_VALIDATION_END,
+        )
         super().__init__(event_type, message)
         self._requirement_check = requirement_check
         self._validation_result = validation_result
@@ -2636,8 +2788,9 @@ class RequirementCheckValidationEvent(Event):
         return f"RequirementCheckValidationEvent({self.event_type}, {self.requirement_check})"
 
     def __repr__(self) -> str:
-        return f"RequirementCheckValidationEvent(event_type={self.event_type}, " \
-            f"requirement_check={self.requirement_check})"
+        return (
+            f"RequirementCheckValidationEvent(event_type={self.event_type}, requirement_check={self.requirement_check})"
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RequirementCheckValidationEvent):
@@ -2710,7 +2863,8 @@ class Validator(Publisher):
                 context.profiles_path,
                 extra_profiles_path=context.extra_profiles_path,
                 publicID=context.publicID,
-                severity=context.requirement_severity)
+                severity=context.requirement_severity,
+            )
             profiles = [p for p in available_profiles if p.uri in candidate_profiles_uris]
             # get the candidate profiles
             for profile in profiles:
@@ -2719,7 +2873,11 @@ class Validator(Publisher):
                 for inherited_profile in inherited_profiles:
                     if inherited_profile in candidate_profiles:
                         candidate_profiles.remove(inherited_profile)
-            logger.debug("%d Candidate Profiles found: %s", len(candidate_profiles), candidate_profiles)
+            logger.debug(
+                "%d Candidate Profiles found: %s",
+                len(candidate_profiles),
+                candidate_profiles,
+            )
             # unmatched candidate profiles
             unmatched_profiles = candidate_profiles_uris.difference(set(p.uri for p in profiles))
             logger.debug("Unmatched Candidate Profiles URIs: %s", unmatched_profiles)
@@ -2745,13 +2903,11 @@ class Validator(Publisher):
         """
         Validates the RO-Crate against the specified subset of the profile requirements
         """
-        assert all(isinstance(requirement, Requirement) for requirement in requirements), \
-            "Invalid requirement type"
+        assert all(isinstance(requirement, Requirement) for requirement in requirements), "Invalid requirement type"
         # perform the requirements validation
         return self.__do_validate__(requirements)
 
-    def __do_validate__(self,
-                        requirements: Optional[list[Requirement]] = None) -> ValidationResult:
+    def __do_validate__(self, requirements: Optional[list[Requirement]] = None) -> ValidationResult:
 
         # initialize the validation context
         context = ValidationContext(self, self.validation_settings)
@@ -2761,31 +2917,59 @@ class Validator(Publisher):
         # initialize the requirement types
         self.__invoke_pre_validation_hooks__(context)
 
+        try:
             # set the profiles to validate against
             profiles = context.profiles
             assert len(profiles) > 0, "No profiles to validate"
             self.notify(EventType.VALIDATION_START)
             for profile in profiles:
-                logger.debug("Validating profile %s (id: %s)", profile.name, profile.identifier)
+                logger.debug(
+                    "Validating profile %s (id: %s)",
+                    profile.name,
+                    profile.identifier,
+                )
                 # set the target profile in the context
                 context._target_validation_profile = profile
                 self.notify(ProfileValidationEvent(EventType.PROFILE_VALIDATION_START, profile=profile))
                 # perform the requirements validation
                 requirements = profile.get_requirements(
-                    context.requirement_severity, exact_match=context.requirement_severity_only)
-                logger.debug("Validating profile %s with %s requirements", profile.identifier, len(requirements))
-                logger.debug("For profile %s, validating these %s requirements: %s",
-                             profile.identifier, len(requirements), requirements)
+                    context.requirement_severity,
+                    exact_match=context.requirement_severity_only,
+                )
+                logger.debug(
+                    "Validating profile %s with %s requirements",
+                    profile.identifier,
+                    len(requirements),
+                )
+                logger.debug(
+                    "For profile %s, validating these %s requirements: %s",
+                    profile.identifier,
+                    len(requirements),
+                    requirements,
+                )
                 terminate = False
                 for requirement in requirements:
                     if not requirement.overridden:
-                        self.notify(RequirementValidationEvent(
-                            EventType.REQUIREMENT_VALIDATION_START, requirement=requirement))
+                        self.notify(
+                            RequirementValidationEvent(
+                                EventType.REQUIREMENT_VALIDATION_START,
+                                requirement=requirement,
+                            )
+                        )
                     passed = requirement._do_validate_(context)
-                    logger.debug("Requirement %s passed: %s", requirement.identifier, passed)
+                    logger.debug(
+                        "Requirement %s passed: %s",
+                        requirement.identifier,
+                        passed,
+                    )
                     if not requirement.overridden:
-                        self.notify(RequirementValidationEvent(
-                            EventType.REQUIREMENT_VALIDATION_END, requirement=requirement, validation_result=passed))
+                        self.notify(
+                            RequirementValidationEvent(
+                                EventType.REQUIREMENT_VALIDATION_END,
+                                requirement=requirement,
+                                validation_result=passed,
+                            )
+                        )
                     if passed:
                         logger.debug("Validation Requirement passed")
                     else:
@@ -2823,7 +3007,7 @@ class Validator(Publisher):
         logger.debug("Finalizing requirement types: completed")
 
     def notify(self, event: Union[Event, EventType]):
-        """ Override notify to update statistics """
+        """Override notify to update statistics"""
         assert self.__current_context__ is not None, "No current validation context"
         result: ValidationResult = self.__current_context__.result
         if isinstance(event, EventType):
@@ -2857,8 +3041,10 @@ class ValidationContext:
         if settings.metadata_dict:
             self._rocrate = ROCrate.from_metadata_dict(settings.metadata_dict)
         else:
-            self._rocrate = ROCrate.new_instance(settings.rocrate_uri,
-                                                 relative_root_path=settings.rocrate_relative_root_path)
+            self._rocrate = ROCrate.new_instance(
+                settings.rocrate_uri,
+                relative_root_path=settings.rocrate_relative_root_path,
+            )
         assert isinstance(self._rocrate, ROCrate), "Invalid RO-Crate instance"
 
     @property
@@ -2997,8 +3183,11 @@ class ValidationContext:
     def __load_data_graph__(self) -> Graph:
         data_graph = Graph()
         logger.debug("Loading RO-Crate metadata of: %s", self.ro_crate.uri)
-        _ = data_graph.parse(data=self.ro_crate.metadata.as_dict(),
-                             format="json-ld", publicID=self.publicID)
+        _ = data_graph.parse(
+            data=self.ro_crate.metadata.as_dict(),
+            format="json-ld",
+            publicID=self.publicID,
+        )
         logger.debug("RO-Crate metadata loaded: %s", data_graph)
         return data_graph
 
@@ -3083,7 +3272,8 @@ class ValidationContext:
             extra_profiles_path=self.settings.extra_profiles_path,
             publicID=self.publicID,
             severity=self.requirement_severity,
-            allow_requirement_check_override=self.allow_requirement_check_override)
+            allow_requirement_check_override=self.allow_requirement_check_override,
+        )
 
         # Check if the target profile is in the list of profiles
         profile = Profile.get_by_identifier(self.profile_identifier)
@@ -3104,7 +3294,8 @@ class ValidationContext:
                     logger.exception(e)
                 raise ProfileNotFound(
                     self.profile_identifier,
-                    message=f"Profile '{self.profile_identifier}' not found in '{self.profiles_path}'") from e
+                    message=f"Profile '{self.profile_identifier}' not found in '{self.profiles_path}'",
+                ) from e
 
         # if the inheritance is enabled, return only the target profile
         if not self.inheritance_enabled:

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1144,6 +1144,32 @@ class RequirementLoader:
         return loader_instance
 
     @staticmethod
+    def __get_requirement_classes__() -> list[Type[Requirement]]:
+
+        # Ensure known requirement modules are imported so subclasses are registered.
+        for requirement_type in ("python", "shacl"):
+            module_name = f"rocrate_validator.requirements.{requirement_type}"
+            try:
+                importlib.import_module(module_name)
+            except Exception:
+                logger.debug(
+                    "Unable to import requirement module: %s",
+                    module_name,
+                    exc_info=True,
+                )
+
+        def all_subclasses(
+            base_class: Type[Requirement],
+        ) -> list[Type[Requirement]]:
+            result: list[Type[Requirement]] = []
+            for subcls in base_class.__subclasses__():
+                result.append(subcls)
+                result.extend(all_subclasses(subcls))
+            return result
+
+        return all_subclasses(Requirement)
+
+    @staticmethod
     def load_requirements(profile: Profile, severity: Severity = None) -> list[Requirement]:
         """
         Load the requirements related to the profile
@@ -2682,7 +2708,8 @@ class Validator(Publisher):
         # register the current context
         self.__current_context__ = context
 
-        try:
+        # initialize the requirement types
+        self.__invoke_pre_validation_hooks__(context)
 
             # set the profiles to validate against
             profiles = context.profiles
@@ -2720,13 +2747,30 @@ class Validator(Publisher):
                 self.notify(ProfileValidationEvent(EventType.PROFILE_VALIDATION_END, profile=profile))
                 if terminate:
                     break
-            self.notify(ValidationEvent(EventType.VALIDATION_END,
-                        validation_result=context.result))
 
+            # finalize the requirement types
+            self.__invoke_post_validation_hooks__(context)
+            # notify the end of the validation
+            self.notify(ValidationEvent(EventType.VALIDATION_END, validation_result=context.result))
+            # return the validation result
             return context.result
         finally:
             # clear the current context
             self.__current_context__ = None
+
+    def __invoke_pre_validation_hooks__(self, context: ValidationContext):
+        logger.debug("Initializing requirement types: starting...")
+        requirements_types = RequirementLoader.__get_requirement_classes__()
+        for requirement_type in requirements_types:
+            requirement_type.initialize(context)
+        logger.debug("Initializing requirement types: completed")
+
+    def __invoke_post_validation_hooks__(self, context: ValidationContext):
+        logger.debug("Finalizing requirement types: starting...")
+        requirements_types = RequirementLoader.__get_requirement_classes__()
+        for requirement_type in requirements_types:
+            requirement_type.finalize(context)
+        logger.debug("Finalizing requirement types: completed")
 
     def notify(self, event: Union[Event, EventType]):
         """ Override notify to update statistics """

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import bisect
 import enum
+import importlib
 import inspect
 import json
 import re
@@ -25,35 +26,43 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from functools import total_ordering
 from pathlib import Path
-from typing import Optional, Protocol, Tuple, Union
+from typing import Optional, Protocol, Tuple, Type, Union
 from urllib.error import HTTPError
 
 import enum_tools
 from rdflib import RDF, RDFS, Graph, Namespace, URIRef
 
 from rocrate_validator import __version__
-from rocrate_validator.constants import (DEFAULT_HTTP_CACHE_MAX_AGE,
-                                         DEFAULT_ONTOLOGY_FILE,
-                                         DEFAULT_PROFILE_IDENTIFIER,
-                                         DEFAULT_PROFILE_README_FILE,
-                                         IGNORED_PROFILE_DIRECTORIES,
-                                         JSON_OUTPUT_FORMAT_VERSION, PROF_NS,
-                                         PROFILE_FILE_EXTENSIONS,
-                                         PROFILE_SPECIFICATION_FILE,
-                                         ROCRATE_METADATA_FILE, SCHEMA_ORG_NS)
-from rocrate_validator.errors import (DuplicateRequirementCheck,
-                                      InvalidProfilePath, ProfileNotFound,
-                                      ProfileSpecificationError,
-                                      ProfileSpecificationNotFound,
-                                      ROCrateMetadataNotFoundError)
+from rocrate_validator.constants import (
+    DEFAULT_HTTP_CACHE_MAX_AGE,
+    DEFAULT_ONTOLOGY_FILE,
+    DEFAULT_PROFILE_IDENTIFIER,
+    DEFAULT_PROFILE_README_FILE,
+    IGNORED_PROFILE_DIRECTORIES,
+    JSON_OUTPUT_FORMAT_VERSION,
+    PROF_NS,
+    PROFILE_FILE_EXTENSIONS,
+    PROFILE_SPECIFICATION_FILE,
+    ROCRATE_METADATA_FILE,
+    SCHEMA_ORG_NS,
+)
+from rocrate_validator.errors import (
+    DuplicateRequirementCheck,
+    InvalidProfilePath,
+    ProfileNotFound,
+    ProfileSpecificationError,
+    ProfileSpecificationNotFound,
+    ROCrateMetadataNotFoundError,
+)
 from rocrate_validator.events import Event, EventType, Publisher, Subscriber
 from rocrate_validator.rocrate import ROCrate
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.collections import MapIndex, MultiIndexMap
 from rocrate_validator.utils.http import HttpRequester
 from rocrate_validator.utils.paths import get_profiles_path
-from rocrate_validator.utils.python_helpers import \
-    get_requirement_name_from_file
+from rocrate_validator.utils.python_helpers import (
+    get_requirement_name_from_file,
+)
 from rocrate_validator.utils.uri import URI
 
 # set the default profiles path
@@ -1108,9 +1117,36 @@ class Requirement(ABC):
             result["checks"] = [_.to_dict(with_requirement=False, with_profile=False) for _ in self._checks]
         return result
 
+    @classmethod
+    def initialize(cls, context: ValidationContext) -> None:
+        logger.debug(
+            "Starting %s requirement initialization for context %s",
+            cls.__name__,
+            context,
+        )
+        # do initialization logic here (empty for now)
+        logger.debug(
+            "Completed %s requirement initialization for context %s",
+            cls.__name__,
+            context,
+        )
+
+    @classmethod
+    def finalize(cls, context: ValidationContext) -> None:
+        logger.debug(
+            "Starting %s requirement finalization for context %s",
+            cls.__name__,
+            context,
+        )
+        # do finalization logic here (empty for now)
+        logger.debug(
+            "Completed %s requirement finalization for context %s",
+            cls.__name__,
+            context,
+        )
+
 
 class RequirementLoader:
-
     def __init__(self, profile: Profile):
         self._profile = profile
 
@@ -1129,7 +1165,6 @@ class RequirementLoader:
 
     @classmethod
     def __get_requirement_loader__(cls, profile: Profile, requirement_path: Path) -> RequirementLoader:
-        import importlib
         requirement_type = cls.__get_requirement_type__(requirement_path)
         loader_instance_name = f"_{requirement_type}_loader_instance"
         loader_instance = getattr(profile, loader_instance_name, None)
@@ -1174,16 +1209,21 @@ class RequirementLoader:
         """
         Load the requirements related to the profile
         """
-        def ok_file(p: Path) -> bool:
-            return p.is_file() \
-                and p.suffix in PROFILE_FILE_EXTENSIONS \
-                and not p.name == DEFAULT_ONTOLOGY_FILE \
-                and not p.name == PROFILE_SPECIFICATION_FILE \
-                and not p.name.startswith('.') \
-                and not p.name.startswith('_')
 
-        files = sorted((p for p in profile.path.rglob('*.*') if ok_file(p)),
-                       key=lambda x: (not x.suffix == '.py', x))
+        def ok_file(p: Path) -> bool:
+            return (
+                p.is_file()
+                and p.suffix in PROFILE_FILE_EXTENSIONS
+                and not p.name == DEFAULT_ONTOLOGY_FILE
+                and not p.name == PROFILE_SPECIFICATION_FILE
+                and not p.name.startswith(".")
+                and not p.name.startswith("_")
+            )
+
+        files = sorted(
+            (p for p in profile.path.rglob("*.*") if ok_file(p)),
+            key=lambda x: (not x.suffix == ".py", x),
+        )
 
         # set the requirement level corresponding to the severity
         requirement_level = LevelCollection.get(severity.name)
@@ -1195,23 +1235,33 @@ class RequirementLoader:
                 if requirement_level_from_path < requirement_level:
                     continue
             except ValueError:
-                logger.debug("The requirement level could not be determined from the path: %s", requirement_path)
+                logger.debug(
+                    "The requirement level could not be determined from the path: %s",
+                    requirement_path,
+                )
             requirement_loader = RequirementLoader.__get_requirement_loader__(profile, requirement_path)
             for requirement in requirement_loader.load(
-                    profile, requirement_level,
-                    requirement_path, publicID=profile.publicID):
+                profile,
+                requirement_level,
+                requirement_path,
+                publicID=profile.publicID,
+            ):
                 requirements.append(requirement)
         # sort the requirements by severity
-        requirements = sorted(requirements,
-                              key=lambda x: (-x.severity_from_path.value, x.path.name, x.name)
-                              if x.severity_from_path is not None else (0, x.path.name, x.name),
-                              reverse=False)
+        requirements = sorted(
+            requirements,
+            key=lambda x: (
+                (-x.severity_from_path.value, x.path.name, x.name)
+                if x.severity_from_path is not None
+                else (0, x.path.name, x.name)
+            ),
+            reverse=False,
+        )
         # assign order numbers to requirements
         for i, requirement in enumerate(requirements):
             requirement._order_number = i + 1
         # log and return the requirements
-        logger.debug("Profile %s loaded %s requirements: %s",
-                     profile.identifier, len(requirements), requirements)
+        logger.debug("Profile %s loaded %s requirements: %s", profile.identifier, len(requirements), requirements)
         return requirements
 
 

--- a/rocrate_validator/requirements/shacl/requirements.py
+++ b/rocrate_validator/requirements/shacl/requirements.py
@@ -19,8 +19,14 @@ from rdflib import RDF
 
 from rocrate_validator.utils import log as logging
 from rocrate_validator.constants import VALIDATOR_NS
-from rocrate_validator.models import (Profile, Requirement, RequirementCheck,
-                                      RequirementLevel, RequirementLoader)
+from rocrate_validator.models import (
+    Profile,
+    Requirement,
+    RequirementCheck,
+    RequirementLevel,
+    RequirementLoader,
+    ValidationContext,
+)
 from rocrate_validator.requirements.shacl.checks import SHACLCheck
 from rocrate_validator.requirements.shacl.models import Shape, ShapesRegistry
 
@@ -82,9 +88,67 @@ class SHACLRequirement(Requirement):
                 return True
         return False
 
+    @classmethod
+    def finalize(cls, context: ValidationContext) -> None:
+        """ "
+        Finalize the SHACL requirement by ensuring that a SHACL validation run is triggered for the target profile
+        if it has no shapes of its own (e.g. an extension profile that purely inherits or only deactivates).
+
+        SHACL is normally driven by the first execute_check of a check
+        belonging to the target profile (see SHACLValidationContextManager).
+        If the target has zero SHACL checks of its own (e.g. an extension
+        profile that purely inherits or only deactivates), no pyshacl run
+        is ever triggered and inherited shapes are never evaluated.
+        Force one final run on the merged shapes graph in that case.
+        """
+
+        logger.debug("Starting %s requirement finalization for context %s", cls.__name__, context)
+
+        # extract profiles and target profile from context
+        profiles = context.profiles
+
+        from rocrate_validator.requirements.shacl.checks import SHACLCheck
+        from rocrate_validator.requirements.shacl.validator import SHACLValidationContext
+
+        target = next((p for p in profiles if p.identifier == context.settings.profile_identifier), None)
+        if target is None:
+            return
+
+        shacl_context = SHACLValidationContext.get_instance(context)
+        # If pyshacl already ran for the target during the main loop there is
+        # nothing to do.
+        if shacl_context.get_validation_result(target) is not None:
+            return
+
+        # Pick any SHACLCheck across the loaded profiles to drive the run; the
+        # check identity is only used for logging inside __do_execute_check__,
+        # the actual validation is graph-wide.
+        runner = next(
+            (c for p in profiles for r in p.requirements for c in r.get_checks() if isinstance(c, SHACLCheck)),
+            None,
+        )
+        if runner is None:
+            return
+
+        # Make sure the target's shapes (if any) are in the merged registry
+        # and switch the current profile so violations are attributed under
+        # the target profile in the report.
+        shacl_context.__set_current_validation_profile__(target)
+        shacl_context._current_validation_profile = target
+        try:
+            runner.__do_execute_check__(shacl_context)
+        except Exception as e:
+            logger.warning("Forced SHACL run for zero-shape target profile %s failed: %s", target.identifier, e)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.exception(e)
+        finally:
+            shacl_context.__unset_current_validation_profile__()
+
+        # do finalization logic here (empty for now)
+        logger.debug("Completed %s requirement finalization for context %s", cls.__name__, context)
+
 
 class SHACLRequirementLoader(RequirementLoader):
-
     def __init__(self, profile: Profile):
         super().__init__(profile)
         self._shape_registry = ShapesRegistry.get_instance(profile)

--- a/rocrate_validator/requirements/shacl/requirements.py
+++ b/rocrate_validator/requirements/shacl/requirements.py
@@ -35,16 +35,11 @@ logger = logging.getLogger(__name__)
 
 
 class SHACLRequirement(Requirement):
-
-    def __init__(self,
-                 shape: Shape,
-                 profile: Profile,
-                 path: Path):
+    def __init__(self, shape: Shape, profile: Profile, path: Path):
         self._shape = shape
-        super().__init__(profile,
-                         shape.name if shape.name else "",
-                         shape.description if shape.description else "",
-                         path)
+        super().__init__(
+            profile, shape.name if shape.name else "", shape.description if shape.description else "", path
+        )
         # init checks
         self._checks = self.__init_checks__()
         # assign check IDs
@@ -65,8 +60,15 @@ class SHACLRequirement(Requirement):
         # check if the shape has nested properties
         has_properties = hasattr(self.shape, "properties") and len(self.shape.properties) > 0
         # create a check for the shape itself, hidden if the shape has nested properties
-        checks.append(SHACLCheck(self, self.shape, name=f"Check {self.shape.name}" if has_properties else None,
-                                 hidden=has_properties, root=True))
+        checks.append(
+            SHACLCheck(
+                self,
+                self.shape,
+                name=f"Check {self.shape.name}" if has_properties else None,
+                hidden=has_properties,
+                root=True,
+            )
+        )
         # create a check for each property if the shape has nested properties
         if has_properties:
             for prop in self.shape.properties:
@@ -159,9 +161,9 @@ class SHACLRequirementLoader(RequirementLoader):
     def shapes_registry(self) -> ShapesRegistry:
         return self._shape_registry
 
-    def load(self, profile: Profile,
-             requirement_level: RequirementLevel,
-             file_path: Path, publicID: Optional[str] = None) -> list[Requirement]:
+    def load(
+        self, profile: Profile, requirement_level: RequirementLevel, file_path: Path, publicID: Optional[str] = None
+    ) -> list[Requirement]:
         assert file_path is not None, "The file path cannot be None"
         shapes: list[Shape] = self.shapes_registry.load_shapes(file_path, publicID)
         logger.debug("Loaded %s shapes: %s", len(shapes), shapes)

--- a/rocrate_validator/requirements/shacl/utils.py
+++ b/rocrate_validator/requirements/shacl/utils.py
@@ -190,20 +190,23 @@ class ShapesList:
 
     def get_shape_property_graph(self, shape_node: Node, shape_property: Node) -> Graph:
         """
-        Get the subgraph of the given shape node excluding the given property
+        Get the subgraph of a property shape nested inside a node shape.
+
+        Includes only triples reachable from `shape_property` (its constraints
+        and any RDF lists used by `sh:and`/`sh:or`/`sh:xone`), plus the link
+        triple `(shape_node, sh:property, shape_property)`. Nothing reachable
+        only via sibling properties is included, so subtracting this graph
+        from the merged shapes graph cannot break sibling constructs.
         """
         node_graph = self.get_shape_graph(shape_node)
         assert node_graph is not None, "The shape graph cannot be None"
 
         property_graph = Graph()
-        shacl_ns = Namespace(SHACL_NS)
-        nested_properties_to_exclude = [o for (_, _, o) in node_graph.triples(
-            (shape_node, shacl_ns.property, None)) if o != shape_property]
-        triples_to_exclude = [(s, _, o) for (s, _, o) in node_graph.triples((None, None, None))
-                              if s in nested_properties_to_exclude
-                              or o in nested_properties_to_exclude]
+        for s, p, o in __extract_related_triples__(node_graph, shape_property):
+            property_graph.add((s, p, o))
 
-        property_graph += node_graph - triples_to_exclude
+        shacl_ns = Namespace(SHACL_NS)
+        property_graph.add((shape_node, shacl_ns.property, shape_property))
 
         return property_graph
 

--- a/tests/data/profiles/fake/c-wrapper/profile.ttl
+++ b/tests/data/profiles/fake/c-wrapper/profile.ttl
@@ -1,0 +1,30 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+# A "wrapper" extension profile that inherits from c without declaring any
+# SHACL shape of its own. Used to exercise the zero-shape target profile
+# path: pyshacl must still run for inherited shapes to be evaluated.
+<https://w3id.org/c-wrapper>
+    a prof:Profile ;
+    rdfs:label "Profile C-wrapper" ;
+    rdfs:comment """Pure inheritance from Profile C, no own checks."""@en ;
+    dct:publisher <https://publisherCwrapper> ;
+    prof:isProfileOf <https://w3id.org/c> ;
+    prof:isTransitiveProfileOf <https://w3id.org/a>, <https://w3id.org/c> ;
+    prof:hasToken "c-wrapper" ;
+.

--- a/tests/unit/requirements/test_profiles.py
+++ b/tests/unit/requirements/test_profiles.py
@@ -16,13 +16,11 @@ import logging
 import os
 
 import pytest
+from requirements.shacl.checks import SHACLCheck
 
 from rocrate_validator.constants import DEFAULT_PROFILE_IDENTIFIER
-from rocrate_validator.errors import (DuplicateRequirementCheck,
-                                      InvalidProfilePath,
-                                      ProfileSpecificationError)
-from rocrate_validator.models import (Profile, ValidationContext,
-                                      ValidationSettings, Validator)
+from rocrate_validator.errors import DuplicateRequirementCheck, InvalidProfilePath, ProfileSpecificationError
+from rocrate_validator.models import Profile, ValidationContext, ValidationSettings, Validator
 from tests.ro_crates import InvalidFileDescriptorEntity, ValidROC
 
 # set up logging
@@ -295,6 +293,32 @@ def test_load_valid_profile_with_override_on_inherited_profile(fake_profiles_pat
     # the number of checks should be 2
     requirements_checks = [requirement for profile in profiles for requirement in profile.requirements]
     assert len(requirements_checks) == 3, "The number of requirements should be 2"
+
+
+def test_zero_shape_target_profile_triggers_pyshacl_run(fake_profiles_path: str):
+    """Regression test for the 0-shape profile bug: 
+    when the target profile has no SHACL checks of its own, 
+    Validator must still drive a single pyshacl run
+    on the merged shapes graph so inherited shapes get evaluated. 
+    Without the fix in `Validator.__ensure_target_shacl_run__`, 
+    no SHACLCheck would be recorded as executed for the wrapper target."""
+    
+    settings = ValidationSettings(**{
+        "profiles_path": fake_profiles_path,
+        "profile_identifier": "c-wrapper",
+        "rocrate_uri": ValidROC().wrroc_paper,
+        "enable_profile_inheritance": True,
+        "allow_requirement_check_override": True,
+        "disable_check_for_duplicates": True,
+    })
+    result = Validator(settings).validate()
+
+    executed_shacl = [c for c in result.executed_checks
+                      if isinstance(c, SHACLCheck)]
+    assert executed_shacl, (
+        "Expected at least one inherited SHACLCheck to be executed for the "
+        "c-wrapper target. None recorded — the zero-shape pyshacl run was "
+        "skipped.")
 
 
 def test_profile_parents(check_overriding_profiles_path: str):

--- a/tests/unit/requirements/test_profiles.py
+++ b/tests/unit/requirements/test_profiles.py
@@ -16,11 +16,11 @@ import logging
 import os
 
 import pytest
-from requirements.shacl.checks import SHACLCheck
 
 from rocrate_validator.constants import DEFAULT_PROFILE_IDENTIFIER
 from rocrate_validator.errors import DuplicateRequirementCheck, InvalidProfilePath, ProfileSpecificationError
 from rocrate_validator.models import Profile, ValidationContext, ValidationSettings, Validator
+from rocrate_validator.requirements.shacl.checks import SHACLCheck
 from tests.ro_crates import InvalidFileDescriptorEntity, ValidROC
 
 # set up logging
@@ -55,7 +55,7 @@ def test_load_invalid_profile_from_validation_context(fake_profiles_path: str):
         "profiles_path": "/tmp/random_path_xxx",
         "profile_identifier": DEFAULT_PROFILE_IDENTIFIER,
         "rocrate_uri": ValidROC().wrroc_paper,
-        "enable_profile_inheritance": False
+        "enable_profile_inheritance": False,
     }
 
     settings = ValidationSettings(**settings)
@@ -77,7 +77,7 @@ def test_load_valid_profile_without_inheritance_from_validation_context(fake_pro
         "profiles_path": fake_profiles_path,
         "profile_identifier": "c",
         "rocrate_uri": ValidROC().wrroc_paper,
-        "enable_profile_inheritance": False
+        "enable_profile_inheritance": False,
     }
 
     settings = ValidationSettings(**settings)
@@ -126,7 +126,8 @@ def test_profile_spec_properties(fake_profiles_path: str):
     assert profile.version == "1.0.0", "The profile version should be 1.0.0"
     assert profile.is_profile_of == ["https://w3id.org/a"], "The profileOf property should be ['a']"
     assert profile.is_transitive_profile_of == [
-        "https://w3id.org/a"], "The transitiveProfileOf property should be ['a']"
+        "https://w3id.org/a"
+    ], "The transitiveProfileOf property should be ['a']"
 
 
 def test_profiles_loading_free_folder_structure(profiles_with_free_folder_structure_path: str):
@@ -204,8 +205,9 @@ def test_loaded_valid_profile_with_inheritance_from_validator_context(fake_profi
 
         # The number of profiles should be 1
         profiles_names = [_.token for _ in profile.inherited_profiles]
-        assert profiles_names == expected_inherited_profiles, \
-            f"The number of profiles should be {expected_inherited_profiles}"
+        assert (
+            profiles_names == expected_inherited_profiles
+        ), f"The number of profiles should be {expected_inherited_profiles}"
 
     # Test the inheritance mode with 1 profile
     __perform_test__("a", [])
@@ -250,7 +252,7 @@ def test_load_invalid_profile_with_override_on_same_profile(fake_profiles_path: 
         "profile_identifier": "invalid-duplicated-shapes",
         "rocrate_uri": ValidROC().wrroc_paper,
         "enable_profile_inheritance": True,
-        "allow_requirement_check_override": False
+        "allow_requirement_check_override": False,
     }
 
     settings = ValidationSettings(**settings)
@@ -273,7 +275,7 @@ def test_load_valid_profile_with_override_on_inherited_profile(fake_profiles_pat
         "profile_identifier": "c-overridden",
         "rocrate_uri": ValidROC().wrroc_paper,
         "enable_profile_inheritance": True,
-        "allow_requirement_check_override": True
+        "allow_requirement_check_override": True,
     }
 
     settings = ValidationSettings(**settings)
@@ -296,29 +298,31 @@ def test_load_valid_profile_with_override_on_inherited_profile(fake_profiles_pat
 
 
 def test_zero_shape_target_profile_triggers_pyshacl_run(fake_profiles_path: str):
-    """Regression test for the 0-shape profile bug: 
-    when the target profile has no SHACL checks of its own, 
+    """Regression test for the 0-shape profile bug:
+    when the target profile has no SHACL checks of its own,
     Validator must still drive a single pyshacl run
-    on the merged shapes graph so inherited shapes get evaluated. 
-    Without the fix in `Validator.__ensure_target_shacl_run__`, 
+    on the merged shapes graph so inherited shapes get evaluated.
+    Without the fix in `Validator.__ensure_target_shacl_run__`,
     no SHACLCheck would be recorded as executed for the wrapper target."""
-    
-    settings = ValidationSettings(**{
-        "profiles_path": fake_profiles_path,
-        "profile_identifier": "c-wrapper",
-        "rocrate_uri": ValidROC().wrroc_paper,
-        "enable_profile_inheritance": True,
-        "allow_requirement_check_override": True,
-        "disable_check_for_duplicates": True,
-    })
+
+    settings = ValidationSettings(
+        **{
+            "profiles_path": fake_profiles_path,
+            "profile_identifier": "c-wrapper",
+            "rocrate_uri": ValidROC().wrroc_paper,
+            "enable_profile_inheritance": True,
+            "allow_requirement_check_override": True,
+            "disable_check_for_duplicates": True,
+        }
+    )
     result = Validator(settings).validate()
 
-    executed_shacl = [c for c in result.executed_checks
-                      if isinstance(c, SHACLCheck)]
+    executed_shacl = [c for c in result.executed_checks if isinstance(c, SHACLCheck)]
     assert executed_shacl, (
         "Expected at least one inherited SHACLCheck to be executed for the "
         "c-wrapper target. None recorded — the zero-shape pyshacl run was "
-        "skipped.")
+        "skipped."
+    )
 
 
 def test_profile_parents(check_overriding_profiles_path: str):
@@ -390,29 +394,31 @@ def test_profile_check_overriding(check_overriding_profiles_path: str):
 
     def check_profile(profile, check, inherited_profiles, overridden_by, override):
         # Check inherited profiles
-        assert len(profile.inherited_profiles) == len(inherited_profiles), \
-            f"The number of inherited profiles should be {len(inherited_profiles)}"
+        assert len(profile.inherited_profiles) == len(
+            inherited_profiles
+        ), f"The number of inherited profiles should be {len(inherited_profiles)}"
         inherited_profiles_tokens = [_.token for _ in profile.inherited_profiles]
-        assert set(inherited_profiles_tokens) == set(inherited_profiles), \
-            f"The inherited profiles should be {inherited_profiles}"
+        assert set(inherited_profiles_tokens) == set(
+            inherited_profiles
+        ), f"The inherited profiles should be {inherited_profiles}"
 
         # Check overridden status
-        logger.debug("%r overridden by: %r", check.identifier, [
-                     _.requirement.profile.identifier for _ in check.overridden_by])
-        assert check.overridden == (len(overridden_by) > 0), \
-            f"The check overridden status should be {len(overridden_by) > 0}"
-        assert len(check.overridden_by) == len(overridden_by), \
-            f"The number of overridden checks should be {len(overridden_by)}"
+        logger.debug(
+            "%r overridden by: %r", check.identifier, [_.requirement.profile.identifier for _ in check.overridden_by]
+        )
+        assert check.overridden == (
+            len(overridden_by) > 0
+        ), f"The check overridden status should be {len(overridden_by) > 0}"
+        assert len(check.overridden_by) == len(
+            overridden_by
+        ), f"The number of overridden checks should be {len(overridden_by)}"
         overridden_by_tokens = [_.requirement.profile.identifier for _ in check.overridden_by]
-        assert set(overridden_by_tokens) == set(overridden_by), \
-            f"The overridden checks should be {overridden_by}"
+        assert set(overridden_by_tokens) == set(overridden_by), f"The overridden checks should be {overridden_by}"
 
         # Check override status
-        assert len(check.overrides) == len(override), \
-            f"The number of overridden checks should be {len(override)}"
+        assert len(check.overrides) == len(override), f"The number of overridden checks should be {len(override)}"
         override_tokens = [_.requirement.profile.identifier for _ in check.overrides]
-        assert set(override_tokens) == set(override), \
-            f"The overridden checks should be {override}"
+        assert set(override_tokens) == set(override), f"The overridden checks should be {override}"
 
     # Check the number of requirements and checks of each profile
     for profile in profiles:

--- a/tests/unit/requirements/test_shacl_utils.py
+++ b/tests/unit/requirements/test_shacl_utils.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for ``ShapesList.get_shape_property_graph``.
+
+The method must return a subgraph that:
+* contains every triple reachable from the property shape (its constraints
+    and any RDF lists used by ``sh:and``/``sh:or``/``sh:xone``);
+* contains the link triple ``(shape_node, sh:property, shape_property)``;
+* does NOT contain triples that belong only to sibling property shapes
+"""
+
+import pytest
+from rdflib import RDF, BNode, Graph, Literal, Namespace, URIRef
+from rdflib.collection import Collection
+
+from rocrate_validator.constants import SHACL_NS
+from rocrate_validator.requirements.shacl.utils import load_shapes_from_graph
+
+SH = Namespace(SHACL_NS)
+EX = Namespace("http://example.org/")
+
+
+def _build_two_property_shape() -> tuple[Graph, URIRef, URIRef, URIRef]:
+    """
+    Build a NodeShape with two sibling property shapes.
+
+    Returns ``(graph, node_shape, prop_a, prop_b)``.
+
+    Each property shape is a BNode owning its own ``sh:path``,
+    ``sh:datatype``, ``sh:minCount`` constraints.
+    """
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("ex", EX)
+
+    node_shape = EX.PersonShape
+    g.add((node_shape, RDF.type, SH.NodeShape))
+    g.add((node_shape, SH.targetClass, EX.Person))
+
+    prop_a = BNode("propA")
+    g.add((node_shape, SH.property, prop_a))
+    g.add((prop_a, SH.path, EX.name))
+    g.add((prop_a, SH.datatype, EX.stringType))
+    g.add((prop_a, SH.minCount, Literal(1)))
+
+    prop_b = BNode("propB")
+    g.add((node_shape, SH.property, prop_b))
+    g.add((prop_b, SH.path, EX.age))
+    g.add((prop_b, SH.datatype, EX.intType))
+    g.add((prop_b, SH.minCount, Literal(0)))
+
+    return g, node_shape, prop_a, prop_b
+
+
+def test_returns_link_triple_to_target_property():
+    """The link ``(node_shape, sh:property, shape_property)`` must be present."""
+    g, node_shape, prop_a, prop_b = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+
+    # The link to the prop_a shape must be present
+    assert (node_shape, SH.property, prop_a) in pg
+    # but not the link to the prop_b shape.
+    assert (node_shape, SH.property, prop_b) not in pg
+
+
+def test_includes_all_constraints_of_target_property():
+    """All triples whose subject is the target property shape must be included."""
+    g, node_shape, prop_a, _ = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+
+    assert (prop_a, SH.path, EX.name) in pg
+    assert (prop_a, SH.datatype, EX.stringType) in pg
+    assert (prop_a, SH.minCount, Literal(1)) in pg
+
+
+def test_excludes_sibling_property_link_and_constraints():
+    """
+    Sibling property shapes and their link triples must not appear in the
+    returned subgraph. This is the regression the new implementation fixes.
+    """
+    g, node_shape, prop_a, prop_b = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+
+    # Sibling link triple must not be present.
+    assert (node_shape, SH.property, prop_b) not in pg
+    # Sibling constraints must not be present.
+    assert (prop_b, SH.path, EX.age) not in pg
+    assert (prop_b, SH.datatype, EX.intType) not in pg
+    assert (prop_b, SH.minCount, Literal(0)) not in pg
+
+
+def test_subtraction_preserves_sibling_property_link():
+    """
+    Subtracting the returned subgraph from the merged shapes graph must
+    leave the sibling property's link to the parent NodeShape intact
+    """
+    g, node_shape, prop_a, prop_b = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+    remaining = shapes_list.shapes_graph - pg
+
+    # The sibling property is still linked to the NodeShape.
+    assert (node_shape, SH.property, prop_b) in remaining
+    # And so are its constraints.
+    assert (prop_b, SH.path, EX.age) in remaining
+
+
+def test_does_not_include_unrelated_node_shape_triples():
+    """
+    Triples on the parent NodeShape that are not the target link must
+    not be pulled in (e.g. ``sh:targetClass``).
+    """
+    g, node_shape, prop_a, _ = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+
+    assert (node_shape, SH.targetClass, EX.Person) not in pg
+    assert (node_shape, RDF.type, SH.NodeShape) not in pg
+
+
+def test_includes_rdf_list_triples_for_sh_or():
+    """
+    When the property shape uses ``sh:or`` (an RDF list), the list spine
+    (``rdf:first``/``rdf:rest``) and every list member must be reachable
+    in the returned subgraph.
+    """
+    g = Graph()
+    node_shape = EX.SomeShape
+    g.add((node_shape, RDF.type, SH.NodeShape))
+
+    prop = BNode("prop")
+    g.add((node_shape, SH.property, prop))
+    g.add((prop, SH.path, EX.something))
+
+    member_a = BNode("memberA")
+    g.add((member_a, SH.datatype, EX.t1))
+    member_b = BNode("memberB")
+    g.add((member_b, SH.datatype, EX.t2))
+
+    list_head = BNode("listHead")
+    Collection(g, list_head, [member_a, member_b])
+    g.add((prop, SH["or"], list_head))
+
+    shapes_list = load_shapes_from_graph(g)
+    pg = shapes_list.get_shape_property_graph(node_shape, prop)
+
+    # The sh:or link is reachable from the property.
+    assert (prop, SH["or"], list_head) in pg
+    # Both list members and their constraints are reachable.
+    assert (member_a, SH.datatype, EX.t1) in pg
+    assert (member_b, SH.datatype, EX.t2) in pg
+    # The RDF list spine is included so the list can be re-walked.
+    list_spine_subjects = {s for s, _, _ in pg.triples((None, RDF.first, None))}
+    assert list_head in list_spine_subjects
+
+
+def test_only_target_link_present_when_node_has_multiple_properties():
+    """
+    The graph must contain exactly one ``sh:property`` triple originating
+    from the parent NodeShape — the one pointing at the target property.
+    """
+    g, node_shape, prop_a, _ = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    pg = shapes_list.get_shape_property_graph(node_shape, prop_a)
+
+    property_links = list(pg.triples((node_shape, SH.property, None)))
+    assert len(property_links) == 1
+    assert property_links[0] == (node_shape, SH.property, prop_a)
+
+
+def test_unknown_shape_node_raises():
+    """A shape node not in the registry should raise ``KeyError``."""
+    g, _, prop_a, _ = _build_two_property_shape()
+    shapes_list = load_shapes_from_graph(g)
+
+    with pytest.raises(KeyError):
+        shapes_list.get_shape_property_graph(EX.UnknownShape, prop_a)

--- a/tests/unit/test_requirement_lifecycle.py
+++ b/tests/unit/test_requirement_lifecycle.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rocrate_validator import services
+from rocrate_validator.models import RequirementLoader, Severity, ValidationContext, ValidationSettings
+from tests.ro_crates import InvalidRootDataEntity
+
+
+class _RequirementTypeSpy:
+    """Stand-in for a Requirement subclass that records lifecycle hook calls."""
+
+    def __init__(self, name: str, timeline: list):
+        self.__name__ = name
+        self._timeline = timeline
+        self.calls: list[tuple[str, ValidationContext]] = []
+
+    def initialize(self, context: ValidationContext) -> None:
+        self.calls.append(("initialize", context))
+        self._timeline.append(("initialize", self.__name__))
+
+    def finalize(self, context: ValidationContext) -> None:
+        self.calls.append(("finalize", context))
+        self._timeline.append(("finalize", self.__name__))
+
+
+@pytest.fixture
+def validation_settings():
+    return ValidationSettings(
+        rocrate_uri=str(InvalidRootDataEntity().invalid_root_type),
+        requirement_severity=Severity.OPTIONAL,
+        abort_on_first=False,
+    )
+
+
+@pytest.fixture
+def lifecycle_spies(monkeypatch):
+    """
+    Replace the registered requirement classes with two spy stand-ins.
+
+    Returns (spies, timeline) where timeline records the global ordering
+    of hook invocations across all spies.
+    """
+    timeline: list[tuple[str, str]] = []
+    spies = [
+        _RequirementTypeSpy("SpyTypeA", timeline),
+        _RequirementTypeSpy("SpyTypeB", timeline),
+    ]
+    monkeypatch.setattr(
+        RequirementLoader,
+        "__get_requirement_classes__",
+        staticmethod(lambda: spies),
+    )
+    return spies, timeline
+
+
+def test_initialize_and_finalize_called_once_per_requirement_type(lifecycle_spies, validation_settings):
+    """
+    Check that each requirement type's initialize and
+    finalize hooks are called exactly once per validation run.
+    """
+    spies, _ = lifecycle_spies
+
+    services.validate(validation_settings)
+
+    for spy in spies:
+        events = [evt for evt, _ in spy.calls]
+        assert events == ["initialize", "finalize"], (
+            f"{spy.__name__} expected exactly one initialize then one finalize, got {events}"
+        )
+
+
+def test_lifecycle_hooks_receive_the_same_validation_context(lifecycle_spies, validation_settings):
+    """
+    Check that all lifecycle hooks receive the same ValidationContext instance.
+    This ensures that the context is properly shared across all requirements.
+    """
+    spies, _ = lifecycle_spies
+
+    services.validate(validation_settings)
+
+    contexts = [ctx for spy in spies for _, ctx in spy.calls]
+    assert contexts, "No lifecycle hook was invoked"
+    first = contexts[0]
+    assert isinstance(first, ValidationContext)
+    assert all(ctx is first for ctx in contexts), (
+        "All initialize/finalize invocations must share the same ValidationContext"
+    )
+
+
+def test_all_initialize_hooks_run_before_any_finalize_hook(lifecycle_spies, validation_settings):
+    """
+    Check that all initialize hooks are called before any finalize hook is called.
+    This ensures that the context is fully initialized before any requirement starts finalizing.
+    """
+    _, timeline = lifecycle_spies
+
+    services.validate(validation_settings)
+
+    init_indices = [i for i, (evt, _) in enumerate(timeline) if evt == "initialize"]
+    finalize_indices = [i for i, (evt, _) in enumerate(timeline) if evt == "finalize"]
+    assert init_indices and finalize_indices, "Lifecycle hooks were not all triggered"
+    assert max(init_indices) < min(finalize_indices), (
+        f"Expected every initialize to precede every finalize, got timeline {timeline}"
+    )
+
+
+def test_lifecycle_hooks_invoked_exactly_once_per_validation_run(lifecycle_spies, validation_settings):
+    """
+    Run validation multiple times and check that each spy receives exactly one
+    initialize+finalize pair per run.
+    """
+
+    # extract spies from fixture
+    spies, _ = lifecycle_spies
+
+    # run validation multiple times and
+    # check that each spy receives exactly one initialize+finalize pair per run
+    runs = 3
+    for _ in range(runs):
+        services.validate(validation_settings)
+
+    for spy in spies:
+        events = [evt for evt, _ in spy.calls]
+        assert events == ["initialize", "finalize"] * runs, (
+            f"{spy.__name__} should receive exactly one initialize+finalize "
+            f"pair per validation run (got {events} across {runs} runs)"
+        )


### PR DESCRIPTION
This PR fixes two validation issues: the first dealing with incorrect construction of property subgraphs, and the second with inherited shapes being skipped when the profile defines no own checks.
