### PR TITLE
feat(checks): allow extension profiles to deactivate inherited checks

### DIFF
--- a/docs/11_writing_a_profile.rst
+++ b/docs/11_writing_a_profile.rst
@@ -94,6 +94,154 @@ These instructions assume you are familiar with code development using Python an
 #. When your profile & tests are written, open a pull request to contribute 
    it back to the repository!
 
+Overriding inherited checks
+---------------------------
+
+When a profile inherits from another profile (via ``prof:isProfileOf`` /
+``prof:isTransitiveProfileOf``), it automatically receives every check
+declared by its ancestors. The validator additionally supports
+**override-by-name**: a child profile can replace an inherited check by
+declaring a new check with the **same name**.
+
+This allows an extension profile to *redefine* the content of an inherited
+check — for example, to make a constraint stricter or looser, change its
+severity, or, as described in the next section, fully deactivate it.
+
+Override-by-name is enabled by default. It can be disabled via the
+``allow_requirement_check_override`` validation setting (CLI / API), which
+will raise an error on duplicate check names instead.
+
+SHACL checks
+^^^^^^^^^^^^
+
+Each SHACL ``NodeShape`` / ``PropertyShape`` becomes a check whose name is
+its ``sh:name``. To override an inherited check, declare a shape in the
+extension profile with the **same** ``sh:name`` as the inherited one:
+
+.. code-block:: turtle
+
+   # Parent profile
+   ro:ShapeC
+       a sh:NodeShape ;
+       sh:name "The Shape C" ;
+       sh:targetNode ro:ro-crate-metadata.json ;
+       sh:property [
+           a sh:PropertyShape ;
+           sh:name "Check Metadata File Descriptor entity existence" ;
+           sh:path rdf:type ;
+           sh:minCount 1 ;
+           sh:message "Missing entity" ;
+       ] .
+
+.. code-block:: turtle
+
+   # Extension profile — overrides the inherited PropertyShape by sh:name
+   ro:ShapeC
+       a sh:NodeShape ;
+       sh:name "The Shape C" ;
+       sh:targetNode ro:ro-crate-metadata.json ;
+       sh:property [
+           a sh:PropertyShape ;
+           sh:name "Check Metadata File Descriptor entity existence" ;
+           sh:path rdf:type ;
+           sh:minCount 1 ;
+           sh:maxCount 1 ;
+           sh:message "Stricter override from extension profile" ;
+       ] .
+
+Both top-level shapes and ``PropertyShape`` entries nested inside a parent
+``NodeShape`` (i.e., declared inline, without an absolute IRI) can be
+overridden this way.
+
+Python checks
+^^^^^^^^^^^^^
+
+Python checks declared via the ``@check`` decorator are matched by their
+``name`` argument. To override an inherited Python check, declare a new
+function with the same ``name`` in the extension profile:
+
+.. code-block:: python
+
+   # In the extension profile's checks module
+   from rocrate_validator.requirements.python import check
+
+   @check(name="Check Metadata File Descriptor entity existence")
+   def overridden_check(self, ctx):
+       # New implementation that replaces the inherited one
+       ...
+
+Deactivating inherited checks
+-----------------------------
+
+A child profile can also **fully deactivate** a check inherited from one of
+its ancestors. A deactivated check is skipped during validation and
+reported as such in the validation result. This is useful when an extension
+profile relaxes the parent's expectations, or replaces a coarse-grained
+check with a more specific one declared elsewhere in the same profile.
+
+SHACL checks
+^^^^^^^^^^^^
+
+Two complementary mechanisms are supported, depending on whether the shape
+to disable has an absolute IRI of its own.
+
+**Shape with an absolute IRI** (e.g. a top-level ``NodeShape`` or a named
+``PropertyShape``): reference the shape by IRI from the extension profile
+and mark it as deactivated, without redeclaring it.
+
+.. code-block:: turtle
+
+   # Extension profile
+   <https://parent-profile/ShapeC> sh:deactivated true .
+
+**Nested ``PropertyShape`` without an absolute IRI** (a property declared
+inline inside a parent ``NodeShape``): use the override-by-name mechanism
+described in the previous section. Declare a new ``PropertyShape`` in the
+extension profile with the same ``sh:name`` as the one to disable, and set
+``sh:deactivated true`` on it. This overrides the parent's
+``PropertyShape``, and the validator reports the resulting check as
+deactivated.
+
+.. code-block:: turtle
+
+   # Extension profile — disables the inherited PropertyShape by sh:name
+   ro:ShapeC
+       a sh:NodeShape ;
+       sh:name "The Shape C" ;
+       sh:targetNode ro:ro-crate-metadata.json ;
+       sh:property [
+           a sh:PropertyShape ;
+           sh:name "Check Metadata File Descriptor entity existence" ;
+           sh:path rdf:type ;
+           sh:deactivated true ;
+       ] .
+
+.. note::
+
+   Cross-profile deactivation is scoped to the shape's transitive
+   descendants: a ``sh:deactivated true`` triple declared by a profile
+   that does not inherit (directly or transitively) from the shape's
+   owning profile is ignored. This prevents unrelated profiles loaded in
+   the same process from interfering with one another.
+
+Python checks
+^^^^^^^^^^^^^
+
+The ``@check`` decorator accepts a ``deactivated`` flag, mirroring SHACL's
+``sh:deactivated``. Combined with override-by-name, an extension profile
+can disable an inherited Python check by redeclaring it with
+``deactivated=True``:
+
+.. code-block:: python
+
+   from rocrate_validator.requirements.python import check
+
+   @check(name="Check Metadata File Descriptor entity existence",
+          deactivated=True)
+   def disabled(self, ctx):
+       # Body is irrelevant — the check is skipped during validation.
+       return True
+
 Running validator & tests during profile development
 ----------------------------------------------------
 

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -457,6 +457,14 @@ class Profile:
         return self.get_sibling_profiles(self)
 
     @property
