### PR TITLE
fix: support non-HTTP URI schemes for (Web)Data Entities (#176)

### DIFF
--- a/rocrate_validator/errors.py
+++ b/rocrate_validator/errors.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    # Imported only for type-checking to avoid a circular import:
+    # rocrate_validator.utils.uri imports this module at runtime.
+    from rocrate_validator.utils.uri import URI
 
 
 class ROCValidatorError(Exception):
@@ -243,29 +251,34 @@ class CheckValidationError(ValidationError):
 class ROCrateInvalidURIError(ROCValidatorError):
     """Raised when an invalid URI is provided."""
 
-    def __init__(self, uri: str, message: Optional[str] = None):
+    def __init__(self, uri: Union[str, Path, URI], message: Optional[str] = None):
         self._uri = uri
         self._message = message or self.default_error_message(uri)
 
     @property
-    def uri(self) -> Optional[str]:
-        """The invalid URI."""
+    def uri(self) -> Union[str, Path, URI]:
+        """The invalid URI, as originally provided (str, Path, or URI)."""
         return self._uri
 
     @property
-    def message(self) -> Optional[str]:
+    def uri_string(self) -> str:
+        """The invalid URI normalised to its string form."""
+        return str(self._uri)
+
+    @property
+    def message(self) -> str:
         """The error message."""
         return self._message
 
     def __str__(self) -> str:
         return self._message
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ROCrateInvalidURIError({self._uri!r})"
 
     @classmethod
-    def default_error_message(cls, uri: str) -> str:
-        return f"\"{uri}\" is not a valid RO-Crate URI. "\
+    def default_error_message(cls, uri: Union[str, Path, URI]) -> str:
+        return f"\"{str(uri)}\" is not a valid RO-Crate URI. "\
             "It MUST be either a local path to the RO-Crate root directory or a local/remote RO-Crate ZIP file."
 
 

--- a/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/must/4_data_entity_metadata.py
@@ -38,11 +38,13 @@ class DataEntityRequiredChecker(PyFunctionCheck):
             return True
         # Perform the check
         result = True
+        # Web-based Data Entities (absolute URIs with any scheme other than `file`,
+        # e.g. http://, https://, ftp://, scp://, s3://, ...) are not required to
+        # be part of the local payload per the RO-Crate specification.
         for entity in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True):
             assert entity.id is not None, "Entity has no @id"
             logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
             try:
