### PR TITLE
Fix error message for bad position in HowToStep

### DIFF
--- a/rocrate_validator/profiles/provenance-run-crate/must/1_howtostep.ttl
+++ b/rocrate_validator/profiles/provenance-run-crate/must/1_howtostep.ttl
@@ -52,14 +52,14 @@ provenance-run-crate:ProvRCHowToStepRequired a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:name "HowToStep position type" ;
-        sh:description "If specified, position must be a string representing an integer" ;
+        sh:description "If specified, position must be an integer or a string representing an integer" ;
         sh:path schema:position ;
         sh:or (
             [ sh:datatype xsd:string ; ]
             [ sh:datatype xsd:integer ; ]
         ) ;
         sh:pattern "\\d+" ;
-        sh:message "If specified, position must be a string representing an integer" ;
+        sh:message "If specified, position must be an integer or a string representing an integer" ;
     ] ;
     sh:property [
         a sh:PropertyShape ;

--- a/tests/integration/profiles/provenance-run-crate/test_provrc_howtostep.py
+++ b/tests/integration/profiles/provenance-run-crate/test_provrc_howtostep.py
@@ -97,14 +97,14 @@ def test_provrc_howtostep_no_position():
 def test_provrc_howtostep_bad_position():
     """\
     Test a Provenance Run Crate where a HowToStep has a position that is not
-    a string representing an integer.
+    an integer or a string representing an integer.
     """
     do_entity_test(
         InvalidProvRC().howtostep_bad_position,
         Severity.REQUIRED,
         False,
         ["ProvRC HowToStep MUST"],
-        ["If specified, position must be a string representing an integer"],
+        ["If specified, position must be an integer or a string representing an integer"],
         profile_identifier="provenance-run-crate"
     )
 


### PR DESCRIPTION
Fixes #81.

@elichad please let me know if this looks fine.

Note that the valid crate example we have for Provenance Run Crate already tests the presence of both an integer and a string representing an integer as a value for `position`, so I just changed the message.