+    def descendants(self) -> list[Profile]:
+        """
+        The list of profiles that are descendants of this profile
+        (i.e., profiles that have this profile among their inherited profiles).
+        """
+        return self.get_descendants(self)
+
+    @property
     def readme_file_path(self) -> Path:
         """
         The path of the README file of the profile.
@@ -867,6 +875,20 @@ class Profile:
         :rtype: list[Profile]
         """
         return [p for p in cls.__profiles_map.values() if profile in p.parents]
+
+    @classmethod
+    def get_descendants(cls, profile: Profile) -> list[Profile]:
+        """
+        Get the transitive descendants of the given profile (any profile
+        that has `profile` among its `inherited_profiles`).
+
+        :param profile: the profile
+        :type profile: Profile
+
+        :return: the list of descendant profiles
+        :rtype: list[Profile]
+        """
+        return [p for p in cls.__profiles_map.values() if profile in p.inherited_profiles]
 
     @classmethod
     def all(cls) -> list[Profile]:

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1380,6 +1380,7 @@ class RequirementCheck(ABC):
         level: Optional[RequirementLevel] = LevelCollection.REQUIRED,
         description: Optional[str] = None,
         hidden: Optional[bool] = None,
+        deactivated: bool = False,
     ):
         self._requirement: Requirement = requirement
         self._order_number = 0
@@ -1387,6 +1388,7 @@ class RequirementCheck(ABC):
         self._level = level
         self._description = description
         self._hidden = hidden
+        self._deactivated = deactivated
 
     @property
     def order_number(self) -> int:
@@ -1451,6 +1453,10 @@ class RequirementCheck(ABC):
     @property
     def overridden(self) -> bool:
         return len(self.overridden_by) > 0
+
+    @property
+    def deactivated(self) -> bool:
+        return self._deactivated
 
     @property
     def hidden(self) -> bool:

--- a/rocrate_validator/models.py
+++ b/rocrate_validator/models.py
@@ -1110,6 +1110,10 @@ class Requirement(ABC):
                         [_.identifier for _ in check.overridden_by],
                     )
                     continue
+                if check.deactivated:
+                    logger.debug("Skipping check '%s' because deactivated", check.identifier)
+                    context.result._add_skipped_check(check)
+                    continue
                 # Determine whether to skip event notification for inherited profiles
                 skip_event_notify = False
                 if (
@@ -2949,6 +2953,12 @@ class Validator(Publisher):
             # set the profiles to validate against
             profiles = context.profiles
             assert len(profiles) > 0, "No profiles to validate"
+            # Pre-load every profile's requirements so all shape graphs are
+            # populated before the validation loop runs. This lets a check
+            # see `sh:deactivated true` triples declared by descendant
+            # profiles that have not yet been visited.
+            for p in profiles:
+                _ = p.requirements
             self.notify(EventType.VALIDATION_START)
             for profile in profiles:
                 logger.debug(

--- a/rocrate_validator/requirements/python/__init__.py
+++ b/rocrate_validator/requirements/python/__init__.py
@@ -38,11 +38,12 @@ class PyFunctionCheck(RequirementCheck):
                  name: str,
                  check_function: Callable[[RequirementCheck, ValidationContext], bool],
                  description: Optional[str] = None,
-                 level: Optional[LevelCollection] = LevelCollection.REQUIRED):
+                 level: Optional[LevelCollection] = LevelCollection.REQUIRED,
+                 deactivated: bool = False):
         """
         check_function: a function that accepts an instance of PyFunctionCheck and a ValidationContext.
         """