-                logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
                 if entity.has_local_identifier():
                     logger.debug(
                         "Ignoring the Data Entity '%s' as it is a local entity with a local identifier. "

--- a/rocrate_validator/profiles/ro-crate/should/5_web_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/should/5_web_data_entity_metadata.py
@@ -16,6 +16,7 @@ from rocrate_validator.utils import log as logging
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import (PyFunctionCheck, check,
                                                    requirement)
+from rocrate_validator.utils.uri import AvailabilityStatus
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -32,13 +33,37 @@ class WebDataEntityRecommendedChecker(PyFunctionCheck):
     def check_availability(self, context: ValidationContext) -> bool:
         """
         Check if the Web-based Data Entity is directly downloadable
-        by a simple retrieval (e.g. HTTP GET) permitting redirection and HTTP/HTTPS URIs
+        by a simple retrieval (e.g. HTTP GET) permitting redirection and HTTP/HTTPS URIs.
+
+        Resources that cannot be natively retrieved by the validator (e.g.
+        `scp://`, `s3://`, `sftp://`) or that are protected by an authorization
+        mechanism (HTTP 401/403) are reported as recommendation-level issues
+        and logged as warnings, without invalidating the validation.
         """
         result = True
         for entity in context.ro_crate.metadata.get_web_data_entities():
             assert entity.id is not None, "Entity has no @id"
             try:
-                if not entity.is_available():
+                status = entity.check_availability()
+                if status == AvailabilityStatus.AVAILABLE:
+                    continue
+                if status == AvailabilityStatus.UNAUTHORIZED:
+                    msg = (
+                        f"Web-based Data Entity {entity.id} is protected by an "
+                        f"authorization mechanism; availability could not be verified"
+                    )
+                    logger.warning(msg)
+                    context.result.add_issue(msg, self)
+                elif status == AvailabilityStatus.UNCHECKABLE:
+                    scheme = entity.id_as_uri.scheme
+                    msg = (
+                        f"Web-based Data Entity {entity.id} uses scheme "
+                        f"'{scheme}' which is not natively supported by the "
+                        f"validator; availability could not be verified"
+                    )
+                    logger.warning(msg)
+                    context.result.add_issue(msg, self)
+                else:
                     context.result.add_issue(
                         f'Web-based Data Entity {entity.id} is not available', self)
                     result = False
@@ -59,6 +84,12 @@ class WebDataEntityRecommendedChecker(PyFunctionCheck):
         result = True
         for entity in context.ro_crate.metadata.get_web_data_entities():
             assert entity.id is not None, "Entity has no @id"
+            # Skip entities whose scheme the validator cannot natively fetch
+            # (e.g. scp://, s3://): without retrieving the content there is
+            # no actual size to compare `contentSize` against. Reachability
+            # is then checked separately via `is_available()` below.
+            if not entity.id_as_uri.is_natively_checkable():
+                continue
             if entity.is_available():
                 content_size = entity.get_property("contentSize")
                 if content_size and int(content_size) != context.ro_crate.get_external_file_size(entity.id):

--- a/rocrate_validator/rocrate.py
+++ b/rocrate_validator/rocrate.py
@@ -30,7 +30,7 @@ from rocrate_validator.utils import log as logging
 from rocrate_validator.errors import ROCrateInvalidURIError
 from rocrate_validator.utils.uri import validate_rocrate_uri
 from rocrate_validator.utils.http import HttpRequester
-from rocrate_validator.utils.uri import URI
+from rocrate_validator.utils.uri import URI, AvailabilityStatus, is_external_reference
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -140,8 +140,17 @@ class ROCrateEntity:
     @classmethod
     def get_id_as_uri(cls, entity_id: str, ro_crate: ROCrate) -> URI:
         assert entity_id, "Entity ID cannot be None"
-        if entity_id.startswith("http"):
+        # Per RO-Crate 1.1 § 4.2.2, an `@id` is either a relative URI path or
+        # an external URI/IRI (RFC 3986/3987). External references are used
+        # as-is (without resolving them against the crate URI) so the entity
+        # is classified as remote/web-based; this covers both authority-based
+        # forms (``http://``, ``scp://``) and scheme-only ones (``urn:``,
+        # ``doi:``, ``arcp:``).
+        if is_external_reference(entity_id):
             return URI(entity_id)
+        # Otherwise the `@id` is a relative path: if the RO-Crate itself is
+        # remote, resolve it against the crate URI so the entity is still
+        # classified as remote/web-based.
         if ro_crate.uri.is_remote_resource():
             if entity_id.startswith("./"):
                 return URI(f"{ro_crate.uri}/{entity_id[2:]}")
@@ -208,58 +217,66 @@ class ROCrateEntity:
     def is_local(self) -> bool:
         return not self.is_remote()
 
-    def is_available(self) -> bool:
+    def check_availability(self) -> AvailabilityStatus:
+        """
+        Return a fine-grained availability status for this entity.
+
+        This is the primary check; :meth:`is_available` is the boolean
+        shortcut built on top of it. The status distinguishes definitely
+        unavailable resources, auth-protected ones, and remote URIs whose
+        scheme the validator cannot natively check (scp://, s3://, ...).
+        """
         try:
-            # check if the entity points to an external file
-            if self.id.startswith("http"):
+            entity_uri = self.id_as_uri
+            # Remote entities with a scheme we can natively reach are checked
+            # by inspecting the remote response status.
+            if entity_uri.is_natively_checkable():
                 logger.debug("Checking the availability of a remote entity")
-                return self.ro_crate.get_external_file_size(self.id) > 0
+                return entity_uri.check_availability()
 
-            # check if the entity is part of the local RO-Crate
+            # Remote entities with a non-natively-checkable scheme cannot be
+            # verified (scp://, sftp://, s3://, ...): report UNCHECKABLE so
+            # callers can warn without invalidating the validation.
+            if entity_uri.is_remote_resource():
+                logger.debug(
+                    "Cannot natively verify availability for entity '%s' (scheme '%s')",
+                    self.id,
+                    entity_uri.scheme,
+                )
+                return AvailabilityStatus.UNCHECKABLE
+
+            # Local entity: locate it inside the (local or remote) RO-Crate.
             if self.ro_crate.uri.is_local_resource():
-                # check if the file exists in the local file system
                 if isinstance(self.ro_crate, ROCrateLocalFolder):
-                    logger.debug(
-                        "Checking the availability of a local entity in a local folder"
-                    )
-                    return self.ro_crate.has_file(
-                        self.id_as_path
-                    ) or self.ro_crate.has_directory(self.id_as_path)
-                # check if the file exists in the local zip file
+                    found = self.ro_crate.has_file(self.id_as_path) or self.ro_crate.has_directory(self.id_as_path)
+                    return AvailabilityStatus.AVAILABLE if found else AvailabilityStatus.UNAVAILABLE
                 if isinstance(self.ro_crate, ROCrateLocalZip):
-                    logger.debug(
-                        "Checking the availability of a local entity in a local zip file"
-                    )
-                    # Skip the check for the root of a ZIP archive
                     if self.id == "./":
-                        logger.debug(
-                            "Skipping the check for the presence of the Data Entity '%s' within the RO-Crate "
-                            "as it is the root of a ZIP archive",
-                            self.id,
-                        )
-                        return True
-                    return self.ro_crate.has_directory(
+                        return AvailabilityStatus.AVAILABLE
+                    found = self.ro_crate.has_directory(unquote(str(self.id))) or self.ro_crate.has_file(
                         unquote(str(self.id))
-                    ) or self.ro_crate.has_file(unquote(str(self.id)))
+                    )
+                    return AvailabilityStatus.AVAILABLE if found else AvailabilityStatus.UNAVAILABLE
 
-            # check if the entity is part of the remote RO-Crate
-            logger.debug(
-                "Checking the availability of a remote entity in a remote RO-Crate"
-            )
             if self.ro_crate.uri.is_remote_resource():
                 if self.id == "./":
-                    return self.ro_crate.get_file_size(Path(self.id_as_uri())) > 0
-                return self.ro_crate.has_directory(
-                    unquote(str(self.id))
-                ) or self.ro_crate.has_file(unquote(str(self.id)))
+                    found = self.ro_crate.get_file_size(Path(self.id_as_uri())) > 0
+                else:
+                    found = self.ro_crate.has_directory(unquote(str(self.id))) or self.ro_crate.has_file(
+                        unquote(str(self.id))
+                    )
+                return AvailabilityStatus.AVAILABLE if found else AvailabilityStatus.UNAVAILABLE
         except Exception as e:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception(e)
-            return False
+            return AvailabilityStatus.UNAVAILABLE
 
-        raise ROCrateInvalidURIError(
-            uri=self.id, message="Could not determine the availability of the entity"
-        )
+        # Fallthrough: the crate URI is neither a recognized local nor a
+        # remote resource — the entity location cannot be determined.
+        raise ROCrateInvalidURIError(uri=self.id, message="Could not determine the availability of the entity")
+
+    def is_available(self) -> bool:
+        return self.check_availability() == AvailabilityStatus.AVAILABLE
 
     def get_size(self) -> int:
         try:

--- a/rocrate_validator/utils/uri.py
+++ b/rocrate_validator/utils/uri.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import re
 from pathlib import Path
 from typing import Optional, Union
@@ -23,6 +24,15 @@ from rocrate_validator.utils.http import HttpRequester
 
 # set up logging
 logger = logging.getLogger(__name__)
+
+
+class AvailabilityStatus(enum.Enum):
+    """Outcome of a URI availability check."""
+
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+    UNAUTHORIZED = "unauthorized"
+    UNCHECKABLE = "uncheckable"
 
 
 # RFC 3986 §3.1: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
@@ -67,18 +77,62 @@ def is_external_reference(value: object) -> bool:
 
 
 class URI:
+    # Schemes that the validator can fetch natively to verify availability.
+    # Anything outside this set is treated as remote but un-checkable.
+    NATIVELY_CHECKABLE_SCHEMES = ("http", "https")
 
-    REMOTE_SUPPORTED_SCHEMA = ('http', 'https', 'ftp')
+    # Schemes accepted as RO-Crate root URIs (the loading code can only
+    # handle these as crate locations).
+    SUPPORTED_ROCRATE_SCHEMES = ("http", "https", "ftp", "file")
+
+    # Well-known remote schemes commonly used to reference data resources
+    # (used to distinguish "recognized but un-checkable" from "unknown").
+    KNOWN_REMOTE_SCHEMES = (
+        # Web
+        "http",
+        "https",
+        # FTP family
+        "ftp",
+        "ftps",
+        "sftp",
+        # Remote shell / transfer
+        "scp",
+        "ssh",
+        "rsync",
+        # Cloud object stores
+        "s3",
+        "gs",
+        "abfs",
+        "abfss",
+        "wasb",
+        "wasbs",
+        # WebDAV
+        "dav",
+        "davs",
+        # Research / big-data filesystems
+        "irods",
+        "hdfs",
+    )
+
+    # Backwards-compatible alias kept for callers that still inspect it.
+    REMOTE_SUPPORTED_SCHEMA = SUPPORTED_ROCRATE_SCHEMES[:-1]  # http, https, ftp
 
     def __init__(self, uri: Union[str, Path]):
+        if uri is None or (isinstance(uri, str) and not uri.strip()):
+            raise ValueError("Invalid URI: empty value")
         self._uri = uri = str(uri)
         try:
-            # map local path to URI with file scheme
-            if not re.match(r'^\w+://', uri):
+            # Inputs that are not external references are assumed to be local
+            # paths, so the ``file://`` scheme is added explicitly. The
+            # detection covers both authority-based schemes (``http://``,
+            # ``scp://``) and scheme-only ones (``urn:``, ``doi:``), as
+            # defined by RFC 3986.
+            if not is_external_reference(uri):
                 uri = f"file://{uri}"
             # parse the value to extract the scheme
             self._parse_result = urlparse(uri)
-            assert self.scheme in self.REMOTE_SUPPORTED_SCHEMA + ('file',), "Invalid URI scheme"
+            if not self.scheme:
+                raise ValueError("URI has no scheme")
         except Exception as e:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(e)
@@ -127,10 +181,23 @@ class URI:
         return Path(self._uri)
 
     def is_remote_resource(self) -> bool:
-        return self.scheme in self.REMOTE_SUPPORTED_SCHEMA
+        """Return True for any well-formed URI whose scheme is not `file`."""
+        return bool(self.scheme) and self.scheme != "file"
 
     def is_local_resource(self) -> bool:
-        return not self.is_remote_resource()
+        return self.scheme == "file"
+
+    def is_natively_checkable(self) -> bool:
+        """Return True if availability can be verified via a native request."""
+        return self.scheme in self.NATIVELY_CHECKABLE_SCHEMES
+
+    def is_known_remote_scheme(self) -> bool:
+        """Return True if the scheme is one of the well-known remote schemes."""
+        return self.scheme in self.KNOWN_REMOTE_SCHEMES
+
+    def has_supported_rocrate_scheme(self) -> bool:
+        """Return True if the scheme is supported as an RO-Crate root URI."""
+        return self.scheme in self.SUPPORTED_ROCRATE_SCHEMES
 
     def is_local_directory(self) -> bool:
         return self.is_local_resource() and self.as_path().is_dir()
@@ -138,17 +205,46 @@ class URI:
     def is_local_file(self) -> bool:
         return self.is_local_resource() and self.as_path().is_file()
 
-    def is_available(self) -> bool:
-        """Check if the resource is available"""
+    def check_availability(self) -> AvailabilityStatus:
+        """
+        Inspect the resource availability with as much detail as possible.
+
+        Distinguishes:
+          - AVAILABLE: confirmed reachable
+          - UNAUTHORIZED: reachable but protected (HTTP 401/403)
+          - UNAVAILABLE: confirmed not reachable
+          - UNCHECKABLE: scheme has no native check (e.g. scp://, s3://)
+        """
         if self.is_remote_resource():
+            if not self.is_natively_checkable():
+                logger.debug(
+                    "Cannot natively verify availability for URI '%s' (scheme '%s')",
+                    self._uri,
+                    self.scheme,
+                )
+                return AvailabilityStatus.UNCHECKABLE
             try:
                 response = HttpRequester().head(self._uri, allow_redirects=True)
-                return response.status_code in (200, 302)
+                if response.status_code in (200, 302):
+                    return AvailabilityStatus.AVAILABLE
+                if response.status_code in (401, 403):
+                    return AvailabilityStatus.UNAUTHORIZED
+                return AvailabilityStatus.UNAVAILABLE
             except Exception as e:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(e)
-                return False
-        return Path(self._uri).exists()
+                return AvailabilityStatus.UNAVAILABLE
+        return AvailabilityStatus.AVAILABLE if Path(self._uri).exists() else AvailabilityStatus.UNAVAILABLE
+
+    def is_available(self) -> bool:
+        """
+        Return True only when the resource is confirmed available.
+
+        Resources that cannot be verified (unsupported scheme, auth-protected)
+        return False here; callers that need to distinguish those cases should
+        use :meth:`check_availability` instead.
+        """
+        return self.check_availability() == AvailabilityStatus.AVAILABLE
 
     def __str__(self):
         return self._uri
@@ -179,6 +275,9 @@ def validate_rocrate_uri(uri: Union[str, Path, URI], silent: bool = False) -> bo
         try:
             # parse the value to extract the scheme
             uri = URI(str(uri)) if isinstance(uri, str) or isinstance(uri, Path) else uri
+            # restrict RO-Crate roots to schemes the loader can actually handle
+            if not uri.has_supported_rocrate_scheme():
+                raise errors.ROCrateInvalidURIError(uri)
             # check if the URI is a remote resource or local directory or local file
             if not uri.is_remote_resource() and not uri.is_local_directory() and not uri.is_local_file():
                 raise errors.ROCrateInvalidURIError(uri)
@@ -187,7 +286,7 @@ def validate_rocrate_uri(uri: Union[str, Path, URI], silent: bool = False) -> bo
                 raise errors.ROCrateInvalidURIError(uri)
             # check if the resource is available
             if not uri.is_available():
-                raise errors.ROCrateInvalidURIError(uri, message=f"The RO-crate at the URI \"{uri}\" is not available")
+                raise errors.ROCrateInvalidURIError(uri, message=f'The RO-crate at the URI "{uri}" is not available')
             return True
         except ValueError as e:
             logger.error(e)

--- a/rocrate_validator/utils/uri.py
+++ b/rocrate_validator/utils/uri.py
@@ -15,7 +15,7 @@
 import re
 from pathlib import Path
 from typing import Optional, Union
-from urllib.parse import ParseResult, parse_qsl, urlparse
+from urllib.parse import ParseResult, parse_qsl, urlparse, urlsplit
 
 from rocrate_validator import errors
 from rocrate_validator.utils import log as logging
@@ -23,6 +23,47 @@ from rocrate_validator.utils.http import HttpRequester
 
 # set up logging
 logger = logging.getLogger(__name__)
+
+
+# RFC 3986 §3.1: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+# Require length >= 2 to disambiguate from Windows drive letters
+# (e.g. ``C:\path``). RFC 3986 allows single-character schemes but no
+# IANA-registered scheme is one character long, so this is an acceptable
+# trade-off.
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+\-.]+$")
+
+
+def is_external_reference(value: object) -> bool:
+    """
+    Check if `value` is an external reference (i.e. has a URI scheme).
+
+    Return True if *value* has an explicit URI or IRI scheme (RFC 3986 for URI, and RFC 3987 for IRIs).
+    Both authority-based forms (``http://...``)
+    and scheme-only forms (``urn:...``, ``doi:...``, ``arcp://...``) are
+    accepted, as required by RO-Crate 1.1 §4.2.2.
+
+    The check is purely syntactic: the scheme is not verified against
+    the IANA registry and the hier-part is not resolved.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # urlsplit can raise on malformed IPv6 literals, invalid ports, etc.
+        return False
+
+    # Scheme must conform to RFC 3986 (and be at least 2 chars long).
+    if not _SCHEME_RE.match(parts.scheme):
+        return False
+
+    # Reject scheme-only input (``urn:``, ``doi:``): syntactically valid
+    # per the grammar but semantically unusable as an identifier.
+    if not (parts.netloc or parts.path or parts.query or parts.fragment):
+        return False
+
+    return True
 
 
 class URI:

--- a/rocrate_validator/utils/uri.py
+++ b/rocrate_validator/utils/uri.py
@@ -114,6 +114,10 @@ class URI:
         "hdfs",
     )
 
+    # ``file://`` authorities that denote the local machine (RFC 8089 §2):
+    # an empty authority (``file:///path``) or the special ``localhost`` host.
+    LOCAL_FILE_AUTHORITIES = ("", "localhost")
+
     # Backwards-compatible alias kept for callers that still inspect it.
     REMOTE_SUPPORTED_SCHEMA = SUPPORTED_ROCRATE_SCHEMES[:-1]  # http, https, ftp
 
@@ -123,12 +127,20 @@ class URI:
         self._uri = uri = str(uri)
         try:
             # Inputs that are not external references are assumed to be local
-            # paths, so the ``file://`` scheme is added explicitly. The
+            # paths, so the ``file:`` scheme is added explicitly. The
             # detection covers both authority-based schemes (``http://``,
             # ``scp://``) and scheme-only ones (``urn:``, ``doi:``), as
             # defined by RFC 3986.
+            #
+            # The authority-less ``file:`` form (no ``//``) is used on purpose:
+            # ``file://data/x`` would parse ``data`` as the authority (host),
+            # while ``file:data/x`` keeps ``data/x`` as the path with an empty
+            # authority. This way a local path never gains a spurious host and
+            # the authority remains a reliable signal to tell a local file
+            # (``file:///path``) from a remote one (``file://host/path``,
+            # RFC 8089).
             if not is_external_reference(uri):
-                uri = f"file://{uri}"
+                uri = f"file:{uri}"
             # parse the value to extract the scheme
             self._parse_result = urlparse(uri)
             if not self.scheme:
@@ -181,11 +193,23 @@ class URI:
         return Path(self._uri)
 
     def is_remote_resource(self) -> bool:
-        """Return True for any well-formed URI whose scheme is not `file`."""
-        return bool(self.scheme) and self.scheme != "file"
+        """
+        Return True for any well-formed URI that points to a non-local resource.
+
+        Schemes other than ``file`` (``http``, ``scp``, ``s3``, ...) are always
+        remote. A ``file://`` URI is remote when it carries an explicit,
+        non-local authority (host) — e.g. ``file://hostname/path`` per
+        RFC 8089: the referenced file lives on another machine and is therefore
+        not part of the local RO-Crate payload.
+        """
+        if not self.scheme:
+            return False
+        if self.scheme == "file":
+            return self.get_netloc().lower() not in self.LOCAL_FILE_AUTHORITIES
+        return True
 
     def is_local_resource(self) -> bool:
-        return self.scheme == "file"
+        return self.scheme == "file" and self.get_netloc().lower() in self.LOCAL_FILE_AUTHORITIES
 
     def is_natively_checkable(self) -> bool:
         """Return True if availability can be verified via a native request."""

--- a/tests/integration/profiles/ro-crate/test_data_entity_metadata.py
+++ b/tests/integration/profiles/ro-crate/test_data_entity_metadata.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 
-from rocrate_validator import models
+import pytest
+
+from rocrate_validator import models, services
 from tests.conftest import SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER
 from tests.ro_crates import InvalidDataEntity, ValidROC
 from tests.shared import do_entity_test
@@ -34,7 +37,7 @@ def test_missing_data_entity_reference():
         models.Severity.REQUIRED,
         False,
         ["Data Entity: REQUIRED properties"],
-        ["sort-and-change-case.ga", "foo/xxx"]
+        ["sort-and-change-case.ga", "foo/xxx"],
     )
 
 
@@ -44,7 +47,7 @@ def test_data_entity_must_be_directly_linked():
         paths.direct_hasPart_data_entity_reference,
         models.Severity.REQUIRED,
         True,
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER]
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
     )
 
 
@@ -54,7 +57,7 @@ def test_data_entity_not_linked():
         paths.dataset_not_linked_to_root,
         models.Severity.REQUIRED,
         False,
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER]
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
     )
 
 
@@ -64,7 +67,7 @@ def test_data_entity_must_be_indirectly_linked():
         paths.indirect_hasPart_data_entity_reference,
         models.Severity.REQUIRED,
         True,
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER]
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
     )
 
 
@@ -75,7 +78,7 @@ def test_directory_data_entity_wo_trailing_slash():
         models.Severity.RECOMMENDED,
         False,
         ["Directory Data Entity: RECOMMENDED value restriction"],
-        ["Every Data Entity Directory URI SHOULD end with `/`"]
+        ["Every Data Entity Directory URI SHOULD end with `/`"],
     )
 
 
@@ -86,7 +89,7 @@ def test_missing_data_entity_encoding_format():
         models.Severity.RECOMMENDED,
         False,
         ["File Data Entity: RECOMMENDED properties"],
-        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"]
+        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"],
     )
 
 
@@ -97,7 +100,7 @@ def test_invalid_data_entity_encoding_format_pronom():
         models.Severity.RECOMMENDED,
         False,
         ["File Data Entity: RECOMMENDED properties"],
-        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"]
+        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"],
     )
 
 
@@ -108,7 +111,7 @@ def test_invalid_data_entity_encoding_format_ctx_website_type():
         models.Severity.RECOMMENDED,
         False,
         ["File Data Entity: RECOMMENDED properties"],
-        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"]
+        ["Missing or invalid `encodingFormat` linked to the `File Data Entity`"],
     )
 
 
@@ -119,7 +122,7 @@ def test_invalid_data_entity_encoding_format_ctx_website_name():
         models.Severity.RECOMMENDED,
         False,
         ["WebSite RECOMMENDED Properties"],
-        ["A WebSite MUST have a `name` property"]
+        ["A WebSite MUST have a `name` property"],
     )
 
 
@@ -129,7 +132,7 @@ def test_valid_data_entity_encoding_format_pronom():
         paths.valid_encoding_format_pronom,
         models.Severity.RECOMMENDED,
         True,
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER]
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
     )
 
 
@@ -139,7 +142,7 @@ def test_valid_data_entity_encoding_format_ctx_website():
         paths.valid_encoding_format_ctx_entity,
         models.Severity.RECOMMENDED,
         True,
-        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER]
+        skip_checks=[SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER],
     )
 
 
@@ -150,7 +153,7 @@ def test_missing_file_data_entity_with_quoted_name():
         models.Severity.REQUIRED,
         False,
         ["Data Entity: REQUIRED resource availability"],
-        ["The RO-Crate does not include the Data Entity 'pics/2017-06-11%2012.56.14.jpg' as part of its payload"]
+        ["The RO-Crate does not include the Data Entity 'pics/2017-06-11%2012.56.14.jpg' as part of its payload"],
     )
 
 
@@ -161,7 +164,7 @@ def test_missing_file_data_entity_with_unquoted_name():
         models.Severity.REQUIRED,
         False,
         ["Data Entity: REQUIRED resource availability"],
-        ["The RO-Crate does not include the Data Entity 'pics/2017-06-11 12.56.14.jpg' as part of its payload"]
+        ["The RO-Crate does not include the Data Entity 'pics/2017-06-11 12.56.14.jpg' as part of its payload"],
     )
 
 
@@ -172,7 +175,7 @@ def test_missing_dataset_entity_with_quoted_name():
         models.Severity.REQUIRED,
         False,
         ["Data Entity: REQUIRED resource availability"],
-        ["The RO-Crate does not include the Data Entity 'data%20set/' as part of its payload"]
+        ["The RO-Crate does not include the Data Entity 'data%20set/' as part of its payload"],
     )
 
 
@@ -183,7 +186,7 @@ def test_missing_dataset_entity_with_unquoted_name():
         models.Severity.REQUIRED,
         False,
         ["Data Entity: REQUIRED resource availability"],
-        ["The RO-Crate does not include the Data Entity 'data set/' as part of its payload"]
+        ["The RO-Crate does not include the Data Entity 'data set/' as part of its payload"],
     )
 
 
@@ -194,15 +197,78 @@ def test_missing_absolute_path_data_entity():
         models.Severity.RECOMMENDED,
         False,
         ["Data Entity: RECOMMENDED resource availability"],
-        ["Data Entity file:///tmp/test.txt is not available"]
+        ["Data Entity file:///tmp/test.txt is not available"],
     )
 
 
 def test_valid_rocrate_with_data_entities():
     """"""
-    do_entity_test(
-        ValidROC().rocrate_with_data_entities,
-        models.Severity.REQUIRED,
-        True,
-        profile_identifier="ro-crate"
+    do_entity_test(ValidROC().rocrate_with_data_entities, models.Severity.REQUIRED, True, profile_identifier="ro-crate")
+
+
+@pytest.mark.parametrize(
+    "remote_entity_id",
+    [
+        "scp://transfer.example.org//data/A.0.0",
+        "sftp://user@host/path/to/file",
+        "s3://bucket/key",
+    ],
+)
+def test_remote_data_entity_does_not_fail_required_check(tmp_path, remote_entity_id):
+    """Regression test for issue #176.
+
+    A Data Entity whose `@id` is an absolute URI with a non-file scheme (e.g.
+    ``scp://``, ``sftp://``, ``s3://``) MUST NOT trigger the
+    "Data Entity: REQUIRED resource availability" violation: per the RO-Crate
+    spec, any absolute-URI Data Entity is web-based and is not required to be
+    part of the local payload.
+    """
+    crate_dir = tmp_path / "crate-with-remote-entity"
+    crate_dir.mkdir()
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+                "about": {"@id": "./"},
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Crate with remote entity",
+                "description": "Regression fixture for issue #176",
+                "datePublished": "2026-05-15T07:30:50+00:00",
+                "license": {"@id": "https://spdx.org/licenses/CC0-1.0"},
+                "hasPart": [{"@id": remote_entity_id}],
+            },
+            {
+                "@id": remote_entity_id,
+                "@type": "File",
+                "name": "Remote file",
+                "contentSize": 16,
+                "dateModified": "2026-05-15T07:30:50+00:00",
+                "sdDatePublished": "2026-05-15T07:31:03+00:00",
+            },
+            {"@id": "https://spdx.org/licenses/CC0-1.0", "@type": "CreativeWork", "name": "CC0"},
+        ],
+    }
+    (crate_dir / "ro-crate-metadata.json").write_text(json.dumps(metadata))
+
+    result = services.validate(
+        models.ValidationSettings(
+            rocrate_uri=crate_dir,
+            requirement_severity=models.Severity.REQUIRED,
+            profile_identifier="ro-crate",
+        )
     )
+    assert result.passed(), (
+        f"RO-Crate with remote entity '{remote_entity_id}' should pass REQUIRED "
+        f"validation; got issues: {[i.message for i in result.get_issues()]}"
+    )
+    # And the specific must/4 violation must NOT be among the issues.
+    for issue in result.get_issues():
+        assert "as part of its payload" not in (issue.message or ""), (
+            f"Unexpected payload violation raised for remote entity: {issue.message}"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,11 @@ logger = logging.getLogger(__name__)
 
 @fixture
 def cli_runner() -> CliRunner:
-    return CliRunner()
+    # Force a wide terminal: the CLI renders output through Rich, which wraps
+    # and truncates tables/panels to the terminal width (defaulting to 80
+    # columns when stdout is captured). Pinning COLUMNS keeps the rendered
+    # output deterministic regardless of the environment's actual width.
+    return CliRunner(env={"COLUMNS": "200"})
 
 
 def test_version(cli_runner: CliRunner):
@@ -134,7 +138,11 @@ def test_validate_with_invalid_profiles_path_dir(cli_runner: CliRunner):
     )
     assert result.exit_code == 2
     # logger.debug(result.output)
-    assert re.search(f"Path '{dummy_profiles_path}' does not exist.", result.output)
+    # On narrow terminals the Rich error panel wraps the message across lines
+    # and inserts box-drawing borders (│) between words; strip those and
+    # collapse whitespace so the match does not depend on terminal width.
+    normalized_output = re.sub(r"[\s│]+", " ", result.output)
+    assert re.search(f"Path '{dummy_profiles_path}' does not exist.", normalized_output)
 
 
 def test_profiles_list(cli_runner: CliRunner):

--- a/tests/unit/test_rocrate.py
+++ b/tests/unit/test_rocrate.py
@@ -604,6 +604,9 @@ def _metadata_dict_with_id(entity_id: str) -> dict:
         "s3://bucket/key",
         "https://example.org/data.txt",
         "arcp://name,foo/bar",
+        # `file://` URIs with a (non-local) authority denote files living on
+        # another host (RFC 8089), so they are remote too.
+        "file://gs02r3b58-ib0/scratch/tmp/5190874/tmp_rf_samples_slt86rc0",
         # scheme-only absolute URIs (no authority; RO-Crate 1.1 § 4.2.2 + RFC 3986)
         "urn:doi:10.5281/zenodo.1234",
         "doi:10.5281/zenodo.1234",
@@ -626,4 +629,31 @@ def test_absolute_uri_data_entity_is_classified_as_remote(entity_id):
     )
     assert entity not in crate.metadata.get_data_entities(exclude_web_data_entities=True), (
         f"Entity '{entity_id}' should be excluded from local-only data entities"
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        # `file://` URIs without an authority (RFC 8089) or with the special
+        # `localhost` authority refer to the local machine, so they describe
+        # local payload members that the must/4 check must still verify.
+        "file:///absolute/path/to/file.txt",
+        "file://localhost/absolute/path/to/file.txt",
+    ],
+)
+def test_local_file_uri_data_entity_is_not_remote(entity_id):
+    """
+    `file://` Data Entity identifiers that point to the local machine (empty or
+    `localhost` authority) MUST NOT be treated as remote/web-based: only
+    `file://<host>/...` URIs with a real host are remote (issue #176 follow-up).
+    """
+    crate = ROCrate.from_metadata_dict(_metadata_dict_with_id(entity_id))
+    entity = crate.metadata.get_entity(entity_id)
+    assert entity is not None, "Entity should be present in the metadata"
+    assert not entity.is_remote(), (
+        f"Entity with local file URI '{entity_id}' should NOT be classified as remote"
+    )
+    assert entity not in crate.metadata.get_web_data_entities(), (
+        f"Entity '{entity_id}' should not be listed as a web data entity"
     )

--- a/tests/unit/test_rocrate.py
+++ b/tests/unit/test_rocrate.py
@@ -556,20 +556,74 @@ def test_entity_path_from_identifier():
     quoted_entity_id = "pics/2017-06-11%2012.56.14.jpg"
     path = ROCrateEntity.get_path_from_identifier(quoted_entity_id, rocrate_path=rocrate_path)
     logger.debug(f"Quoted Entity Path: {path}")
-    assert str(path) == f"{rocrate_path}/pics/2017-06-11%2012.56.14.jpg", \
+    assert str(path) == f"{rocrate_path}/pics/2017-06-11%2012.56.14.jpg", (
         "Path should be pics/2017-06-11%2012.56.14.jpg"
+    )
 
     # Test quoted entity id which does not exist within the ro-crate
     quoted_entity_id = "pics/2018-06-11%2012.56.14.jpg"
-    path = ROCrateEntity.get_path_from_identifier(
-        quoted_entity_id, rocrate_path=rocrate_path, decode=True)
+    path = ROCrateEntity.get_path_from_identifier(quoted_entity_id, rocrate_path=rocrate_path, decode=True)
     logger.debug(f"Quoted Entity Path: {path}")
-    assert str(path) == f"{rocrate_path}/pics/2018-06-11 12.56.14.jpg", \
-        "Path should be pics/2018-06-11 12.56.14.jpg"
+    assert str(path) == f"{rocrate_path}/pics/2018-06-11 12.56.14.jpg", "Path should be pics/2018-06-11 12.56.14.jpg"
 
     # Test unquoted entity id which exists within the ro-crate
     unquoted_entity_id = "pics/2017-06-11 12.56.14.jpg"
     path = ROCrateEntity.get_path_from_identifier(unquoted_entity_id, rocrate_path=rocrate_path)
     logger.debug(f"Unquoted Entity Path: {path}")
-    assert str(path) == f"{rocrate_path}/pics/2017-06-11 12.56.14.jpg", \
-        "Path should be pics/2017-06-11 12.56.14.jpg"
+    assert str(path) == f"{rocrate_path}/pics/2017-06-11 12.56.14.jpg", "Path should be pics/2017-06-11 12.56.14.jpg"
+
+
+def _metadata_dict_with_id(entity_id: str) -> dict:
+    """Build a minimal RO-Crate metadata dict referencing a single data entity."""
+    return {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+                "about": {"@id": "./"},
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "Test crate",
+                "hasPart": [{"@id": entity_id}],
+            },
+            {"@id": entity_id, "@type": "File", "name": "remote-file"},
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        # authority-based absolute URIs (with a `//` authority component)
+        "scp://transfer.example.org//data/A.0.0",
+        "sftp://user@host/path/to/file",
+        "s3://bucket/key",
+        "https://example.org/data.txt",
+        "arcp://name,foo/bar",
+        # scheme-only absolute URIs (no authority; RO-Crate 1.1 § 4.2.2 + RFC 3986)
+        "urn:doi:10.5281/zenodo.1234",
+        "doi:10.5281/zenodo.1234",
+    ],
+)
+def test_absolute_uri_data_entity_is_classified_as_remote(entity_id):
+    """
+    Data entities whose @id is an absolute URI (any non-file scheme, with or
+    without authority) MUST be recognized as remote (web-based) data entities
+    so that the must/4 payload check is skipped for them.
+
+    Regression test for issue #176.
+    """
+    crate = ROCrate.from_metadata_dict(_metadata_dict_with_id(entity_id))
+    entity = crate.metadata.get_entity(entity_id)
+    assert entity is not None, "Entity should be present in the metadata"
+    assert entity.is_remote(), f"Entity with absolute URI '{entity_id}' should be classified as remote"
+    assert entity in crate.metadata.get_web_data_entities(), (
+        f"Entity '{entity_id}' should be listed as a web data entity"
+    )
+    assert entity not in crate.metadata.get_data_entities(exclude_web_data_entities=True), (
+        f"Entity '{entity_id}' should be excluded from local-only data entities"
+    )

--- a/tests/unit/test_uri.py
+++ b/tests/unit/test_uri.py
@@ -25,11 +25,52 @@ from rocrate_validator.utils.uri import URI
 def test_valid_url():
     uri = URI("http://example.com")
     assert uri.is_remote_resource()
+    assert uri.is_natively_checkable()
+    assert uri.has_supported_rocrate_scheme()
+
+
+def test_uri_with_unknown_scheme_is_accepted_but_not_supported_as_rocrate_root():
+    # Schemes outside the natively-supported set are valid URIs (they may
+    # appear as Data Entity identifiers, e.g. scp://, s3://) but they are
+    # not accepted as RO-Crate root URIs.
+    uri = URI("httpx:///example.com")
+    assert uri.is_remote_resource()
+    assert not uri.is_natively_checkable()
+    assert not uri.has_supported_rocrate_scheme()
 
 
 def test_invalid_url():
+    # A bare token without any scheme/path separator is not a valid URI.
     with pytest.raises(ValueError):
-        URI("httpx:///example.com")
+        URI("")
+
+
+def test_scp_uri_is_remote():
+    uri = URI("scp://transfer.example.org//data/A.0.0")
+    assert uri.is_remote_resource()
+    assert uri.is_known_remote_scheme()
+    assert not uri.is_natively_checkable()
+
+
+def test_s3_uri_is_remote():
+    uri = URI("s3://bucket/key/path")
+    assert uri.is_remote_resource()
+    assert uri.is_known_remote_scheme()
+    assert not uri.is_natively_checkable()
+
+
+@pytest.mark.parametrize("uri_str,expected_scheme", [
+    # Scheme-only (no authority) absolute URIs are valid per RFC 3986 and
+    # accepted by RO-Crate 1.1 § 4.2.2 as Data Entity `@id` values.
+    ("urn:doi:10.5281/zenodo.1234", "urn"),
+    ("doi:10.5281/zenodo.1234", "doi"),
+    ("arcp://name,foo/bar", "arcp"),
+])
+def test_scheme_only_absolute_uri_is_remote(uri_str, expected_scheme):
+    uri = URI(uri_str)
+    assert uri.scheme == expected_scheme
+    assert uri.is_remote_resource()
+    assert not uri.is_natively_checkable()
 
 
 def test_url_with_query_params():
@@ -131,10 +172,12 @@ def test_rocrate_uri_remote_valid():
 
 
 def test_rocrate_uri_remote_invalid():
-
-    with pytest.raises(ValueError) as excinfo:
-        URI("httpx:///example.com")
-    assert str(excinfo.value) == "Invalid URI: httpx:///example.com"
+    # An unknown scheme is a valid URI but cannot be used as an RO-Crate root.
+    uri = URI("httpx:///example.com")
+    assert not validate_rocrate_uri(uri, silent=True), \
+        f"The URI {uri} should not be accepted as an RO-Crate root"
+    with pytest.raises(ROCrateInvalidURIError):
+        validate_rocrate_uri(uri, silent=False)
 
     # Test with an invalid remote URL
     uri = URI("https:///example.com")

--- a/tests/unit/test_uri.py
+++ b/tests/unit/test_uri.py
@@ -73,6 +73,39 @@ def test_scheme_only_absolute_uri_is_remote(uri_str, expected_scheme):
     assert not uri.is_natively_checkable()
 
 
+def test_file_uri_with_remote_host_is_remote():
+    # A `file://` URI carrying a (non-local) authority points to a file on
+    # another host (RFC 8089) and must be treated as remote, not as a local
+    # payload member (regression for issue #176 with `file://` schemes).
+    uri = URI("file://gs02r3b58-ib0/scratch/tmp/5190874/tmp_rf_samples_slt86rc0")
+    assert uri.scheme == "file"
+    assert uri.is_remote_resource()
+    assert not uri.is_local_resource()
+    assert not uri.is_natively_checkable()
+
+
+@pytest.mark.parametrize("uri_str", [
+    "file:///absolute/path/file.txt",
+    "file://localhost/absolute/path/file.txt",
+])
+def test_file_uri_to_local_host_is_local(uri_str):
+    # An empty or `localhost` authority denotes the local machine.
+    uri = URI(uri_str)
+    assert uri.scheme == "file"
+    assert uri.is_local_resource()
+    assert not uri.is_remote_resource()
+
+
+@pytest.mark.parametrize("path", ["README.md", "data/file.txt", "./", "/abs/dir"])
+def test_local_path_never_gains_a_spurious_host(path):
+    # Plain filesystem paths are normalized to authority-less `file:` URIs, so
+    # the first path segment is never mistaken for a remote host.
+    uri = URI(path)
+    assert uri.is_local_resource()
+    assert not uri.is_remote_resource()
+    assert uri.get_netloc() == ""
+
+
 def test_url_with_query_params():
     uri = URI("http://example.com?param1=value1&param2=value2")
     assert uri.get_query_param("param1") == "value1"


### PR DESCRIPTION
Data Entities referenced by absolute non-HTTP(S) URIs — such as `scp://`, `sftp://`, `s3://`, `arcp://`, `urn:`, and `doi:` — were incorrectly reported as missing local payloads with `REQUIRED` severity. The validator only recognised a limited set of schemes as remote references and relied on `@id.startswith("http")` to classify external resources.

Any absolute URI is now correctly recognised as an external reference and therefore excluded from local-payload checks. Availability issues for resources that cannot be accessed because of authorization constraints or unsupported protocols are now reported as non-blocking warnings (`UNAUTHORIZED` / `UNCHECKABLE`) and no longer affect the overall validation result.

[fix #176]