-        super().__init__(requirement, name, description=description, level=level)
+        super().__init__(requirement, name, description=description, level=level, deactivated=deactivated)
 
         sig = inspect.signature(check_function)
         if len(sig.parameters) != 2:
@@ -115,11 +116,13 @@ class PyRequirement(Requirement):
                                  f"Getting severity from path: {self.severity_from_path}")
                     severity = self.severity_from_path or Severity.REQUIRED
                 logger.debug("Severity log: %r", severity)
+                deactivated = bool(getattr(member, "deactivated", False))
                 check = self.requirement_check_class(self,
                                                      check_name,
                                                      member,
                                                      description=check_description,
-                                                     level=LevelCollection.get(severity.name) if severity else None)
+                                                     level=LevelCollection.get(severity.name) if severity else None,
+                                                     deactivated=deactivated)
                 self._checks.append(check)
                 logger.debug("Added check: %s %r", check_name, check)
 
@@ -159,7 +162,9 @@ def requirement(name: str, description: Optional[str] = None, hidden: bool = Fal
     return decorator
 
 
-def check(name: Optional[str] = None, severity: Optional[Severity] = None):
+def check(name: Optional[str] = None,
+          severity: Optional[Severity] = None,
+          deactivated: bool = False):
     """
     A decorator to mark a function as a check.
 
@@ -178,6 +183,12 @@ def check(name: Optional[str] = None, severity: Optional[Severity] = None):
     :param severity: the severity level
     :type severity: Optional[Severity]
 
+    :param deactivated: when True, the check is skipped during validation.
+        Mirrors SHACL's ``sh:deactivated``: an extension profile may redeclare
+        a check with the same name as one in a parent profile and set this
+        flag to disable the inherited check.
+    :type deactivated: bool
+
     :return: the decorated function
     :rtype: Callable
     """
@@ -193,6 +204,7 @@ def check(name: Optional[str] = None, severity: Optional[Severity] = None):
         func.check = True
         func.name = check_name
         func.severity = severity
+        func.deactivated = deactivated
         return func
     return decorator
 

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -366,12 +366,16 @@ class SHACLCheck(RequirementCheck):
             # all together and not profile by profile
             if requirementCheck.identifier not in failed_requirement_checks_notified:
                 shacl_context.result._add_executed_check(requirementCheck, False)
-                if requirementCheck.identifier not in failed_requirement_checks_notified and \
-                        requirementCheck.requirement.profile != shacl_context.current_validation_profile:
+                if (
+                    requirementCheck.identifier not in failed_requirement_checks_notified
+                    and requirementCheck.requirement.profile != shacl_context.current_validation_profile
+                ):
                     failed_requirement_checks_notified.append(requirementCheck.identifier)
-                    shacl_context.validator.notify(RequirementCheckValidationEvent(
-                        EventType.REQUIREMENT_CHECK_VALIDATION_END,
-                        requirementCheck, validation_result=False))
+                    shacl_context.validator.notify(
+                        RequirementCheckValidationEvent(
+                            EventType.REQUIREMENT_CHECK_VALIDATION_END, requirementCheck, validation_result=False
+                        )
+                    )
                     logger.debug(
                         "Added failed check to the context: %s",
                         requirementCheck.identifier,

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -16,6 +16,9 @@ import json
 from timeit import default_timer as timer
 from typing import Optional
 
+from rdflib import Literal, Namespace
+
+from rocrate_validator.constants import SHACL_NS
 from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.events import EventType
 from rocrate_validator.models import (
@@ -26,7 +29,7 @@ from rocrate_validator.models import (
     SkipRequirementCheck,
     ValidationContext,
 )
-from rocrate_validator.requirements.shacl.models import Shape
+from rocrate_validator.requirements.shacl.models import Shape, ShapesRegistry
 from rocrate_validator.requirements.shacl.utils import make_uris_relative, resolve_parent_shape
 from rocrate_validator.requirements.shacl.validator import (
     SHACLValidationAlreadyProcessed,
@@ -39,6 +42,9 @@ from rocrate_validator.requirements.shacl.validator import (
 from rocrate_validator.utils import log as logging
 
 logger = logging.getLogger(__name__)
+
+_SH = Namespace(SHACL_NS)
+_TRUE_LITERALS = (Literal(True), Literal("true", datatype=None))
 
 
 class SHACLCheck(RequirementCheck):
@@ -96,6 +102,37 @@ class SHACLCheck(RequirementCheck):
     @property
     def root(self) -> bool:
         return self._root
+
+    @property
+    def deactivated(self) -> bool:
+        if self._deactivated:
+            return True
+        shape = self._shape
+        if shape is None:
+            return False
+        # Same-profile deactivation (cases B & C): the shape itself carries
+        # `sh:deactivated true`, possibly because it was redeclared in an
+        # extension profile via override-by-name.
+        for value in shape.graph.objects(subject=shape.node, predicate=_SH.deactivated):
+            if isinstance(value, Literal) and bool(value.toPython()):
+                return True
+        # Cross-profile deactivation (case A): a descendant profile may add
+        # `<parentShapeIRI> sh:deactivated true` to its own shapes graph,
+        # without redeclaring the shape. Scan only profiles that inherit
+        # (transitively) from the shape's owning profile, so unrelated
+        # profiles loaded in the same process can't influence the result.
+        # Validator.__do_validate__ pre-loads the shape graphs.
+        from rocrate_validator.models import Profile
+
+        owning_profile = self.requirement.profile
+        for profile in Profile.get_descendants(owning_profile):
+            try:
+                registry = ShapesRegistry.get_instance(profile)
+            except Exception:
+                continue
+            if registry.is_node_deactivated(shape.node):
+                return True
+        return False
 
     @property
     def description(self) -> str:

--- a/rocrate_validator/requirements/shacl/models.py
+++ b/rocrate_validator/requirements/shacl/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional, Union
 
-from rdflib import Graph, Namespace, URIRef
+from rdflib import Graph, Literal, Namespace, URIRef
 from rdflib.term import Node
 
 from rocrate_validator.constants import SHACL_NS
@@ -343,6 +343,16 @@ class ShapesRegistry:
         g = Graph()
         g += self._shapes_graph
         return g
+
+    def is_node_deactivated(self, node: Node) -> bool:
+        """Return True if the underlying shapes graph asserts
+        `<node> sh:deactivated true`. Avoids the copy made by `shapes_graph`
+        so it is safe to call from hot paths."""
+        deactivated = Namespace(SHACL_NS).deactivated
+        for value in self._shapes_graph.objects(subject=node, predicate=deactivated):
+            if isinstance(value, Literal) and bool(value.toPython()):
+                return True
+        return False
 
     def load_shapes(self, shapes_path: Union[str, Path], publicID: Optional[str] = None) -> list[Shape]:
         """

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import shutil
 import tempfile
 import zipfile
@@ -20,8 +21,7 @@ from typing import Optional, Union
 
 from rocrate_validator.utils import log as logging
 from rocrate_validator.events import Subscriber
-from rocrate_validator.models import (Profile, Severity, ValidationResult,
-                                      ValidationSettings, Validator)
+from rocrate_validator.models import Profile, Severity, ValidationResult, ValidationSettings, Validator
 from rocrate_validator.utils.uri import URI
 from rocrate_validator.utils.paths import get_profiles_path
 from rocrate_validator.utils.http import HttpRequester
@@ -43,9 +43,8 @@ def detect_profiles(settings: Union[dict, ValidationSettings]) -> list[Profile]:
 
 
 def validate_metadata_as_dict(
-        metadata_dict: dict,
-        settings: Union[dict, ValidationSettings],
-        subscribers: Optional[list[Subscriber]] = None) -> ValidationResult:
+    metadata_dict: dict, settings: Union[dict, ValidationSettings], subscribers: Optional[list[Subscriber]] = None
+) -> ValidationResult:
     """
     Validate the RO-Crate metadata only against a profile and return the validation result.
     """
@@ -62,8 +61,9 @@ def validate_metadata_as_dict(
     return validate(settings, subscribers)
 
 
-def validate(settings: Union[dict, ValidationSettings],
-             subscribers: Optional[list[Subscriber]] = None) -> ValidationResult:
+def validate(
+    settings: Union[dict, ValidationSettings], subscribers: Optional[list[Subscriber]] = None
+) -> ValidationResult:
     """
     Validate a RO-Crate against a profile and return the validation result
 
@@ -85,8 +85,9 @@ def validate(settings: Union[dict, ValidationSettings],
     return result
 
 
-def __initialise_validator__(settings: Union[dict, ValidationSettings],
-                             subscribers: Optional[list[Subscriber]] = None) -> Validator:
+def __initialise_validator__(
+    settings: Union[dict, ValidationSettings], subscribers: Optional[list[Subscriber]] = None
+) -> Validator:
     """
     Validate a RO-Crate against a profile
     """
@@ -146,13 +147,13 @@ def __initialise_validator__(settings: Union[dict, ValidationSettings],
     # i.e., if the RO-Crate is a URL. If so, download the RO-Crate
     # and extract it to a temporary directory. We support either http or https
     # or ftp protocols to download the remote RO-Crate.
-    if rocrate_path.scheme in ('http', 'https', 'ftp'):
+    if rocrate_path.scheme in ("http", "https", "ftp"):
         logger.debug("RO-Crate is a remote RO-Crate")
         # create a temp folder to store the downloaded RO-Crate
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             # download the remote RO-Crate
             with HttpRequester().get(rocrate_path.uri, stream=True, allow_redirects=True) as r:
-                with open(tmp_file.name, 'wb') as f:
+                with open(tmp_file.name, "wb") as f:
                     shutil.copyfileobj(r.raw, f)
             logger.debug("RO-Crate downloaded to temporary file: %s", tmp_file.name)
             # continue with the validation process by extracting the RO-Crate and validating it
@@ -171,15 +172,16 @@ def __initialise_validator__(settings: Union[dict, ValidationSettings],
         return __init_validator__(settings)
     else:
         raise ValueError(
-            f"Invalid RO-Crate URI: {rocrate_path}. "
-            "It MUST be a local directory or a ZIP file (local or remote).")
+            f"Invalid RO-Crate URI: {rocrate_path}. It MUST be a local directory or a ZIP file (local or remote)."
+        )
 
 
-def get_profiles(profiles_path: Path = DEFAULT_PROFILES_PATH,
-                 extra_profiles_path: Optional[Path] = None,
-                 severity=Severity.OPTIONAL,
-                 allow_requirement_check_override: bool =
-                 ValidationSettings.allow_requirement_check_override) -> list[Profile]:
+def get_profiles(
+    profiles_path: Path = DEFAULT_PROFILES_PATH,
+    extra_profiles_path: Optional[Path] = None,
+    severity=Severity.OPTIONAL,
+    allow_requirement_check_override: bool = ValidationSettings.allow_requirement_check_override,
+) -> list[Profile]:
     """
     Get the list of profiles supported by the package.
     The profile source path can be overridden by specifying ``profiles_path``.
@@ -203,20 +205,23 @@ def get_profiles(profiles_path: Path = DEFAULT_PROFILES_PATH,
     :return: the list of profiles
     :rtype: list[Profile]
     """
-    profiles = Profile.load_profiles(profiles_path,
-                                     extra_profiles_path=extra_profiles_path,
-                                     severity=severity,
-                                     allow_requirement_check_override=allow_requirement_check_override)
+    profiles = Profile.load_profiles(
+        profiles_path,
+        extra_profiles_path=extra_profiles_path,
+        severity=severity,
+        allow_requirement_check_override=allow_requirement_check_override,
+    )
     logger.debug("Profiles loaded: %s", profiles)
     return profiles
 
 
-def get_profile(profile_identifier: str,
-                profiles_path: Path = DEFAULT_PROFILES_PATH,
-                extra_profiles_path: Optional[Path] = None,
-                severity=Severity.OPTIONAL,
-                allow_requirement_check_override: bool =
-                ValidationSettings.allow_requirement_check_override) -> Profile:
+def get_profile(
+    profile_identifier: str,
+    profiles_path: Path = DEFAULT_PROFILES_PATH,
+    extra_profiles_path: Optional[Path] = None,
+    severity=Severity.OPTIONAL,
+    allow_requirement_check_override: bool = ValidationSettings.allow_requirement_check_override,
+) -> Profile:
     """
     Get the profile with the given identifier.
     The profile source path can be overridden through ``profiles_path``.
@@ -245,8 +250,10 @@ def get_profile(profile_identifier: str,
     :rtype: Profile
 
     """
-    profiles = get_profiles(profiles_path,
-                            extra_profiles_path=extra_profiles_path,
-                            severity=severity,
-                            allow_requirement_check_override=allow_requirement_check_override)
+    profiles = get_profiles(
+        profiles_path,
+        extra_profiles_path=extra_profiles_path,
+        severity=severity,
+        allow_requirement_check_override=allow_requirement_check_override,
+    )
     return Profile.find_in_list(profiles, profile_identifier)

--- a/tests/data/profiles/fake/c-deactivated-direct/profile.ttl
+++ b/tests/data/profiles/fake/c-deactivated-direct/profile.ttl
@@ -1,0 +1,28 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix role: <http://www.w3.org/ns/dx/prof/role/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://w3id.org/c4>
+    a prof:Profile ;
+    rdfs:label "Profile C4" ;
+    rdfs:comment """Comment for Profile C4 (deactivates Profile C's ShapeC by IRI, no override-by-name)."""@en ;
+    dct:publisher <https://publisherC4> ;
+    prof:isProfileOf <https://w3id.org/c> ;
+    prof:isTransitiveProfileOf <https://w3id.org/a>, <https://w3id.org/c> ;
+    prof:hasToken "c-deactivated-direct" ;
+.

--- a/tests/data/profiles/fake/c-deactivated/profile.ttl
+++ b/tests/data/profiles/fake/c-deactivated/profile.ttl
@@ -1,0 +1,28 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix role: <http://www.w3.org/ns/dx/prof/role/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://w3id.org/c3>
+    a prof:Profile ;
+    rdfs:label "Profile C3" ;
+    rdfs:comment """Comment for Profile C3 (deactivates the inherited check from Profile C)."""@en ;
+    dct:publisher <https://publisherC3> ;
+    prof:isProfileOf <https://w3id.org/c> ;
+    prof:isTransitiveProfileOf <https://w3id.org/a>, <https://w3id.org/c> ;
+    prof:hasToken "c-deactivated" ;
+.

--- a/tests/data/profiles/fake/c-deactivated/shape_c.ttl
+++ b/tests/data/profiles/fake/c-deactivated/shape_c.ttl
@@ -1,0 +1,41 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@prefix ro: <./> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema_org: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xml1: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Same NodeShape + PropertyShape names as the inherited Shape C in profile c,
+# so the existing override-by-name mechanism wires this shape to the parent's.
+# The PropertyShape is marked sh:deactivated true: pyshacl skips it during
+# validation, and the override surfaces via RequirementCheck.deactivated.
+ro:ShapeC
+    a sh:NodeShape ;
+    sh:name "The Shape C" ;
+    sh:description "Deactivates the inherited Shape C check from profile c." ;
+    sh:targetNode ro:ro-crate-metadata.json ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:name "Check Metadata File Descriptor entity existence" ;
+        sh:description "Check disabled by extension profile" ;
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:deactivated true ;
+        sh:message "Disabled" ;
+    ] .

--- a/tests/unit/requirements/test_profiles.py
+++ b/tests/unit/requirements/test_profiles.py
@@ -16,11 +16,13 @@ import logging
 import os
 
 import pytest
+from rdflib import Literal, Namespace
 
-from rocrate_validator.constants import DEFAULT_PROFILE_IDENTIFIER
+from rocrate_validator.constants import DEFAULT_PROFILE_IDENTIFIER, SHACL_NS
 from rocrate_validator.errors import DuplicateRequirementCheck, InvalidProfilePath, ProfileSpecificationError
 from rocrate_validator.models import Profile, ValidationContext, ValidationSettings, Validator
 from rocrate_validator.requirements.shacl.checks import SHACLCheck
+from rocrate_validator.requirements.shacl.models import ShapesRegistry
 from tests.ro_crates import InvalidFileDescriptorEntity, ValidROC
 
 # set up logging
@@ -468,3 +470,152 @@ def test_profile_check_overriding(check_overriding_profiles_path: str):
         # Check the profile 'x'
         elif profile.token == "x":
             check_profile(profile, check, ["a", "b", "d"], [], ["d"])
+
+
+def test_python_check_decorator_sets_deactivated_flag():
+    """The @check decorator must propagate the `deactivated` flag onto the
+    decorated function so that PyRequirement.__init_checks__ can read it."""
+    from rocrate_validator.requirements.python import check
+
+    @check(name="off", deactivated=True)
+    def disabled(self, ctx):  # noqa: ANN001
+        return False
+
+    @check(name="on")
+    def enabled(self, ctx):  # noqa: ANN001
+        return True
+
+    assert disabled.deactivated is True
+    assert enabled.deactivated is False
+
+
+def test_shacl_shape_with_deactivated_marks_check_skipped(fake_profiles_path: str):
+    """A child profile that overrides an inherited NodeShape by `sh:name` and
+    sets `sh:deactivated true` should produce a check whose `deactivated`
+    property is True; the parent's check should be marked as `overridden`."""
+    settings = {
+        "profiles_path": fake_profiles_path,
+        "profile_identifier": "c-deactivated",
+        "rocrate_uri": ValidROC().wrroc_paper,
+        "enable_profile_inheritance": True,
+        "allow_requirement_check_override": True,
+    }
+
+    settings = ValidationSettings(**settings)
+    validator = Validator(settings)
+    context = ValidationContext(validator, validator.validation_settings)
+
+    profiles = context.profiles
+    profile_tokens = sorted(p.token for p in profiles)
+    # Inheritance chain: a <- c <- c-deactivated
+    assert profile_tokens == ["a", "c", "c-deactivated"]
+
+    target = next(p for p in profiles if p.token == "c-deactivated")
+    parent_c = next(p for p in profiles if p.token == "c")
+
+    # The PropertyShape carries `sh:deactivated true`; the matching check is
+    # the second one (the first is the hidden NodeShape root check).
+    target_property_check = target.requirements[0].get_checks()[1]
+    parent_property_check = parent_c.requirements[0].get_checks()[1]
+
+    assert (
+        target_property_check.deactivated is True
+    ), "The deactivated property should reflect sh:deactivated true on the PropertyShape"
+
+    # The parent property check is overridden by the child's (same sh:name).
+    overridden_by_tokens = [c.requirement.profile.token for c in parent_property_check.overridden_by]
+    assert "c-deactivated" in overridden_by_tokens, "The parent check should be reported as overridden by c-deactivated"
+    assert parent_property_check.overridden is True
+
+    # Default state for a non-deactivated check.
+    assert parent_property_check.deactivated is False
+
+
+def test_shacl_check_deactivated_via_cross_profile_triple(fake_profiles_path: str):
+    """A child profile that adds `<parentShapeIRI> sh:deactivated true` to its
+    own shapes graph (without redeclaring the shape) should cause the parent's
+    check to report `deactivated=True`. Verifies the cross-profile lookup in
+    SHACLCheck.deactivated and the pre-load pass in Validator."""
+
+    settings = ValidationSettings(
+        **{
+            "profiles_path": fake_profiles_path,
+            "profile_identifier": "c-deactivated-direct",
+            "rocrate_uri": ValidROC().wrroc_paper,
+            "enable_profile_inheritance": True,
+            "allow_requirement_check_override": True,
+        }
+    )
+    validator = Validator(settings)
+    context = ValidationContext(validator, validator.validation_settings)
+
+    profiles = context.profiles
+    profile_tokens = sorted(p.token for p in profiles)
+    assert profile_tokens == ["a", "c", "c-deactivated-direct"]
+
+    target = next(p for p in profiles if p.token == "c-deactivated-direct")
+    parent_c = next(p for p in profiles if p.token == "c")
+
+    # Trigger lazy loading of every profile's shape graph (the Validator
+    # would do this in __do_validate__; we replay it here for the unit test).
+    for p in profiles:
+        _ = p.requirements
+
+    parent_shape_check = next(c for c in parent_c.requirements[0].get_checks() if isinstance(c, SHACLCheck))
+    assert parent_shape_check.deactivated is False, "Sanity check: the parent shape should not be deactivated yet"
+
+    # Simulate what a child-profile shape file would contribute: a single
+    # `<parentShapeIRI> sh:deactivated true` triple in its own shapes graph.
+    target_registry = ShapesRegistry.get_instance(target)
+    sh = Namespace(SHACL_NS)
+    target_registry._shapes_graph.add((parent_shape_check.shape.node, sh.deactivated, Literal(True)))
+
+    assert (
+        parent_shape_check.deactivated is True
+    ), "The parent's check must read sh:deactivated true from the child's shapes graph"
+
+
+def test_shacl_check_deactivation_scoped_to_descendants(fake_profiles_path: str):
+    """A `sh:deactivated true` triple declared by a profile that does NOT
+    inherit from the shape's owning profile must be ignored. Otherwise
+    unrelated profiles loaded in the same process could spuriously deactivate
+    one another's checks."""
+
+    settings = ValidationSettings(
+        **{
+            "profiles_path": fake_profiles_path,
+            "profile_identifier": "c",
+            "rocrate_uri": ValidROC().wrroc_paper,
+            "enable_profile_inheritance": True,
+            "allow_requirement_check_override": True,
+        }
+    )
+    validator = Validator(settings)
+    context = ValidationContext(validator, validator.validation_settings)
+
+    # Force population of the global profile registry by listing all profiles
+    # under the fake_profiles_path, then resolve the specific ones we need.
+    all_profiles = Profile.load_profiles(profiles_path=fake_profiles_path)
+    parent_c = next(p for p in all_profiles if p.token == "c")
+    # Profile "b" is a descendant of "a" but NOT of "c" — unrelated.
+    profile_b = next(p for p in all_profiles if p.token == "b")
+    assert parent_c not in profile_b.inherited_profiles
+    assert profile_b not in Profile.get_descendants(parent_c)
+
+    # Trigger lazy loading.
+    for p in all_profiles:
+        _ = p.requirements
+    _ = context.profiles  # warm context too
+
+    parent_shape_check = next(c for c in parent_c.requirements[0].get_checks() if isinstance(c, SHACLCheck))
+    assert parent_shape_check.deactivated is False
+
+    # Inject a deactivation triple into an unrelated profile's registry.
+    sh = Namespace(SHACL_NS)
+    ShapesRegistry.get_instance(profile_b)._shapes_graph.add(
+        (parent_shape_check.shape.node, sh.deactivated, Literal(True))
+    )
+
+    assert (
+        parent_shape_check.deactivated is False
+    ), "An unrelated profile's deactivation triple must not affect the check"


### PR DESCRIPTION
This PR adds a way for an extension profile to **disable specific checks** inherited from a parent profile, both for SHACL shapes and for Python checks.

## What changes

### SHACL checks
A SHACL check is reported as deactivated — and skipped during validation — when either:

1. A descendant profile adds a `<shapeIRI> sh:deactivated true` triple to its own shapes graph, without redeclaring the shape. Suitable for shapes identified by an absolute IRI.
2. The shape itself carries `sh:deactivated true`. This includes shapes redeclared by an extension profile through the validator's existing **override-by-name** mechanism (the way to disable a `PropertyShape` nested inside a `NodeShape`, i.e. one without an absolute IRI).

Cross-profile deactivation is scoped to the shape's transitive descendants, so unrelated profiles loaded in the same process cannot interfere with one another.

### Python checks
The `@check` decorator on Python requirements now accepts a `deactivated: bool` flag, mirroring SHACL's `sh:deactivated`. A check declared with `deactivated=True` is skipped during validation:

```python
@check(name="my check", deactivated=True)
def check_foo(self, ctx):
 ...
```

This lets an extension profile redeclare a Python check by name and turn it off, in the same spirit as SHACL override-by-name.

## How to deactivate a SHACL check

**Shape with an absolute IRI** (e.g. a top-level `NodeShape` or `PropertyShape`): reference the shape by IRI from the extension profile and mark it as deactivated — no redeclaration needed.

```turtle
<https://parent-profile/ShapeC> sh:deactivated true .
```

**Nested `PropertyShape` without an absolute IRI** (a property declared inline inside a parent `NodeShape`): use the validator's **override-by-name**. Declare a new `PropertyShape` in the extension profile with the same `sh:name` as the one to disable; this overrides the parent's `PropertyShape` and lets you redefine its content — stricter/looser constraints, or full deactivation via `sh:deactivated true`.

```turtle
ro:ShapeC a sh:NodeShape ;
    sh:name "The Shape C" ;
    sh:targetNode ro:ro-crate-metadata.json ;
    sh:property [
        a sh:PropertyShape ;
        sh:name "Check Metadata File Descriptor entity existence" ;
        sh:path rdf:type ;
        sh:deactivated true ;
    ] .
```

[fix #127]