### PR TITLE
feat: batch validation with auto-managed, resumable sessions

### DIFF
--- a/rocrate_validator/cli/__init__.py
+++ b/rocrate_validator/cli/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rocrate_validator.cli.commands import cache, profiles, validate
+from rocrate_validator.cli.commands import cache, profiles, sessions, validate
 from rocrate_validator.cli.main import cli
 
-__all__ = ["cache", "cli", "profiles", "validate"]
+__all__ = ["cache", "cli", "profiles", "sessions", "validate"]

--- a/rocrate_validator/cli/commands/sessions.py
+++ b/rocrate_validator/cli/commands/sessions.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import copy as _copy
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from rich.table import Table
@@ -159,7 +159,9 @@ def _select_session(console, summaries: list[dict], session_id: str | None) -> d
             console.print(f"[yellow]No session matches ID:[/yellow] {session_id}")
             return None
         if len(matches) > 1:
-            console.print(f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]")
+            console.print(
+                f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]"
+            )
             return None
         return matches[0]
     if not summaries:
@@ -414,20 +416,26 @@ def sessions_clear(
                 console.print("Aborted.")
 
         if proceed:
-            removed = 0
-            for s in targets:
-                try:
-                    Path(s["file"]).unlink()
-                    removed += 1
-                except OSError as e:
-                    logger.debug("Could not remove session %s: %s", s["file"], e)
-                    console.print(f"[red]Failed to remove {s['id'][:12]}: {e}[/red]")
+            removed = _remove_sessions(console, targets)
             console.print(f"[green]Removed {removed} session(s).[/green]")
     except Exception as e:
         handle_error(e, console)
         return
     if exit_code:
         ctx.exit(exit_code)
+
+
+def _remove_sessions(console, targets: list[dict]) -> int:
+    """Delete the session files for ``targets``, returning how many were removed."""
+    removed = 0
+    for s in targets:
+        try:
+            Path(s["file"]).unlink()
+            removed += 1
+        except OSError as e:
+            logger.debug("Could not remove session %s: %s", s["file"], e)
+            console.print(f"[red]Failed to remove {s['id'][:12]}: {e}[/red]")
+    return removed
 
 
 def _select_sessions_to_clear(
@@ -459,6 +467,22 @@ def _select_sessions_to_clear(
     return unique
 
 
+def _resolve_resumable_by_id(console, summaries: list[dict], session_id: str) -> dict | None:
+    """Match a resumable session by ID prefix, printing why when it cannot be resolved."""
+    matches = [s for s in summaries if s["id"].startswith(session_id)]
+    if not matches:
+        console.print(f"[yellow]No session matches ID:[/yellow] {session_id}")
+        return None
+    if len(matches) > 1:
+        console.print(f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]")
+        return None
+    target = matches[0]
+    if target["status"] not in _RESUMABLE_STATUSES:
+        console.print(f"[green]Session {target['id'][:12]} is already '{target['status']}'; nothing to resume.[/green]")
+        return None
+    return target
+
+
 def _select_resume_target(
     console,
     summaries: list[dict],
@@ -474,20 +498,7 @@ def _select_resume_target(
     (a message is printed in that case).
     """
     if session_id:
-        matches = [s for s in summaries if s["id"].startswith(session_id)]
-        if not matches:
-            console.print(f"[yellow]No session matches ID:[/yellow] {session_id}")
-            return None
-        if len(matches) > 1:
-            console.print(f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]")
-            return None
-        target = matches[0]
-        if target["status"] not in _RESUMABLE_STATUSES:
-            console.print(
-                f"[green]Session {target['id'][:12]} is already '{target['status']}'; nothing to resume.[/green]"
-            )
-            return None
-        return target
+        return _resolve_resumable_by_id(console, summaries, session_id)
 
     resumable = [s for s in summaries if s["status"] in _RESUMABLE_STATUSES]
     if not resumable:
@@ -596,7 +607,7 @@ def _collect_sessions(status_filter: str | None = None) -> list[dict]:
             continue
         summaries.append(summary)
     summaries.sort(
-        key=lambda s: s["updated_at"] or datetime.min,
+        key=lambda s: s["updated_at"] or datetime.min.replace(tzinfo=timezone.utc),
         reverse=True,
     )
     return summaries
@@ -616,7 +627,7 @@ def _read_session_summary(path: Path) -> dict:
         "completed_crates": None,
         "failed_crates": None,
         "created_at": None,
-        "updated_at": datetime.fromtimestamp(stat.st_mtime),
+        "updated_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
         "target": None,
         "size_bytes": stat.st_size,
     }

--- a/rocrate_validator/cli/commands/sessions.py
+++ b/rocrate_validator/cli/commands/sessions.py
@@ -1,0 +1,731 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+``rocrate-validator sessions`` subcommand: inspect and clear the auto-managed
+batch validation sessions stored under the user cache directory.
+"""
+
+from __future__ import annotations
+
+import copy as _copy
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from rich.table import Table
+
+from rocrate_validator import services
+from rocrate_validator.cli.commands.errors import handle_error
+from rocrate_validator.cli.main import cli, click
+from rocrate_validator.cli.ui.text.validate import (
+    BatchValidationCommandView,
+    format_profile_selection,
+    render_batch_footer,
+    render_batch_header,
+)
+from rocrate_validator.constants import BYTES_PER_KIB
+from rocrate_validator.models import BatchSession, BatchValidationResult, ValidationSettings
+from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.io_helpers.input import single_choice
+from rocrate_validator.utils.io_helpers.output.console import Console
+from rocrate_validator.utils.io_helpers.output.text.statistics import (
+    render_statistics,
+    render_statistics_md,
+)
+from rocrate_validator.utils.paths import get_user_sessions_dir
+
+logger = logging.getLogger(__name__)
+
+# Session states whose validation has not finished and can therefore be resumed.
+_RESUMABLE_STATUSES = ("in_progress", "interrupted")
+
+
+@cli.group("sessions")
+@click.pass_context
+def sessions(ctx):  # pylint: disable=unused-argument
+    """
+    [magenta]rocrate-validator:[/magenta] Manage auto-managed batch validation sessions
+    """
+
+
+@sessions.command("path")
+@click.pass_context
+def sessions_path(ctx):
+    """
+    Print the directory where batch sessions are stored.
+    """
+    console = ctx.obj["console"]
+    console.print(str(get_user_sessions_dir()))
+
+
+@sessions.command("show")
+@click.argument("session_id", required=False)
+@click.option(
+    "--stats",
+    "--statistics",
+    "stats",
+    is_flag=True,
+    default=False,
+    help="Append textual statistics about the session",
+)
+@click.option(
+    "-o",
+    "--output-file",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=None,
+    help="Write statistics to a file instead of the console (requires --stats)",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "md"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format when writing to a file (text or markdown)",
+)
+@click.option(
+    "--color/--no-color",
+    "color",
+    is_flag=True,
+    default=None,
+    help="Keep ANSI colour codes in the file output (text format only)",
+)
+@click.pass_context
+def sessions_show(
+    ctx,
+    session_id: str | None = None,
+    stats: bool = False,
+    output_file: Path | None = None,
+    output_format: str = "text",
+    color: bool | None = None,
+):
+    """
+    Show the recorded output of a stored batch session.
+
+    Pass a session ID (the short ID shown by `sessions list` is enough), or run
+    without arguments in interactive mode to pick one from a menu. The session
+    header and the summary table are rendered from what was saved, without
+    re-validating anything; add --stats for the textual statistics.
+
+    Use --output-file to write the statistics to a file instead of the console.
+    Supported formats are ``text`` (plain or ANSI-coloured) and ``md`` (markdown).
+    """
+    console = ctx.obj["console"]
+    interactive = ctx.obj.get("interactive", False)
+    if not session_id and not interactive:
+        raise click.UsageError("Specify a session ID (run `sessions list` to see the available sessions).")
+    if output_file and not stats:
+        raise click.UsageError("--output-file requires --stats.")
+    try:
+        summaries = _collect_sessions()
+        target = _select_session(console, summaries, session_id)
+        if target is None:
+            return
+        _show_session(
+            console,
+            Path(target["file"]),
+            stats=stats,
+            output_file=output_file,
+            output_format=output_format,
+            color=color,
+        )
+    except Exception as e:
+        handle_error(e, console)
+
+
+def _select_session(console, summaries: list[dict], session_id: str | None) -> dict | None:
+    """
+    Resolve which session to act on (any status). With an explicit ``session_id``
+    the session is matched by ID prefix; without one the stored sessions are
+    offered as an interactive menu. Returns the chosen summary, or ``None``.
+    """
+    if session_id:
+        matches = [s for s in summaries if s["id"].startswith(session_id)]
+        if not matches:
+            console.print(f"[yellow]No session matches ID:[/yellow] {session_id}")
+            return None
+        if len(matches) > 1:
+            console.print(f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]")
+            return None
+        return matches[0]
+    if not summaries:
+        console.print("[yellow]No batch sessions stored.[/yellow]")
+        return None
+    choices = [(s["id"], _resume_choice_label(s)) for s in summaries]
+    chosen_id = single_choice(console, "Select a session to show:", choices)
+    if not chosen_id:
+        return None
+    return next((s for s in summaries if s["id"] == chosen_id), None)
+
+
+def _show_session(
+    console,
+    session_file: Path,
+    *,
+    stats: bool = False,
+    output_file: Path | None = None,
+    output_format: str = "text",
+    color: bool | None = None,
+) -> None:
+    """Render the header and summary table of a stored session (optionally stats)."""
+    session = BatchSession.load(session_file)
+    entries = session.crates
+    base = _common_base([e.path for e in entries])
+
+    # Header: counts + status badge, then session/input/profiles bullet list.
+    profiles, profiles_style = format_profile_selection(session.profile_identifiers, session.no_auto_profile)
+    rows: list[tuple[str, str, str]] = [("Session", str(session_file), "cyan")]
+    if base:
+        rows.append(("Input", base, "cyan"))
+    rows.append(("Profiles", profiles, profiles_style))
+    render_batch_header(
+        console,
+        headline=f"[bold]Session[/bold] [dim]·[/dim] [cyan]{len(entries)}[/cyan] RO-Crate(s)",
+        rows=rows,
+        status=session.status,
+    )
+
+    # Summary table + final verdict (or interruption note). The per-crate list
+    # shown live during `validate` is intentionally not reproduced here — the
+    # summary table already lists every crate.
+    result = BatchValidationResult(session, [])
+    BatchValidationCommandView(console=console).show_summary(result, verbose=False)
+
+    crate_dicts = [e.to_dict() for e in entries]
+    if stats:
+        if output_file:
+            _write_stats_to_file(
+                crate_dicts,
+                output_file=output_file,
+                output_format=output_format,
+                color=color,
+            )
+            console.print(f"[dim]Statistics written to[/dim] {output_file}")
+        else:
+            render_statistics(console, crate_dicts)
+
+    if session.is_completed():
+        render_batch_footer(console, result, [])
+    else:
+        pending = sum(1 for e in entries if e.status not in ("completed", "failed"))
+        console.print(
+            f"\n  [yellow]⚠ Session interrupted[/yellow] — "
+            f"{session.completed_crates}/{len(entries)} validated, {pending} pending\n"
+        )
+
+
+def _write_stats_to_file(
+    crate_dicts: list[dict],
+    *,
+    output_file: Path,
+    output_format: str,
+    color: bool | None = None,
+) -> None:
+    """Write batch statistics to a file in the requested format."""
+    if output_format == "md":
+        with output_file.open("w", encoding="utf-8") as f:
+            render_statistics_md(f, crate_dicts)
+    else:
+        with output_file.open("w", encoding="utf-8") as f:
+            no_color = not color if color is not None else True
+            kwargs: dict = {"file": f}
+            if no_color:
+                kwargs["color_system"] = None
+            else:
+                kwargs["color_system"] = "standard"
+            out = Console(**kwargs)
+            render_statistics(out, crate_dicts)
+
+
+@sessions.command("resume")
+@click.argument("session_id", required=False)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Show the details of failed crates after resuming",
+)
+@click.pass_context
+def sessions_resume(ctx, session_id: str | None = None, verbose: bool = False):
+    """
+    Resume an interrupted batch validation session.
+
+    Pass a session ID (the short ID shown by `sessions list` is enough) to resume
+    that session, or run without arguments in interactive mode to pick one from a
+    menu of the still-open sessions. Validation continues from where it stopped.
+    """
+    console = ctx.obj["console"]
+    interactive = ctx.obj.get("interactive", False)
+    # Without an ID there is nothing to pick from in non-interactive mode: raise
+    # the usage error before the try/except so Click reports it natively.
+    if not session_id and not interactive:
+        raise click.UsageError("Specify a session ID (run `sessions list` to see the available sessions).")
+
+    exit_code = 0
+    try:
+        summaries = _collect_sessions()
+        target = _select_resume_target(console, summaries, session_id)
+        if target is None:
+            return
+        result = _resume_session(console, Path(target["file"]), verbose=verbose, interactive=interactive)
+        exit_code = 0 if result.passed() else 1
+    except Exception as e:
+        handle_error(e, console)
+        return
+    if exit_code:
+        ctx.exit(exit_code)
+
+
+@sessions.command("list")
+@click.option(
+    "--status",
+    "status_filter",
+    type=click.Choice(["in_progress", "interrupted", "completed"], case_sensitive=False),
+    default=None,
+    show_default=False,
+    help="Show only sessions in the given state",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print sessions as JSON",
+)
+@click.pass_context
+def sessions_list(ctx, status_filter: str | None = None, as_json: bool = False):
+    """
+    List the stored batch validation sessions (alias: `ls`).
+    """
+    console = ctx.obj["console"]
+    try:
+        summaries = _collect_sessions(status_filter=status_filter.lower() if status_filter else None)
+
+        if as_json:
+            click.echo(json.dumps([_summary_to_dict(s) for s in summaries], indent=2))
+            return
+
+        if not summaries:
+            if status_filter:
+                console.print(f"[yellow]No sessions with status:[/yellow] {status_filter}")
+            else:
+                console.print("[yellow]No batch sessions stored.[/yellow]")
+            return
+
+        table = Table(title=f"Batch sessions ({len(summaries)})", show_lines=False)
+        table.add_column("ID", no_wrap=True)
+        table.add_column("Status")
+        table.add_column("Crates", justify="right")
+        table.add_column("Target", overflow="fold")
+        table.add_column("Size", justify="right")
+        table.add_column("Updated")
+        for s in summaries:
+            table.add_row(
+                s["id"][:12],
+                _format_status(s["status"]),
+                _format_crates(s),
+                s["target"] or "—",
+                _format_bytes(s["size_bytes"]),
+                _format_dt(s["updated_at"]),
+            )
+        console.print(table)
+        console.print("[dim]Use the (short) ID with `sessions clear <ID>` to remove a specific session.[/dim]")
+    except Exception as e:
+        handle_error(e, console)
+
+
+@sessions.command("clear")
+@click.argument("ids", nargs=-1)
+@click.option(
+    "--all",
+    "clear_all",
+    is_flag=True,
+    default=False,
+    help="Remove every stored session",
+)
+@click.option(
+    "--completed",
+    "completed_only",
+    is_flag=True,
+    default=False,
+    help="Remove only sessions whose validation has completed",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Do not prompt for confirmation before removing sessions",
+)
+@click.pass_context
+def sessions_clear(
+    ctx,
+    ids: tuple[str, ...] = (),
+    clear_all: bool = False,
+    completed_only: bool = False,
+    yes: bool = False,
+):
+    """
+    Remove stored batch sessions (alias: `rm`).
+
+    Pass one or more session IDs (the short ID shown by `sessions list` is enough),
+    or use --completed / --all to select sessions in bulk.
+    """
+    console = ctx.obj["console"]
+    interactive = ctx.obj.get("interactive", False)
+    # Raise usage errors before the try/except so Click reports them natively
+    # instead of routing them through the generic "unexpected error" handler.
+    if not ids and not clear_all and not completed_only:
+        raise click.UsageError("Specify one or more session IDs, or use --completed or --all.")
+
+    exit_code = 0
+    try:
+        summaries = _collect_sessions()
+        targets = _select_sessions_to_clear(summaries, ids=ids, clear_all=clear_all, completed_only=completed_only)
+
+        if not targets:
+            console.print("[green]No matching sessions to remove.[/green]")
+            return
+
+        console.print(f"[bold]Sessions to remove:[/bold] [cyan]{len(targets)}[/cyan]")
+        proceed = yes
+        if not yes:
+            if not interactive:
+                console.print("[yellow]Use --yes to remove sessions in non-interactive mode.[/yellow]")
+                exit_code = 1
+            elif click.confirm(f"Remove {len(targets)} session(s)?", default=False):
+                proceed = True
+            else:
+                console.print("Aborted.")
+
+        if proceed:
+            removed = 0
+            for s in targets:
+                try:
+                    Path(s["file"]).unlink()
+                    removed += 1
+                except OSError as e:
+                    logger.debug("Could not remove session %s: %s", s["file"], e)
+                    console.print(f"[red]Failed to remove {s['id'][:12]}: {e}[/red]")
+            console.print(f"[green]Removed {removed} session(s).[/green]")
+    except Exception as e:
+        handle_error(e, console)
+        return
+    if exit_code:
+        ctx.exit(exit_code)
+
+
+def _select_sessions_to_clear(
+    summaries: list[dict],
+    *,
+    ids: tuple[str, ...],
+    clear_all: bool,
+    completed_only: bool,
+) -> list[dict]:
+    """Resolve the set of sessions to remove from the requested selection criteria."""
+    if clear_all:
+        return list(summaries)
+    selected: list[dict] = []
+    if completed_only:
+        selected.extend(s for s in summaries if s["status"] == "completed")
+    if ids:
+        for requested in ids:
+            matches = [s for s in summaries if s["id"].startswith(requested)]
+            if not matches:
+                logger.debug("No session matches ID prefix '%s'", requested)
+            selected.extend(matches)
+    # De-duplicate while preserving order (a session may match both filters).
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for s in selected:
+        if s["id"] not in seen:
+            seen.add(s["id"])
+            unique.append(s)
+    return unique
+
+
+def _select_resume_target(
+    console,
+    summaries: list[dict],
+    session_id: str | None,
+) -> dict | None:
+    """
+    Resolve which session to resume.
+
+    With an explicit ``session_id`` the session is matched by ID prefix (and must
+    still be resumable). Without one the open sessions are offered as an
+    interactive menu (the caller guarantees interactive mode in that case).
+    Returns the chosen summary, or ``None`` when there is nothing to resume
+    (a message is printed in that case).
+    """
+    if session_id:
+        matches = [s for s in summaries if s["id"].startswith(session_id)]
+        if not matches:
+            console.print(f"[yellow]No session matches ID:[/yellow] {session_id}")
+            return None
+        if len(matches) > 1:
+            console.print(f"[yellow]Ambiguous ID '{session_id}' matches {len(matches)} sessions; use a longer ID.[/yellow]")
+            return None
+        target = matches[0]
+        if target["status"] not in _RESUMABLE_STATUSES:
+            console.print(
+                f"[green]Session {target['id'][:12]} is already '{target['status']}'; nothing to resume.[/green]"
+            )
+            return None
+        return target
+
+    resumable = [s for s in summaries if s["status"] in _RESUMABLE_STATUSES]
+    if not resumable:
+        console.print("[yellow]No resumable (interrupted) sessions found.[/yellow]")
+        return None
+    choices = [(s["id"], _resume_choice_label(s)) for s in resumable]
+    chosen_id = single_choice(console, "Select a session to resume:", choices)
+    if not chosen_id:
+        return None
+    return next((s for s in resumable if s["id"] == chosen_id), None)
+
+
+def _resume_choice_label(summary: dict) -> str:
+    """Build the menu label for a resumable session."""
+    total = summary["total_crates"]
+    completed = summary["completed_crates"] or 0
+    progress = f"{completed}/{total}" if total is not None else "?"
+    target = summary["target"] or "—"
+    return f"{summary['id'][:12]}  [{summary['status']}]  {progress}  {target}"
+
+
+def _resume_session(console, session_file: Path, *, verbose: bool, interactive: bool):
+    """Reconstruct the settings from a saved session and continue its validation."""
+    session = BatchSession.load(session_file)
+    crate_paths = [c.path for c in session.crates]
+
+    # Rebuild the validation settings stored with the session, re-injecting the
+    # one outcome-affecting field dropped by ValidationSettings.to_dict().
+    settings_dict = dict(session.validation_settings)
+    settings_dict.setdefault("rocrate_uri", ".")
+    settings_dict["requirement_severity_only"] = session.requirement_severity_only
+    settings = ValidationSettings.parse(settings_dict)
+
+    # The session does not store the original scan root, so derive a base from the
+    # crate paths to show them relative (and report it as the input below).
+    base = _common_base(crate_paths)
+
+    pending = sum(1 for c in session.crates if c.status != "completed")
+    if interactive:
+        # Header up front: session, input and profiles, before the per-crate list,
+        # so the relative crate paths shown during validation are easy to interpret.
+        profiles, profiles_style = format_profile_selection(session.profile_identifiers, session.no_auto_profile)
+        header_rows: list[tuple[str, str, str]] = [("Session", str(session_file), "cyan")]
+        if base:
+            header_rows.append(("Input", base, "cyan"))
+        header_rows.append(("Profiles", profiles, profiles_style))
+        render_batch_header(
+            console,
+            headline=(
+                f"[bold]Resuming session[/bold] [dim]·[/dim] "
+                f"[cyan]{pending}[/cyan] of [cyan]{len(crate_paths)}[/cyan] crate(s) to validate"
+            ),
+            rows=header_rows,
+            status=session.status,
+        )
+
+    view = BatchValidationCommandView(console=console)
+    result = view.run_with_progress(
+        batch_validate_fn=services.batch_validate,
+        settings=settings,
+        rocrate_uris=crate_paths,
+        session_path=session_file,
+        fresh=False,
+        profile_identifiers=session.profile_identifiers,
+        no_auto_profile=session.no_auto_profile,
+        base_path=Path(base) if base else None,
+    )
+    view.show_summary(result, verbose=verbose)
+
+    # Aligned footer, consistent with `validate`: the session is only repeated
+    # here when the run did not finish (the input is shown in the header above).
+    rows: list[tuple[str, str, str, str]] = []
+    if not result.session.is_completed():
+        rows.append(("💾", "Session", str(session_file), "cyan"))
+    render_batch_footer(console, result, rows)
+    return result
+
+
+def _common_base(crate_paths: list[str]) -> str | None:
+    """Return a base directory for the crate paths, used for relative display."""
+    paths = [p for p in crate_paths if p]
+    if not paths:
+        return None
+    if len(paths) == 1:
+        # A single crate: its parent is the natural base (shows the crate by name).
+        return str(Path(paths[0]).parent)
+    try:
+        return os.path.commonpath(paths)
+    except (ValueError, TypeError):
+        return None
+
+
+def _collect_sessions(status_filter: str | None = None) -> list[dict]:
+    """
+    Read every stored session file and return a list of summary dicts, most
+    recently updated first. Filtering happens here so the table and JSON
+    rendering paths share the same data shape.
+    """
+    sessions_dir = get_user_sessions_dir()
+    if not sessions_dir.is_dir():
+        return []
+    summaries: list[dict] = []
+    for path in sessions_dir.glob("*.json"):
+        summary = _read_session_summary(path)
+        if status_filter and summary["status"] != status_filter:
+            continue
+        summaries.append(summary)
+    summaries.sort(
+        key=lambda s: s["updated_at"] or datetime.min,
+        reverse=True,
+    )
+    return summaries
+
+
+def _read_session_summary(path: Path) -> dict:
+    """
+    Build a summary dict for a single session file. Falls back to a minimal
+    summary (status ``unknown``) when the file cannot be parsed.
+    """
+    stat = path.stat()
+    summary = {
+        "id": path.stem,
+        "file": str(path),
+        "status": "unknown",
+        "total_crates": None,
+        "completed_crates": None,
+        "failed_crates": None,
+        "created_at": None,
+        "updated_at": datetime.fromtimestamp(stat.st_mtime),
+        "target": None,
+        "size_bytes": stat.st_size,
+    }
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        session = data.get("session", {})
+        summary["status"] = session.get("status", "unknown")
+        summary["total_crates"] = session.get("total_crates")
+        summary["completed_crates"] = session.get("completed_crates")
+        summary["failed_crates"] = session.get("failed_crates")
+        summary["created_at"] = _parse_iso(session.get("created_at"))
+        summary["updated_at"] = _parse_iso(session.get("updated_at")) or summary["updated_at"]
+        summary["target"] = _derive_target([c.get("path", "") for c in data.get("crates", [])])
+    except Exception as e:
+        logger.debug("Could not parse session file %s: %s", path, e)
+    return summary
+
+
+def _derive_target(crate_paths: list[str]) -> str | None:
+    """Return the common parent directory of the crate paths, when derivable."""
+    paths = [p for p in crate_paths if p]
+    if not paths:
+        return None
+    try:
+        return os.path.commonpath(paths)
+    except (ValueError, TypeError):
+        return None
+
+
+def _summary_to_dict(summary: dict) -> dict:
+    """JSON-safe view of a session summary."""
+
+    def _iso(value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    return {
+        "id": summary["id"],
+        "status": summary["status"],
+        "total_crates": summary["total_crates"],
+        "completed_crates": summary["completed_crates"],
+        "failed_crates": summary["failed_crates"],
+        "target": summary["target"],
+        "size_bytes": summary["size_bytes"],
+        "created_at": _iso(summary["created_at"]),
+        "updated_at": _iso(summary["updated_at"]),
+        "file": summary["file"],
+    }
+
+
+def _format_crates(summary: dict) -> str:
+    """Render the completed/total (and failed) crate counts for the table."""
+    total = summary["total_crates"]
+    completed = summary["completed_crates"]
+    failed = summary["failed_crates"] or 0
+    if total is None:
+        return "—"
+    text = f"{completed or 0}/{total}"
+    if failed:
+        text += f" [red]({failed}✗)[/red]"
+    return text
+
+
+def _format_status(status: str) -> str:
+    colour = {
+        "completed": "green",
+        "in_progress": "yellow",
+        "interrupted": "yellow",
+        "unknown": "red",
+    }.get(status, "white")
+    return f"[{colour}]{status}[/{colour}]"
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _format_dt(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d %H:%M:%SZ") if value.tzinfo else value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_bytes(size: int) -> str:
+    if size <= 0:
+        return "0 B"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    idx = 0
+    value = float(size)
+    while value >= BYTES_PER_KIB and idx < len(units) - 1:
+        value /= BYTES_PER_KIB
+        idx += 1
+    return f"{value:.2f} {units[idx]}"
+
+
+# Shell-style aliases mirroring the `cache` command: `sessions ls` and
+# `sessions rm` run the same callbacks as `list` and `clear`. Shallow copies
+# give the aliases their own (hidden) names so each command appears once.
+_sessions_ls_alias = _copy.copy(sessions_list)
+_sessions_ls_alias.name = "ls"
+_sessions_ls_alias.hidden = True
+sessions.add_command(_sessions_ls_alias)
+
+_sessions_rm_alias = _copy.copy(sessions_clear)
+_sessions_rm_alias.name = "rm"
+_sessions_rm_alias.hidden = True
+sessions.add_command(_sessions_rm_alias)

--- a/rocrate_validator/cli/commands/sessions.py
+++ b/rocrate_validator/cli/commands/sessions.py
@@ -204,7 +204,7 @@ def _show_session(
     # Summary table + final verdict (or interruption note). The per-crate list
     # shown live during `validate` is intentionally not reproduced here — the
     # summary table already lists every crate.
-    result = BatchValidationResult(session, [])
+    result = BatchValidationResult(session)
     BatchValidationCommandView(console=console).show_summary(result, verbose=False)
 
     crate_dicts = [e.to_dict() for e in entries]

--- a/rocrate_validator/cli/commands/sessions.py
+++ b/rocrate_validator/cli/commands/sessions.py
@@ -329,7 +329,7 @@ def sessions_list(ctx, status_filter: str | None = None, as_json: bool = False):
                 console.print("[yellow]No batch sessions stored.[/yellow]")
             return
 
-        table = Table(title=f"Batch sessions ({len(summaries)})", show_lines=False)
+        table = Table(title=f"Batch sessions ({len(summaries)})", show_lines=True)
         table.add_column("ID", no_wrap=True)
         table.add_column("Status")
         table.add_column("Crates", justify="right")
@@ -679,16 +679,26 @@ def _summary_to_dict(summary: dict) -> dict:
 
 
 def _format_crates(summary: dict) -> str:
-    """Render the completed/total (and failed) crate counts for the table."""
+    """
+    Render the crates cell: the processed/total fraction on the first line,
+    then the valid (✓) and invalid (✗) counts on their own lines. Zero counts
+    are omitted so all-passed and all-failed sessions stay compact.
+    """
     total = summary["total_crates"]
-    completed = summary["completed_crates"]
-    failed = summary["failed_crates"] or 0
     if total is None:
         return "—"
-    text = f"{completed or 0}/{total}"
+    completed = summary["completed_crates"] or 0
+    failed = summary["failed_crates"] or 0
+    valid = max(completed - failed, 0)
+    # Orange flags partial progress; once every crate is processed the count
+    # takes the same colour as the total.
+    completed_colour = "orange3" if completed < total else "cyan"
+    lines = [f"[bold {completed_colour}]{completed}[/bold {completed_colour}]/[bold cyan]{total}[/bold cyan]"]
+    if valid:
+        lines.append(f"[green]✓ {valid}[/green]")
     if failed:
-        text += f" [red]({failed}✗)[/red]"
-    return text
+        lines.append(f"[red]✗ {failed}[/red]")
+    return "\n".join(lines)
 
 
 def _format_status(status: str) -> str:

--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import csv
 import sys
 from contextlib import nullcontext
 from pathlib import Path
@@ -25,15 +26,27 @@ from rich.rule import Rule
 from rocrate_validator import constants, services
 from rocrate_validator.cli.commands.errors import handle_error
 from rocrate_validator.cli.main import cli
-from rocrate_validator.cli.ui.text.validate import ValidationCommandView
+from rocrate_validator.cli.ui.text.validate import (
+    BatchValidationCommandView,
+    ValidationCommandView,
+    format_profile_selection,
+    render_batch_footer,
+    render_batch_header,
+)
 from rocrate_validator.errors import ROCrateInvalidURIError
-from rocrate_validator.models import Severity, ValidationResult, ValidationSettings
+from rocrate_validator.models import (
+    BatchValidationResult,
+    Severity,
+    ValidationResult,
+    ValidationSettings,
+)
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.io_helpers.input import get_single_char, multiple_choice
 from rocrate_validator.utils.io_helpers.output.console import Console
 from rocrate_validator.utils.io_helpers.output.json import JSONOutputFormatter
 from rocrate_validator.utils.io_helpers.output.text import TextOutputFormatter
 from rocrate_validator.utils.io_helpers.output.text.layout.report import LiveTextProgressLayout, get_app_header_rule
+from rocrate_validator.utils.io_helpers.output.text.statistics import render_statistics
 from rocrate_validator.utils.paths import get_profiles_path
 from rocrate_validator.utils.uri import validate_rocrate_uri
 
@@ -43,10 +56,74 @@ DEFAULT_PROFILES_PATH = get_profiles_path()
 # set up logging
 logger = logging.getLogger(__name__)
 
+# Organise the (long) list of `validate` options into labelled sections in the
+# `--help` output. Options not listed here are shown under a default group.
+# The key is matched against the command path with fnmatch, so the leading
+# wildcard makes it work regardless of the program name (entry point, `python -m`,
+# or the test runner). Applied via the command's own ``rich_config`` below.
+_VALIDATE_OPTION_GROUPS = {
+    "* validate": [
+        {
+            "name": "Batch validation",
+            "options": [
+                "--batch",
+                "--batch-pattern",
+                "--no-resume",
+                "--stats",
+            ],
+        },
+        {
+            "name": "Profiles",
+            "options": [
+                "--profile-identifier",
+                "--no-auto-profile",
+                "--disable-profile-inheritance",
+                "--profiles-path",
+                "--extra-profiles-path",
+            ],
+        },
+        {
+            "name": "Requirements & checks",
+            "options": [
+                "--requirement-severity",
+                "--requirement-severity-only",
+                "--skip-checks",
+                "--metadata-only",
+                "--fail-fast",
+                "--relative-root-path",
+                "--creation-time",
+                "--enforce-availability",
+                "--skip-availability-check",
+            ],
+        },
+        {
+            "name": "Output",
+            "options": [
+                "--output-format",
+                "--output-file",
+                "--output-line-width",
+                "--verbose",
+                "--no-paging",
+            ],
+        },
+        {
+            "name": "Cache & network",
+            "options": [
+                "--cache-max-age",
+                "--cache-path",
+                "--no-cache",
+                "--offline",
+            ],
+        },
+    ],
+}
 
-def validate_uri(ctx, param, value):
+
+def validate_uri(ctx, param, value):  # pylint: disable=unused-argument
     """
     Validate if the value is a path or a URI
+
+    ``ctx`` is part of the click callback signature but is not used here.
     """
     if value:
         try:
@@ -59,6 +136,12 @@ def validate_uri(ctx, param, value):
 
 
 @cli.command("validate")
+@click.rich_config(
+    help_config=click.RichHelpConfiguration(
+        text_markup="rich",
+        option_groups=_VALIDATE_OPTION_GROUPS,  # type: ignore[arg-type]
+    )
+)
 @click.argument("rocrate-uri", callback=validate_uri, default=".")
 @click.option(
     "-rr",
@@ -191,15 +274,15 @@ def validate_uri(ctx, param, value):
 @click.option(
     "-f",
     "--output-format",
-    type=click.Choice(["json", "text"], case_sensitive=False),
+    type=click.Choice(["text", "csv", "json"], case_sensitive=False),
     default="text",
     show_default=True,
-    help="Output format of the validation report",
+    help="Output format of the validation report ([bold]csv[/bold] is available in batch mode only)",
 )
 @click.option(
     "-o",
     "--output-file",
-    type=click.Path(),
+    type=click.Path(path_type=Path),
     default=None,
     show_default=True,
     help="Path to the output file for the validation report",
@@ -247,7 +330,45 @@ def validate_uri(ctx, param, value):
     default=False,
     show_default=True,
 )
+# Batch mode options
+@click.option(
+    "-b",
+    "--batch",
+    is_flag=True,
+    help="Validate every RO-Crate found under the [bold]RO-CRATE-URI[/bold] directory",
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "--batch-pattern",
+    type=click.STRING,
+    default="*",
+    show_default=True,
+    help="Glob pattern to filter RO-Crates in batch mode",
+)
+@click.option(
+    "--no-resume",
+    is_flag=True,
+    help=(
+        "Ignore any auto-saved batch session and re-validate every RO-Crate "
+        "from scratch (sessions are otherwise resumed automatically)"
+    ),
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "--stats",
+    "--statistics",
+    "stats",
+    is_flag=True,
+    help="Append textual statistics about the batch run (text output only)",
+    default=False,
+    show_default=True,
+)
 @click.pass_context
+# The CLI command surfaces every validation option as a parameter; pylint counts
+# those arguments as locals, so the limit is not meaningful here.
+# pylint: disable-next=too-many-locals
 def validate(
     ctx,
     profiles_path: Path = DEFAULT_PROFILES_PATH,
@@ -274,6 +395,10 @@ def validate(
     cache_path: Path | None = None,
     no_cache: bool = False,
     offline: bool = False,
+    batch: bool = False,
+    batch_pattern: str = "*",
+    no_resume: bool = False,
+    stats: bool = False,
 ):
     """
     [magenta]rocrate-validator:[/magenta] Validate a RO-Crate against a profile
@@ -314,6 +439,14 @@ def validate(
 
     _warn_if_remote_offline(console, rocrate_uri, offline)
 
+    # Batch mode is enabled by -b/--batch and scans the positional RO-CRATE-URI.
+    batch_mode = batch
+    _check_batch_only_options(
+        batch_mode=batch_mode,
+        batch_pattern=batch_pattern,
+        no_resume=no_resume,
+    )
+
     skip_checks_list = _parse_skip_checks(skip_checks)
 
     try:
@@ -346,6 +479,31 @@ def validate(
         if output_format == "text" and output_file is None:
             console.print(get_app_header_rule())
 
+        # Batch mode validates a directory of crates and exits with the aggregated
+        # status. Profiles are resolved *per crate* inside the batch (explicit
+        # selection or per-crate auto-detection), so the single-crate profile
+        # resolution below is intentionally skipped for batch runs.
+        if batch_mode:
+            _run_batch_validation(
+                console,
+                base_settings=validation_settings,
+                profile_identifiers=list(profile_identifier),
+                no_auto_profile=no_auto_profile,
+                cache_max_age=cache_max_age,
+                verbose=verbose,
+                rocrate_uri=rocrate_uri,
+                batch_pattern=batch_pattern,
+                fresh=no_resume,
+                output_format=output_format,
+                output_file=output_file,
+                output_line_width=output_line_width,
+                stats=stats,
+            )
+
+        # CSV is a batch-only report format; reject it for single-crate validation.
+        if output_format == "csv":
+            raise click.UsageError("The 'csv' output format is only available in batch mode (-b/--batch).")
+
         # Get the available profiles
         available_profiles = services.get_profiles(profiles_path, extra_profiles_path=extra_profiles_path)
 
@@ -360,48 +518,21 @@ def validate(
             validation_settings,
         )
 
-        # Validate the RO-Crate against the selected profiles
-        is_valid = True
-        results = {}
-        for profile in profile_identifiers:
-            # Duplicate settings for each profile and set the profile identifier
-            logger.info("\nValidating RO-Crate against profile: [bold cyan]%s[/bold cyan]", profile)
-            profile_settings = validation_settings.copy()
-            profile_settings["profile_identifier"] = profile
-            logger.debug("Profile selected for validation: %s", profile)
-            logger.debug("Profile autodetected: %s", autodetection)
-
-            # Perform the validation and render the result for the chosen output target.
-            if output_format == "text" and not output_file:
-                result = _render_console_result(
-                    profile_settings,
-                    console=console,
-                    pager=pager,
-                    interactive=interactive,
-                    enable_pager=enable_pager,
-                    verbose=verbose,
-                )
-            else:
-                result = _render_file_or_collected_result(
-                    profile,
-                    profile_settings,
-                    console=console,
-                    interactive=interactive,
-                    verbose=verbose,
-                    output_format=output_format,
-                    output_file=output_file,
-                    output_line_width=output_line_width,
-                )
-            results[profile] = result
-
-            # Update the global validation status
-            is_valid = is_valid and result.passed()
-
-            # Interrupt the validation if the fail fast mode is enabled
-            if fail_fast and not is_valid:
-                break
-
-        # Process JSON output format
+        # Single-crate mode: validate against the selected profiles and report.
+        results, is_valid = _run_single_validations(
+            profile_identifiers,
+            validation_settings,
+            autodetection=autodetection,
+            console=console,
+            pager=pager,
+            interactive=interactive,
+            enable_pager=enable_pager,
+            verbose=verbose,
+            fail_fast=fail_fast,
+            output_format=output_format,
+            output_file=output_file,
+            output_line_width=output_line_width,
+        )
         if output_format == "json":
             _emit_json_report(
                 results,
@@ -419,6 +550,354 @@ def validate(
         sys.exit(0 if is_valid else 1)
     except Exception as e:
         handle_error(e, console)
+
+
+# Threads the CLI options through to the batch helpers; pylint counts these
+# pass-through arguments as locals, so the limit is not meaningful here.
+# pylint: disable-next=too-many-locals
+def _run_batch_validation(
+    console: Console,
+    *,
+    base_settings: dict,
+    profile_identifiers: list[str],
+    no_auto_profile: bool,
+    cache_max_age: int,
+    verbose: bool,
+    rocrate_uri: str | Path,
+    batch_pattern: str,
+    fresh: bool,
+    output_format: str,
+    output_file: Path | None,
+    output_line_width: int | None,
+    stats: bool = False,
+) -> None:
+    """Run batch validation end-to-end and exit with the aggregated status code."""
+    crate_paths = _discover_batch_crates(
+        rocrate_uri=rocrate_uri,
+        batch_pattern=batch_pattern,
+    )
+    if not crate_paths:
+        console.print("[bold yellow]No RO-Crates found for batch validation.[/bold yellow]")
+        sys.exit(0)
+
+    batch_settings = _build_batch_settings(
+        base_settings,
+        profile_identifiers=profile_identifiers,
+        cache_max_age=cache_max_age,
+        verbose=verbose,
+    )
+    # The batch session is auto-managed: its location is derived deterministically
+    # from the scan target and settings, so re-running the same command resumes an
+    # interrupted session automatically (no user-supplied session file).
+    scan_root = Path(rocrate_uri).resolve()
+    session_path = services.resolve_batch_session_path(
+        batch_settings,
+        scan_root,
+        batch_pattern,
+        profile_identifiers=profile_identifiers,
+        no_auto_profile=no_auto_profile,
+    )
+    _print_batch_header(
+        console,
+        count=len(crate_paths),
+        session_path=session_path,
+        input_path=scan_root,
+        profile_identifiers=profile_identifiers,
+        no_auto_profile=no_auto_profile,
+    )
+
+    batch_view = BatchValidationCommandView(console=console)
+    # Run batch validation with a progress bar on stderr (always visible,
+    # even when the report goes to a file).
+    batch_result = batch_view.run_with_progress(
+        batch_validate_fn=services.batch_validate,
+        settings=batch_settings,
+        rocrate_uris=crate_paths,
+        session_path=session_path,
+        fresh=fresh,
+        profile_identifiers=profile_identifiers,
+        no_auto_profile=no_auto_profile,
+        base_path=scan_root,
+    )
+    # Writing a large report to a file can take a moment; show a spinner on
+    # stderr while it happens (skipped when the summary is rendered to the
+    # console, which is itself the visible output).
+    if output_file:
+        status_console = Console(file=sys.stderr, no_color=console.no_color, width=console.width)
+        report_ctx = status_console.status(f"[cyan]Writing report to {output_file}…[/cyan]")
+    else:
+        report_ctx = nullcontext()
+    with report_ctx:
+        _write_batch_report(
+            batch_view,
+            batch_result,
+            output_format=output_format,
+            output_file=output_file,
+            output_line_width=output_line_width,
+            verbose=verbose,
+            stats=stats,
+        )
+    # Statistics are a human-readable view; they are not embedded in machine output.
+    if stats and output_format in ("json", "csv"):
+        Console(file=sys.stderr, no_color=console.no_color, width=console.width).print(
+            f"[yellow]Note:[/yellow] --stats is ignored for '{output_format}' output (text mode only)."
+        )
+    _report_batch_status(
+        console,
+        batch_result,
+        session_path=session_path,
+        output_file=output_file,
+        output_format=output_format,
+    )
+    sys.exit(0 if batch_result.passed() else 1)
+
+
+# Threads the CLI options through to the rendering helpers; pylint counts these
+# pass-through arguments as locals, so the limit is not meaningful here.
+# pylint: disable-next=too-many-locals
+def _run_single_validations(
+    profile_identifiers: list[str],
+    validation_settings: dict,
+    *,
+    autodetection: bool,
+    console: Console,
+    pager,
+    interactive: bool,
+    enable_pager: bool,
+    verbose: bool,
+    fail_fast: bool,
+    output_format: str,
+    output_file: Path | None,
+    output_line_width: int | None,
+) -> tuple[dict, bool]:
+    """Validate the RO-Crate against each selected profile, returning (results, overall-validity)."""
+    is_valid = True
+    results = {}
+    for profile in profile_identifiers:
+        # Duplicate settings for each profile and set the profile identifier
+        logger.info("\nValidating RO-Crate against profile: [bold cyan]%s[/bold cyan]", profile)
+        profile_settings = validation_settings.copy()
+        profile_settings["profile_identifier"] = profile
+        logger.debug("Profile selected for validation: %s", profile)
+        logger.debug("Profile autodetected: %s", autodetection)
+
+        # Perform the validation and render the result for the chosen output target.
+        if output_format == "text" and not output_file:
+            result = _render_console_result(
+                profile_settings,
+                console=console,
+                pager=pager,
+                interactive=interactive,
+                enable_pager=enable_pager,
+                verbose=verbose,
+            )
+        else:
+            result = _render_file_or_collected_result(
+                profile,
+                profile_settings,
+                console=console,
+                interactive=interactive,
+                verbose=verbose,
+                output_format=output_format,
+                output_file=output_file,
+                output_line_width=output_line_width,
+            )
+        results[profile] = result
+
+        # Update the global validation status
+        is_valid = is_valid and result.passed()
+
+        # Interrupt the validation if the fail fast mode is enabled
+        if fail_fast and not is_valid:
+            break
+
+    return results, is_valid
+
+
+def _build_batch_settings(
+    base_settings: dict,
+    *,
+    profile_identifiers: list[str],
+    cache_max_age: int,
+    verbose: bool,
+) -> ValidationSettings:
+    """Derive the shared batch ``ValidationSettings`` from the single-crate settings."""
+    # Batch mode targets a directory of crates, so only the per-crate RO-Crate URI
+    # is dropped (it is set per crate during validation). The creation-time and
+    # availability flags are intentionally kept so they apply uniformly to every
+    # crate, exactly as they would in single-crate validation.
+    batch_settings_dict = {k: v for k, v in base_settings.items() if k != "rocrate_uri"}
+    batch_settings_dict.update(
+        {
+            # Base profile for the shared settings object; the actual profile(s) used
+            # for each crate are resolved per crate by the services layer (explicit
+            # ``--profile-identifier`` list or per-crate auto-detection).
+            "profile_identifier": profile_identifiers[0] if profile_identifiers else "ro-crate",
+            "cache_max_age": cache_max_age,
+            "verbose": verbose,
+        }
+    )
+    return ValidationSettings.parse(batch_settings_dict)
+
+
+def _discover_batch_crates(
+    *,
+    rocrate_uri: str | Path,
+    batch_pattern: str,
+) -> list[str]:
+    """
+    Resolve the list of RO-Crate paths to validate in batch mode by scanning the
+    target directory. Auto-resume of an interrupted session is handled in the
+    services layer by comparing this discovered list against the saved session.
+    """
+    scan_dir = Path(rocrate_uri).resolve()
+    if not scan_dir.is_dir():
+        raise click.BadParameter(
+            f"Batch target must be a directory: {scan_dir}", param_hint="RO-CRATE-URI"
+        )
+    return [str(p) for p in services.discover_ro_crates(scan_dir, pattern=batch_pattern)]
+
+
+def _write_batch_report(
+    batch_view: BatchValidationCommandView,
+    batch_result: BatchValidationResult,
+    *,
+    output_format: str,
+    output_file: Path | None,
+    output_line_width: int | None,
+    verbose: bool,
+    stats: bool = False,
+) -> None:
+    """
+    Write the batch result as JSON, CSV or a text summary, to a file or the console.
+
+    When ``stats`` is set, the textual statistics are appended after the summary
+    in text mode (console or file); they are a human-readable view and are not
+    emitted for the machine-readable JSON/CSV formats.
+
+    Where the report is saved is reported afterwards by :func:`_report_batch_status`,
+    so this function does not print its own "writing to ..." notes.
+    """
+    if output_format == "json":
+        with output_file.open("w", encoding="utf-8") if output_file else nullcontext(sys.stdout) as f:
+            out = Console(color_system=None, width=output_line_width, file=f)
+            out.register_formatter(JSONOutputFormatter())
+            out.print(batch_result)
+        return
+
+    if output_format == "csv":
+        with output_file.open("w", encoding="utf-8", newline="") if output_file else nullcontext(sys.stdout) as f:
+            _write_batch_csv(batch_result, f)
+        return
+
+    crate_dicts = [entry.to_dict() for entry in batch_result.crates]
+    if output_file:
+        with output_file.open("w", encoding="utf-8") as f:
+            out = Console(color_system=None, width=output_line_width, file=f)
+            out.register_formatter(TextOutputFormatter())
+            BatchValidationCommandView(console=out).show_summary(batch_result, verbose=verbose)
+            if stats:
+                render_statistics(out, crate_dicts)
+    else:
+        batch_view.show_summary(batch_result, verbose=verbose)
+        if stats:
+            render_statistics(batch_view.console, crate_dicts)
+
+
+def _write_batch_csv(batch_result: BatchValidationResult, file) -> None:
+    """Write the batch result as CSV (one row per crate) to an open text file."""
+    writer = csv.writer(file)
+    writer.writerow(
+        [
+            "source",
+            "crate",
+            "path",
+            "profiles",
+            "size_bytes",
+            "status",
+            "total_checks",
+            "passed_checks",
+            "issues",
+            "duration",
+            "error",
+        ]
+    )
+    for entry in batch_result.crates:
+        stats = entry.statistics or {}
+        path = Path(entry.path)
+        writer.writerow(
+            [
+                path.parent.name,
+                path.name,
+                entry.path,
+                ";".join(entry.profiles or []),
+                entry.size_bytes if entry.size_bytes is not None else "",
+                "passed" if entry.passed else "failed",
+                stats.get("total_checks", ""),
+                stats.get("total_passed_checks", ""),
+                len(entry.issues or []),
+                f"{entry.duration:.3f}" if entry.duration is not None else "",
+                entry.error or "",
+            ]
+        )
+
+
+def _print_batch_header(
+    console: Console,
+    *,
+    count: int,
+    session_path: Path | None,
+    input_path: Path,
+    profile_identifiers: list[str],
+    no_auto_profile: bool,
+) -> None:
+    """
+    Print the batch header on stderr (always): the number of crates found, the
+    session file, the input scanned and the profile selection. Shown before the
+    per-crate list so the relative crate paths printed during validation are
+    easy to interpret.
+    """
+    stderr_console = Console(file=sys.stderr, no_color=console.no_color, width=console.width)
+    profiles, profiles_style = format_profile_selection(profile_identifiers, no_auto_profile)
+    rows: list[tuple[str, str, str]] = []
+    if session_path:
+        rows.append(("Session", str(session_path), "cyan"))
+    rows.append(("Input", str(input_path), "cyan"))
+    rows.append(("Profiles", profiles, profiles_style))
+    render_batch_header(
+        stderr_console,
+        headline=f"[bold]Batch validation[/bold] [dim]·[/dim] [cyan]{count}[/cyan] RO-Crate(s)",
+        rows=rows,
+    )
+
+
+def _report_batch_status(
+    console: Console,
+    batch_result: BatchValidationResult,
+    *,
+    session_path: Path | None,
+    output_file: Path | None,
+    output_format: str,
+) -> None:
+    """
+    Print the final batch verdict on stderr, followed by a spaced block listing
+    where the report was saved (and the session, only when the run did not
+    complete and may need to be resumed).
+
+    Everything is written to stderr so it never pollutes machine-readable output
+    (JSON/CSV) sent to stdout. The input scanned is reported up front by
+    :func:`_print_batch_header`, so it is not repeated here.
+    """
+    stderr_console = Console(file=sys.stderr, no_color=console.no_color, width=console.width)
+
+    rows: list[tuple[str, str, str, str]] = []  # (icon, label, path, path-style)
+    if output_file:
+        rows.append(("📄", f"Report ({output_format})", str(output_file), "bold cyan"))
+    # The session is only useful here if the run did not finish (so it can be
+    # resumed); when completed it is redundant with the header shown at the start.
+    if session_path and not batch_result.session.is_completed():
+        rows.append(("💾", "Session", str(session_path), "cyan"))
+    render_batch_footer(stderr_console, batch_result, rows)
 
 
 def _log_validation_inputs(
@@ -468,6 +947,32 @@ def _warn_if_remote_offline(console: Console, rocrate_uri: str | Path, offline: 
                 (1, 2, 0, 2),
             )
         )
+
+
+def _check_batch_only_options(
+    *,
+    batch_mode: bool,
+    batch_pattern: str,
+    no_resume: bool,
+) -> None:
+    """
+    Reject batch-only options when batch mode is not enabled.
+
+    ``--batch-pattern`` and ``--no-resume`` only make sense in batch mode; using
+    them without ``-b/--batch`` is a usage error rather than a silently ignored
+    no-op.
+    """
+    if batch_mode:
+        return
+    misused = []
+    if batch_pattern != "*":
+        misused.append("--batch-pattern")
+    if no_resume:
+        misused.append("--no-resume")
+    if misused:
+        joined = ", ".join(misused)
+        verb = "is" if len(misused) == 1 else "are"
+        raise click.UsageError(f"{joined} {verb} only valid in batch mode; enable it with -b/--batch.")
 
 
 def _parse_skip_checks(skip_checks: list[str] | None) -> list[str]:

--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -752,9 +752,7 @@ def _discover_batch_crates(
     """
     scan_dir = Path(rocrate_uri).resolve()
     if not scan_dir.is_dir():
-        raise click.BadParameter(
-            f"Batch target must be a directory: {scan_dir}", param_hint="RO-CRATE-URI"
-        )
+        raise click.BadParameter(f"Batch target must be a directory: {scan_dir}", param_hint="RO-CRATE-URI")
     return [str(p) for p in services.discover_ro_crates(scan_dir, pattern=batch_pattern)]
 
 

--- a/rocrate_validator/cli/ui/text/validate.py
+++ b/rocrate_validator/cli/ui/text/validate.py
@@ -14,9 +14,19 @@
 
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rich.console import Group
+from rich.padding import Padding
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+from rich.rule import Rule
+from rich.table import Table
+
 from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.io_helpers.colors import get_severity_color
 from rocrate_validator.utils.io_helpers.output.console import Console
 from rocrate_validator.utils.io_helpers.output.text import TextOutputFormatter
 from rocrate_validator.utils.io_helpers.output.text.layout.report import ValidationReportLayout
@@ -24,11 +34,146 @@ from rocrate_validator.utils.io_helpers.output.text.layout.report import Validat
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from rocrate_validator.models import ValidationResult, ValidationSettings, ValidationStatistics
+    from rocrate_validator.models import (
+        BatchCrateEntry,
+        BatchValidationResult,
+        Severity,
+        ValidationResult,
+        ValidationSettings,
+        ValidationStatistics,
+    )
     from rocrate_validator.utils.io_helpers.output.pager import SystemPager
 
 # set up logging
 logger = logging.getLogger(__name__)
+
+# Number of bytes per unit step when formatting human-readable sizes.
+_BYTES_PER_UNIT = 1024
+# Minimum path components below the common prefix needed to derive a source label.
+_MIN_REL_PARTS_FOR_SOURCE = 2
+
+
+class _SpacedProgress(Progress):
+    """
+    A :class:`rich.progress.Progress` that renders a blank line above its status
+    bar, separating the live ``Batch: … passed … failed`` line from the per-crate
+    results printed above it. The blank is part of the (transient) live region, so
+    it is cleared together with the bar when validation ends.
+    """
+
+    def get_renderable(self):
+        return Group("", super().get_renderable())
+
+
+def format_crate_line(
+    index: int,
+    total: int,
+    *,
+    status: str,
+    name: str,
+    detail: str = "",
+    profiles: list[str] | None = None,
+    index_width: int | None = None,
+    name_width: int = 0,
+) -> str:
+    """
+    Render a single per-crate result line, shared by the live batch run and the
+    static ``sessions show`` rendering so both stay identical.
+
+    ``status`` is one of ``passed`` / ``failed`` / ``error`` / ``pending``;
+    ``detail`` is the trailing text (e.g. ``(3 issues)`` or an error message).
+    The running index is right-aligned and the name left-padded so the status
+    text lines up across rows.
+    """
+    iw = index_width if index_width is not None else len(str(total))
+    idx = f"[{index:>{iw}}/{total}]"
+    name_cell = f"{name:<{name_width}}"
+    prof = (
+        f"  [white]profile:[/white] [bold magenta]{', '.join(profiles)}[/bold magenta]" if profiles else ""
+    )
+    if status == "passed":
+        return f"  [green]✓[/green] {idx} {name_cell}  [bold green]passed[/bold green] [green]{detail}[/green]{prof}"
+    if status == "failed":
+        return f"  [red]✗[/red] {idx} {name_cell}  [bold red]failed[/bold red] [red]{detail}[/red]{prof}"
+    if status == "error":
+        return f"  [yellow]⚠[/yellow] {idx} {name_cell}  [yellow]{detail}[/yellow]"
+    return f"  [dim]·[/dim] {idx} {name_cell}  [dim]pending[/dim]"
+
+
+_STATUS_STYLES = {
+    "completed": "green",
+    "in_progress": "yellow",
+    "interrupted": "yellow",
+    "unknown": "red",
+}
+
+
+def format_profile_selection(profile_identifiers: list[str] | None, no_auto_profile: bool) -> tuple[str, str]:
+    """Return the profile-selection label and its Rich style for the header."""
+    if profile_identifiers:
+        return ", ".join(profile_identifiers), "magenta"
+    if no_auto_profile:
+        return "ro-crate (auto-detection disabled)", "dim italic"
+    return "auto-detected per crate", "dim italic"
+
+
+def render_batch_header(
+    console: Console,
+    *,
+    headline: str,
+    rows: list[tuple[str, str, str]],
+    status: str | None = None,
+) -> None:
+    """
+    Render the batch/session header: a headline (optionally with a coloured status
+    badge) followed by a bullet list of ``(label, value, value_style)`` rows with
+    bold labels aligned to a common width.
+
+    Shared by the ``validate`` batch run and the ``sessions show``/``resume``
+    commands so the header looks the same everywhere.
+    """
+    console.print()
+    if status:
+        st = _STATUS_STYLES.get(status, "white")
+        headline = f"{headline}   [{st}]●[/{st}] [bold {st}]{status}[/bold {st}]"
+    console.print(headline)
+    console.print()
+    label_width = max((len(label) for label, _, _ in rows), default=0)
+    for label, value, value_style in rows:
+        console.print(f"  [dim]•[/dim] [bold]{label:<{label_width}}[/bold]   [{value_style}]{value}[/{value_style}]")
+    console.print()
+
+
+def render_batch_footer(
+    console: Console,
+    batch_result: BatchValidationResult,
+    rows: list[tuple[str, str, str, str]],
+) -> None:
+    """
+    Render the final batch verdict followed by an aligned details block.
+
+    Shared by the ``validate`` and ``sessions resume`` commands so their output
+    stays consistent. ``rows`` is a list of ``(icon, label, path, path_style)``
+    tuples; labels are padded to a common width. The whole block is indented by
+    two spaces so the icons line up with the per-crate ``✓``/``✗`` marks printed
+    above it.
+    """
+    indent = "  "
+    if batch_result.passed():
+        console.print(
+            f"\n{indent}[green]✅ [bold]All {batch_result.total_crates()} RO-Crate(s) passed validation![/bold][/green]"
+        )
+    else:
+        console.print(
+            f"\n{indent}[red]❌ [bold]{len(batch_result.failed_entries())} "
+            f"out of {batch_result.total_crates()} RO-Crate(s) failed validation.[/bold][/red]"
+        )
+    if rows:
+        label_width = max(len(label) for _, label, _, _ in rows)
+        console.print()  # blank line separating the verdict from the details block
+        for icon, label, path, path_style in rows:
+            console.print(f"{indent}{icon} [bold]{label:<{label_width}}[/bold]  [{path_style}]{path}[/{path_style}]")
+    console.print()  # trailing blank line to separate the output from the next prompt
 
 
 class ValidationCommandView:
@@ -114,3 +259,326 @@ class ValidationCommandView:
 
         with self.console.pager(pager=self.pager, styles=not self.console.no_color) if self.pager else self.console:
             self.console.print(result)
+
+
+class BatchValidationCommandView:
+    """
+    Displays batch validation progress and results in text mode.
+    """
+
+    def __init__(self, console: Console):
+        self._console = console
+        self.console.register_formatter(TextOutputFormatter())
+
+    @property
+    def console(self) -> Console:
+        return self._console
+
+    def run_with_progress(
+        self,
+        batch_validate_fn: Callable,
+        settings: ValidationSettings,
+        rocrate_uris: list[str],
+        session_path: Path | None = None,
+        fresh: bool = False,
+        profile_identifiers: list[str] | None = None,
+        no_auto_profile: bool = False,
+        base_path: Path | None = None,
+    ) -> BatchValidationResult:
+        """
+        Run batch validation with a persistent Rich progress bar on stderr.
+
+        The progress bar stays visible at the bottom of the terminal during
+        validation and is replaced by the summary once complete. When ``base_path``
+        is given, each crate is shown relative to it so the lines stay short.
+        """
+        total = len(rocrate_uris)
+        passed_count = 0
+        failed_count = 0
+
+        def _display(crate_path: str) -> str:
+            """Render a crate path relative to ``base_path`` (the scan root) when possible."""
+            if base_path is None:
+                return crate_path
+            try:
+                rel = os.path.relpath(crate_path, base_path)
+            except ValueError:
+                return crate_path
+            return "." if rel == os.curdir else rel
+
+        # Column widths so the per-crate lines line up: a fixed-width running index
+        # (e.g. "[ 1/43]") and crate names padded to the longest name, so the
+        # trailing "passed (N issues)" / "failed (N issues)" all start at the same
+        # column.
+        index_width = len(str(total))
+        name_width = max((len(_display(p)) for p in rocrate_uris), default=0)
+
+        # Use stderr for progress so it's always visible even when stdout
+        # is redirected to a file.
+        progress_console = Console(
+            file=sys.stderr,
+            no_color=getattr(self.console, "no_color", False),
+            width=getattr(self.console, "width", None),
+        )
+
+        progress = _SpacedProgress(
+            TextColumn("{task.description}", justify="left"),
+            BarColumn(bar_width=None),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("•", style="dim"),
+            TimeElapsedColumn(),
+            console=progress_console,
+            transient=True,
+            expand=True,
+        )
+
+        with progress:
+            task = progress.add_task(
+                description="[cyan]⏳ Initialising batch...[/cyan]",
+                total=total,
+            )
+
+            def _progress_callback(crate_path, index, total, status, message, profiles=None):
+                nonlocal passed_count, failed_count
+                # Finalisation: writing a large session to disk can take a moment;
+                # show it on the bar so the run does not look frozen at 100%.
+                if status == "saving":
+                    progress.update(task, description="[cyan]💾 Saving session…[/cyan]")
+                    return
+                disp = _display(crate_path)
+                if status == "passed":
+                    passed_count += 1
+                    progress.update(task, advance=1)
+                elif status == "failed":
+                    failed_count += 1
+                    progress.update(task, advance=1)
+                elif status == "error":
+                    failed_count += 1
+                    progress.update(task, advance=1)
+                if status in ("passed", "failed", "error"):
+                    progress_console.print(
+                        format_crate_line(
+                            index,
+                            total,
+                            status=status,
+                            name=disp,
+                            detail=message or "",
+                            profiles=profiles,
+                            index_width=index_width,
+                            name_width=name_width,
+                        )
+                    )
+                # Update the status line at the bottom
+                remaining = total - passed_count - failed_count
+                progress.update(
+                    task,
+                    description=(
+                        f"[bold]Batch:[/bold] "
+                        f"[green]{passed_count} passed[/green] "
+                        f"[red]{failed_count} failed[/red] "
+                        f"[dim]{remaining} remaining[/dim]"
+                    ),
+                )
+
+            return batch_validate_fn(
+                settings=settings,
+                rocrate_uris=rocrate_uris,
+                session_path=session_path,
+                fresh=fresh,
+                progress_callback=_progress_callback,
+                profile_identifiers=profile_identifiers,
+                no_auto_profile=no_auto_profile,
+            )
+
+    @staticmethod
+    def _format_size(num_bytes: int) -> str:
+        """Format a byte count as a human-readable string."""
+        size = float(num_bytes)
+        for unit in ("B", "KB", "MB", "GB"):
+            if size < _BYTES_PER_UNIT:
+                return f"{size:.1f} {unit}"
+            size /= _BYTES_PER_UNIT
+        return f"{size:.1f} TB"
+
+    @staticmethod
+    def _crate_disk_size(crate_path: str) -> str | None:
+        """Return a human-readable disk size for a crate path, or None if unavailable."""
+        try:
+            p = Path(crate_path)
+            if p.is_dir():
+                total_bytes = sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+            elif p.is_file():
+                total_bytes = p.stat().st_size
+            else:
+                return None
+        except OSError:
+            return None
+        return BatchValidationCommandView._format_size(total_bytes)
+
+    @staticmethod
+    def _summary_source_and_name(crate_path: str, common: str, common_prefix: str) -> tuple[str, str]:
+        """Split a crate path into a (source, crate-name) pair relative to the common prefix."""
+        if common_prefix and crate_path.startswith(common_prefix):
+            rel_parts = Path(crate_path[len(common_prefix) :]).parts
+            if len(rel_parts) >= _MIN_REL_PARTS_FOR_SOURCE:
+                return rel_parts[0], str(Path(*rel_parts[1:]))
+            # crate is a direct child of common prefix: use common's last dir as source
+            return Path(common).name, (rel_parts[0] if rel_parts else crate_path)
+        return Path(crate_path).parent.name, Path(crate_path).name
+
+    def _add_summary_row(
+        self,
+        table: Table,
+        entry: BatchCrateEntry,
+        *,
+        common: str,
+        common_prefix: str,
+    ) -> None:
+        """Append a single crate's summary row to the batch table from its session entry."""
+        source, crate_name = self._summary_source_and_name(entry.path, common, common_prefix)
+        stats = entry.statistics or {}
+        size = (
+            self._format_size(entry.size_bytes)
+            if entry.size_bytes is not None
+            else self._crate_disk_size(entry.path) or "—"
+        )
+        duration = entry.duration
+        table.add_row(
+            source,
+            crate_name,
+            ", ".join(entry.profiles or []) or "—",
+            size,
+            "[green]✓ PASSED[/green]" if entry.passed else "[red]✗ FAILED[/red]",
+            str(stats.get("total_checks", 0)),
+            str(stats.get("total_passed_checks", 0)),
+            str(len(entry.issues or [])),
+            f"{duration:.2f}s" if duration else "—",
+        )
+
+    def show_summary(self, batch_result: BatchValidationResult, verbose: bool = False):
+        """
+        Show the batch validation summary table and optional per-crate details.
+
+        The table is sourced from the persistent session entries, so it stays
+        complete even when this invocation only re-validated part of a resumed
+        batch. The verbose per-crate details below use the live results, which
+        are available only for crates validated in the current run.
+        """
+        total = batch_result.total_crates()
+        passed = len(batch_result.passed_entries())
+        failed = len(batch_result.failed_entries())
+
+        # Summary table
+        table = Table(
+            title="Batch Validation Summary",
+            title_style="bold",
+            show_header=True,
+            header_style="bold cyan",
+            border_style="blue",
+            expand=True,
+        )
+        table.add_column("Source", style="dim", no_wrap=True)
+        table.add_column("RO-Crate", style="white", no_wrap=True, ratio=1)
+        table.add_column("Profile", style="cyan", no_wrap=True)
+        table.add_column("Size", justify="right", min_width=9)
+        table.add_column("Status", min_width=8, max_width=10)
+        table.add_column("Checks", justify="right", min_width=6)
+        table.add_column("Passed", justify="right", min_width=6)
+        table.add_column("Issues", justify="right", min_width=6)
+        table.add_column("Duration", justify="right", min_width=8)
+
+        # Compute common prefix once so the first path component after it
+        # always identifies the repository source (workflowhub, rohub, …),
+        # even for deeply-nested crates like .../workflowhub/id/subdir/crate.
+        all_paths = [entry.path for entry in batch_result.crates]
+        try:
+            common = str(Path(os.path.commonpath(all_paths)))
+            common_prefix = common + os.sep
+        except (ValueError, TypeError):
+            common = ""
+            common_prefix = ""
+
+        for entry in batch_result.crates:
+            self._add_summary_row(
+                table,
+                entry,
+                common=common,
+                common_prefix=common_prefix,
+            )
+
+        self.console.print(Padding(Rule(style="blue"), (0, 0)))
+        self.console.print(table)
+
+        # Overall stats
+        self.console.print(
+            Padding(
+                f"\n[bold]Total: {total} crates | [green]{passed} passed[/green] | [red]{failed} failed[/red][/bold]",
+                (0, 2),
+            )
+        )
+
+        # Per-crate details in verbose mode. These rely on the live, in-memory
+        # results, so only crates validated in the current run are shown (e.g.
+        # after resuming, previously-failed crates appear in the table above but
+        # their deep details are not re-rendered).
+        live_failures = [(p, r) for p, r in batch_result.results if not r.passed()]
+        if verbose and live_failures:
+            self.console.print(Padding(Rule(style="dim"), (1, 0)))
+            self.console.print(Padding("[bold]Failed crate details:[/bold]", (0, 2)))
+            for crate_path, result in live_failures:
+                self._show_crate_detail(crate_path, result)
+                self.console.print(Padding(Rule(style="dim"), (0, 0)))
+
+    def _show_crate_detail(self, crate_path: str, result: ValidationResult):
+        """
+        Show detailed validation result for a single crate in verbose batch mode.
+        """
+        stats = result.statistics
+        if not stats:
+            return
+
+        status = "PASSED" if result.passed() else "FAILED"
+        color = "green" if result.passed() else "red"
+        header = f"\n[{color}]✗ {status}[/{color}]: [bold]{crate_path}[/bold]"
+        if stats.duration:
+            header += f" ({stats.duration:.2f}s)"
+        self.console.print(Padding(header, (1, 2)))
+        self.console.print(
+            Padding(
+                f"Checks executed: {stats.total_checks} | "
+                f"Passed: {len(stats.passed_checks)} | "
+                f"Failed: {len(stats.failed_checks)}",
+                (0, 4),
+            )
+        )
+
+        # Group failed checks by severity
+        checks_by_severity: dict[Severity, list] = {}
+        for check in stats.failed_checks:
+            checks_by_severity.setdefault(check.severity, []).append(check)
+
+        for severity in sorted(checks_by_severity.keys(), key=lambda s: s.value, reverse=True):
+            checks = checks_by_severity[severity]
+            color = get_severity_color(severity)
+            severity_name = severity.name.capitalize()
+            self.console.print(
+                Padding(
+                    f"\n[bold {color}]╔══ {severity_name} ({len(checks)} failed) ═══[/bold {color}]",
+                    (0, 4),
+                )
+            )
+            for check in checks:
+                self.console.print(
+                    Padding(
+                        f"  [bold]{check.identifier}[/bold] - {check.name}",
+                        (0, 6),
+                    )
+                )
+                issues = result.get_issues_by_check(check)
+                for issue in issues:
+                    self.console.print(
+                        Padding(
+                            f"    └─ [{color}]{severity_name}[/{color}] {issue.message}",
+                            (0, 8),
+                        )
+                    )

--- a/rocrate_validator/cli/ui/text/validate.py
+++ b/rocrate_validator/cli/ui/text/validate.py
@@ -88,9 +88,7 @@ def format_crate_line(
     iw = index_width if index_width is not None else len(str(total))
     idx = f"[{index:>{iw}}/{total}]"
     name_cell = f"{name:<{name_width}}"
-    prof = (
-        f"  [white]profile:[/white] [bold magenta]{', '.join(profiles)}[/bold magenta]" if profiles else ""
-    )
+    prof = f"  [white]profile:[/white] [bold magenta]{', '.join(profiles)}[/bold magenta]" if profiles else ""
     if status == "passed":
         return f"  [green]✓[/green] {idx} {name_cell}  [bold green]passed[/bold green] [green]{detail}[/green]{prof}"
     if status == "failed":
@@ -349,10 +347,7 @@ class BatchValidationCommandView:
                 if status == "passed":
                     passed_count += 1
                     progress.update(task, advance=1)
-                elif status == "failed":
-                    failed_count += 1
-                    progress.update(task, advance=1)
-                elif status == "error":
+                elif status in ("failed", "error"):
                     failed_count += 1
                     progress.update(task, advance=1)
                 if status in ("passed", "failed", "error"):

--- a/rocrate_validator/cli/ui/text/validate.py
+++ b/rocrate_validator/cli/ui/text/validate.py
@@ -25,6 +25,7 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.rule import Rule
 from rich.table import Table
 
+from rocrate_validator.models.severity import Severity
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.io_helpers.colors import get_severity_color
 from rocrate_validator.utils.io_helpers.output.console import Console
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from rocrate_validator.models import (
         BatchCrateEntry,
         BatchValidationResult,
-        Severity,
         ValidationResult,
         ValidationSettings,
         ValidationStatistics,
@@ -51,6 +51,14 @@ logger = logging.getLogger(__name__)
 _BYTES_PER_UNIT = 1024
 # Minimum path components below the common prefix needed to derive a source label.
 _MIN_REL_PARTS_FOR_SOURCE = 2
+
+
+def _severity_rank(severity_name: str) -> int:
+    """Sort key for serialized severity names (unknown names sort last)."""
+    try:
+        return int(Severity[severity_name].value)
+    except KeyError:
+        return -1
 
 
 class _SpacedProgress(Progress):
@@ -454,10 +462,9 @@ class BatchValidationCommandView:
         """
         Show the batch validation summary table and optional per-crate details.
 
-        The table is sourced from the persistent session entries, so it stays
-        complete even when this invocation only re-validated part of a resumed
-        batch. The verbose per-crate details below use the live results, which
-        are available only for crates validated in the current run.
+        Both the table and the verbose per-crate details are sourced from the
+        persistent session entries, so they stay complete even when this
+        invocation only re-validated part of a resumed batch.
         """
         total = batch_result.total_crates()
         passed = len(batch_result.passed_entries())
@@ -512,68 +519,70 @@ class BatchValidationCommandView:
             )
         )
 
-        # Per-crate details in verbose mode. These rely on the live, in-memory
-        # results, so only crates validated in the current run are shown (e.g.
-        # after resuming, previously-failed crates appear in the table above but
-        # their deep details are not re-rendered).
-        live_failures = [(p, r) for p, r in batch_result.results if not r.passed()]
-        if verbose and live_failures:
+        # Per-crate details in verbose mode, sourced from the session entries
+        # like the summary table: details are available for every failed crate,
+        # including those validated by an earlier run of a resumed session.
+        failures = batch_result.failed_entries()
+        if verbose and failures:
             self.console.print(Padding(Rule(style="dim"), (1, 0)))
             self.console.print(Padding("[bold]Failed crate details:[/bold]", (0, 2)))
-            for crate_path, result in live_failures:
-                self._show_crate_detail(crate_path, result)
+            for entry in failures:
+                self._show_crate_detail(entry)
                 self.console.print(Padding(Rule(style="dim"), (0, 0)))
 
-    def _show_crate_detail(self, crate_path: str, result: ValidationResult):
+    def _show_crate_detail(self, entry: BatchCrateEntry):
         """
-        Show detailed validation result for a single crate in verbose batch mode.
+        Show the detailed outcome of a failed crate in verbose batch mode.
+
+        Rendered entirely from the persisted session entry (headline statistics
+        and serialized issues), so it needs no in-memory validation result.
         """
-        stats = result.statistics
-        if not stats:
+        header = f"\n[red]✗ FAILED[/red]: [bold]{entry.path}[/bold]"
+        if entry.duration:
+            header += f" ({entry.duration:.2f}s)"
+        self.console.print(Padding(header, (1, 2)))
+
+        if entry.error:
+            # The validation itself errored out (e.g. unreadable crate): there
+            # is no check breakdown, only the error message.
+            self.console.print(Padding(f"[red]Error:[/red] {entry.error}", (0, 4)))
             return
 
-        status = "PASSED" if result.passed() else "FAILED"
-        color = "green" if result.passed() else "red"
-        header = f"\n[{color}]✗ {status}[/{color}]: [bold]{crate_path}[/bold]"
-        if stats.duration:
-            header += f" ({stats.duration:.2f}s)"
-        self.console.print(Padding(header, (1, 2)))
-        self.console.print(
-            Padding(
-                f"Checks executed: {stats.total_checks} | "
-                f"Passed: {len(stats.passed_checks)} | "
-                f"Failed: {len(stats.failed_checks)}",
-                (0, 4),
-            )
-        )
-
-        # Group failed checks by severity
-        checks_by_severity: dict[Severity, list] = {}
-        for check in stats.failed_checks:
-            checks_by_severity.setdefault(check.severity, []).append(check)
-
-        for severity in sorted(checks_by_severity.keys(), key=lambda s: s.value, reverse=True):
-            checks = checks_by_severity[severity]
-            color = get_severity_color(severity)
-            severity_name = severity.name.capitalize()
+        stats = entry.statistics or {}
+        if stats:
             self.console.print(
                 Padding(
-                    f"\n[bold {color}]╔══ {severity_name} ({len(checks)} failed) ═══[/bold {color}]",
+                    f"Checks executed: {stats.get('total_checks', 0)} | "
+                    f"Passed: {stats.get('total_passed_checks', 0)} | "
+                    f"Failed: {stats.get('total_failed_checks', 0)}",
                     (0, 4),
                 )
             )
-            for check in checks:
-                self.console.print(
-                    Padding(
-                        f"  [bold]{check.identifier}[/bold] - {check.name}",
-                        (0, 6),
-                    )
+
+        # Group the crate's issues by severity, then by failed check.
+        issues_by_severity: dict[str, dict[str, list[dict]]] = {}
+        for issue in entry.issues or []:
+            severity_name = issue.get("severity") or "REQUIRED"
+            check = issue.get("check") or {}
+            check_label = f"[bold]{check.get('identifier', '?')}[/bold] - {check.get('name', '')}"
+            issues_by_severity.setdefault(severity_name, {}).setdefault(check_label, []).append(issue)
+
+        for severity_name in sorted(issues_by_severity, key=_severity_rank, reverse=True):
+            checks = issues_by_severity[severity_name]
+            color = get_severity_color(severity_name)
+            severity_label = severity_name.capitalize()
+            self.console.print(
+                Padding(
+                    f"\n[bold {color}]╔══ {severity_label} ({len(checks)} failed) ═══[/bold {color}]",
+                    (0, 4),
                 )
-                issues = result.get_issues_by_check(check)
+            )
+            for check_label, issues in checks.items():
+                self.console.print(Padding(f"  {check_label}", (0, 6)))
                 for issue in issues:
                     self.console.print(
                         Padding(
-                            f"    └─ [{color}]{severity_name}[/{color}] {issue.message}",
+                            f"    └─ [{color}]{severity_label}[/{color}] {issue.get('message', '')}",
                             (0, 8),
                         )
                     )

--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -118,5 +118,8 @@ DEFAULT_HTTP_CACHE_PATH_PREFIX = "/tmp/rocrate_validator_cache"
 USER_CACHE_DIR_NAME = "rocrate-validator"
 # Filename (without extension) of the persistent HTTP cache under the user cache dir
 USER_CACHE_FILE_NAME = "http_cache"
+# Directory name (under the user cache dir) where auto-managed batch session
+# files are persisted, keyed by a deterministic hash of the batch target.
+USER_SESSIONS_DIR_NAME = "sessions"
 # Environment variable to disable automatic warm-up of the HTTP cache
 AUTO_WARM_ENV_VAR = "ROCRATE_VALIDATOR_AUTO_WARM"

--- a/rocrate_validator/models/__init__.py
+++ b/rocrate_validator/models/__init__.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 from rocrate_validator.models._logging import logger
+from rocrate_validator.models.batch import (
+    BatchCrateEntry,
+    BatchSession,
+    BatchValidationResult,
+)
 from rocrate_validator.models.events import (
     ProfileValidationEvent,
     RequirementCheckValidationEvent,
@@ -58,6 +63,9 @@ __all__ = [
     "URI",
     "AggregatedValidationStatistics",
     "BaseTypes",
+    "BatchCrateEntry",
+    "BatchSession",
+    "BatchValidationResult",
     "CheckIssue",
     "CustomEncoder",
     "LevelCollection",

--- a/rocrate_validator/models/batch.py
+++ b/rocrate_validator/models/batch.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from rocrate_validator import __version__
+from rocrate_validator.models.result import CustomEncoder, ValidationResult
+
+
+@dataclass
+class BatchCrateEntry:
+    """Represents a single entry in a batch validation session."""
+
+    path: str
+    status: str  # pending | in_progress | completed | failed | skipped
+    passed: bool | None = None
+    duration: float | None = None
+    error: str | None = None
+    issues: list[Any] | None = None  # serialized CheckIssue dicts
+    statistics: dict[str, Any] | None = None  # ValidationStatistics.to_dict()
+    size_bytes: int | None = None  # disk size of the crate at validation time
+    profiles: list[str] | None = None  # profile identifier(s) the crate was validated against
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "size_bytes": self.size_bytes,
+            "status": self.status,
+            "passed": self.passed,
+            "profiles": self.profiles or [],
+            "duration": self.duration,
+            "error": self.error,
+            "issues": self.issues or [],
+            "statistics": self.statistics,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BatchCrateEntry:
+        field_names = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in field_names})
+
+
+class BatchSession:
+    """
+    Manages a batch validation session with incremental save/resume support.
+    """
+
+    SESSION_VERSION = "1.0"
+
+    def __init__(
+        self,
+        validation_settings: dict,
+        crate_paths: list[str],
+        session_path: Path | None = None,
+    ):
+        self.version: str = self.SESSION_VERSION
+        self.rocrate_validator_version: str = __version__
+        self.created_at: datetime = datetime.now(timezone.utc)
+        self.updated_at: datetime = self.created_at
+        self.status: str = "in_progress"
+        self.total_crates: int = len(crate_paths)
+        self.completed_crates: int = 0
+        self.failed_crates: int = 0
+        self.validation_settings: dict = validation_settings
+        self.session_path: Path | None = session_path
+        self.crates: list[BatchCrateEntry] = [BatchCrateEntry(path=p, status="pending") for p in crate_paths]
+        # Per-crate profile resolution options, persisted so an interrupted
+        # session can be resumed (via `sessions resume`) with the exact same
+        # criteria even outside the original `validate` invocation.
+        self.profile_identifiers: list[str] | None = None
+        self.no_auto_profile: bool = False
+        # `requirement_severity_only` is dropped by ``ValidationSettings.to_dict()``,
+        # so it is tracked here to faithfully reconstruct the settings on resume.
+        self.requirement_severity_only: bool = False
+
+    @staticmethod
+    def _compute_size_bytes(crate_path: str) -> int | None:
+        """Return total disk size in bytes for a crate path, or None on error."""
+        try:
+            p = Path(crate_path)
+            if p.is_dir():
+                return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+            if p.is_file():
+                return p.stat().st_size
+        except OSError:
+            pass
+        return None
+
+    def add_result(self, crate_path: str, result: ValidationResult, duration: float):
+        """Record a single-profile validation result for a crate."""
+        self.add_results(crate_path, [result], duration)
+
+    def add_results(
+        self,
+        crate_path: str,
+        results: list[ValidationResult] | list[tuple[str, ValidationResult]],
+        duration: float,
+    ):
+        """
+        Record the validation result(s) for a crate and update session state.
+
+        A crate may be validated against more than one profile; in that case the
+        per-profile outcomes are combined: the crate passes only when it passes
+        every profile, its issues are the union across profiles, and the headline
+        statistics counters are summed.
+        """
+        entry = self._find_entry(crate_path)
+        if entry is None:
+            return
+        # Accept both bare results and (profile, result) pairs.
+        normalized = [r[1] if isinstance(r, tuple) else r for r in results]
+        profiles = [r[0] for r in results if isinstance(r, tuple) and r[0]]
+        passed = all(r.passed() for r in normalized)
+        issues: list[Any] = []
+        for r in normalized:
+            issues.extend(i.to_dict() for i in r.issues)
+        entry.status = "completed"
+        entry.passed = passed
+        entry.profiles = profiles or None
+        entry.duration = duration
+        entry.issues = issues
+        entry.statistics = self._aggregate_statistics(normalized)
+        entry.size_bytes = self._compute_size_bytes(crate_path)
+        self.completed_crates += 1
+        if not passed:
+            self.failed_crates += 1
+
+    @staticmethod
+    def _aggregate_statistics(results: list[ValidationResult]) -> dict[str, Any] | None:
+        """
+        Combine the statistics of one or more per-profile results into one dict.
+
+        For a single profile the statistics are returned unchanged. For multiple
+        profiles the headline counters (``total_checks``, ``total_passed_checks``,
+        ``total_failed_checks``) are summed so the batch summary, CSV and JSON
+        reports stay consistent.
+        """
+        stat_dicts = [r.statistics.to_dict() for r in results if r.statistics]
+        if not stat_dicts:
+            return None
+        if len(stat_dicts) == 1:
+            return stat_dicts[0]
+        aggregated = dict(stat_dicts[0])
+        for key in ("total_checks", "total_passed_checks", "total_failed_checks"):
+            aggregated[key] = sum(d.get(key, 0) or 0 for d in stat_dicts)
+        return aggregated
+
+    def mark_failed(self, crate_path: str, error: str, duration: float = 0.0):
+        """Mark a crate as failed with an error message."""
+        entry = self._find_entry(crate_path)
+        if entry is None:
+            return
+        entry.status = "failed"
+        entry.passed = False
+        entry.duration = duration
+        entry.error = error
+        entry.size_bytes = self._compute_size_bytes(crate_path)
+        self.completed_crates += 1
+        self.failed_crates += 1
+
+    def get_pending(self) -> list[BatchCrateEntry]:
+        """Return entries that still need validation."""
+        return [e for e in self.crates if e.status in ("pending", "in_progress")]
+
+    def is_completed(self) -> bool:
+        return self.completed_crates >= self.total_crates
+
+    def save(self, path: Path | None = None):
+        """Serialize the session to a JSON file."""
+        save_path = path or self.session_path
+        if save_path is None:
+            return
+        self.updated_at = datetime.now(timezone.utc)
+        if self.is_completed():
+            self.status = "completed"
+        data = self.to_dict()
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with Path(save_path).open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4, cls=CustomEncoder)
+
+    def to_dict(self) -> dict:
+        return {
+            "session": {
+                "version": self.version,
+                "rocrate_validator_version": self.rocrate_validator_version,
+                "created_at": self.created_at.isoformat(),
+                "updated_at": self.updated_at.isoformat(),
+                "status": self.status,
+                "total_crates": self.total_crates,
+                "completed_crates": self.completed_crates,
+                "failed_crates": self.failed_crates,
+            },
+            "validation_settings": self.validation_settings,
+            "batch_options": {
+                "profile_identifiers": self.profile_identifiers,
+                "no_auto_profile": self.no_auto_profile,
+                "requirement_severity_only": self.requirement_severity_only,
+            },
+            "crates": [c.to_dict() for c in self.crates],
+        }
+
+    @classmethod
+    def load(cls, path: Path) -> BatchSession:
+        """Deserialize a session from a JSON file."""
+        with Path(path).open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        session_data = data["session"]
+        instance = cls.__new__(cls)
+        instance.version = session_data["version"]
+        instance.rocrate_validator_version = session_data.get("rocrate_validator_version", "")
+        instance.created_at = datetime.fromisoformat(session_data["created_at"])
+        instance.updated_at = datetime.fromisoformat(session_data["updated_at"])
+        instance.status = session_data["status"]
+        instance.total_crates = session_data["total_crates"]
+        instance.completed_crates = session_data["completed_crates"]
+        instance.failed_crates = session_data["failed_crates"]
+        instance.validation_settings = data.get("validation_settings", {})
+        batch_options = data.get("batch_options", {})
+        instance.profile_identifiers = batch_options.get("profile_identifiers")
+        instance.no_auto_profile = bool(batch_options.get("no_auto_profile", False))
+        instance.requirement_severity_only = bool(batch_options.get("requirement_severity_only", False))
+        instance.session_path = path
+        instance.crates = [BatchCrateEntry.from_dict(c) for c in data.get("crates", [])]
+        return instance
+
+    def _find_entry(self, crate_path: str) -> BatchCrateEntry | None:
+        for e in self.crates:
+            if e.path == crate_path:
+                return e
+        return None
+
+
+class BatchValidationResult:
+    """
+    Aggregated result of a batch validation run.
+
+    Headline figures (totals, pass/fail counts, JSON/CSV/summary rows) are
+    sourced from the persistent ``session``, so they remain complete even when
+    a run resumes a previously interrupted session. The live ``results`` of the
+    crates validated in *this* invocation are kept separately and used only for
+    the verbose per-crate details, which require the in-memory result objects.
+    """
+
+    def __init__(self, session: BatchSession, results: list[tuple[str, ValidationResult]]):
+        self.session = session
+        self._results = results
+
+    @property
+    def results(self) -> list[tuple[str, ValidationResult]]:
+        """Live results for the crates validated in the current invocation."""
+        return self._results
+
+    @property
+    def crates(self) -> list[BatchCrateEntry]:
+        """All session entries (complete across resumes), in discovery order."""
+        return self.session.crates
+
+    def passed(self) -> bool:
+        return self.session.failed_crates == 0 and self.session.is_completed()
+
+    def total_crates(self) -> int:
+        return len(self.session.crates)
+
+    def passed_entries(self) -> list[BatchCrateEntry]:
+        return [e for e in self.session.crates if e.passed]
+
+    def failed_entries(self) -> list[BatchCrateEntry]:
+        return [e for e in self.session.crates if e.status in ("completed", "failed") and not e.passed]
+
+    def to_dict(self) -> dict:
+        session_dict = self.session.to_dict()
+        session_dict["results"] = [
+            {
+                "crate": entry.path,
+                "profiles": entry.profiles or [],
+                "passed": entry.passed,
+                "issues": entry.issues or [],
+                "statistics": entry.statistics,
+            }
+            for entry in self.session.crates
+        ]
+        session_dict["batch_passed"] = self.passed()
+        return session_dict
+
+    def to_json(self, path: Path | None = None) -> str:
+        result = json.dumps(self.to_dict(), indent=4, cls=CustomEncoder)
+        if path:
+            with Path(path).open("w", encoding="utf-8") as f:
+                f.write(result)
+        return result

--- a/rocrate_validator/models/batch.py
+++ b/rocrate_validator/models/batch.py
@@ -251,21 +251,17 @@ class BatchValidationResult:
     """
     Aggregated result of a batch validation run.
 
-    Headline figures (totals, pass/fail counts, JSON/CSV/summary rows) are
-    sourced from the persistent ``session``, so they remain complete even when
-    a run resumes a previously interrupted session. The live ``results`` of the
-    crates validated in *this* invocation are kept separately and used only for
-    the verbose per-crate details, which require the in-memory result objects.
+    Everything (totals, pass/fail counts, JSON/CSV/summary rows and the verbose
+    per-crate details) is sourced from the persistent ``session`` entries, so
+    the result remains complete even when a run resumes a previously
+    interrupted session. Live ``ValidationResult`` objects are deliberately
+    *not* retained: each one pins its full validation context (data graph,
+    RO-Crate and loaded profiles with their shape graphs), which makes the
+    memory footprint of a batch grow linearly with the number of crates.
     """
 
-    def __init__(self, session: BatchSession, results: list[tuple[str, ValidationResult]]):
+    def __init__(self, session: BatchSession):
         self.session = session
-        self._results = results
-
-    @property
-    def results(self) -> list[tuple[str, ValidationResult]]:
-        """Live results for the crates validated in the current invocation."""
-        return self._results
 
     @property
     def crates(self) -> list[BatchCrateEntry]:

--- a/rocrate_validator/models/batch.py
+++ b/rocrate_validator/models/batch.py
@@ -251,31 +251,34 @@ class BatchValidationResult:
     """
     Aggregated result of a batch validation run.
 
-    Everything (totals, pass/fail counts, JSON/CSV/summary rows and the verbose
-    per-crate details) is sourced from the persistent ``session`` entries, so
-    the result remains complete even when a run resumes a previously
-    interrupted session. Live ``ValidationResult`` objects are *not* retained
-    by default: each one pins its full validation context (data graph,
-    RO-Crate and loaded profiles with their shape graphs), which makes the
-    memory footprint of a batch grow linearly with the number of crates. They
-    are kept in :attr:`results` only when the batch runs with
-    ``keep_results=True`` (see :func:`~rocrate_validator.services.batch_validate`).
+    The per-crate outcomes of the batch are always available in :attr:`crates`
+    (the persistent ``session`` entries): totals, pass/fail counts, issues and
+    the JSON/CSV/summary rows are all sourced from there, so the result remains
+    complete even when a run resumes a previously interrupted session. Live
+    ``ValidationResult`` objects are *not* retained by default: each one pins
+    its full validation context (data graph, RO-Crate and loaded profiles with
+    their shape graphs), which makes the memory footprint of a batch grow
+    linearly with the number of crates. They are kept in :attr:`live_results`
+    only when the batch runs with ``keep_results=True``
+    (see :func:`~rocrate_validator.services.batch_validate`).
     """
 
-    def __init__(self, session: BatchSession, results: list[tuple[str, ValidationResult]] | None = None):
+    def __init__(self, session: BatchSession, live_results: list[tuple[str, ValidationResult]] | None = None):
         self.session = session
-        self._results = results if results is not None else []
+        self._live_results = live_results if live_results is not None else []
 
     @property
-    def results(self) -> list[tuple[str, ValidationResult]]:
+    def live_results(self) -> list[tuple[str, ValidationResult]]:
         """
         Live ``(crate_path, ValidationResult)`` pairs of the crates validated in
         the current invocation. Empty unless the batch was run with
         ``keep_results=True``, which is meant for debugging and interactive
         exploration: every retained result pins its full validation context in
-        memory for the whole batch.
+        memory for the whole batch. For the recorded outcome of *every* crate
+        (including those validated by an earlier run of a resumed session), use
+        :attr:`crates`.
         """
-        return self._results
+        return self._live_results
 
     @property
     def crates(self) -> list[BatchCrateEntry]:

--- a/rocrate_validator/models/batch.py
+++ b/rocrate_validator/models/batch.py
@@ -254,14 +254,28 @@ class BatchValidationResult:
     Everything (totals, pass/fail counts, JSON/CSV/summary rows and the verbose
     per-crate details) is sourced from the persistent ``session`` entries, so
     the result remains complete even when a run resumes a previously
-    interrupted session. Live ``ValidationResult`` objects are deliberately
-    *not* retained: each one pins its full validation context (data graph,
+    interrupted session. Live ``ValidationResult`` objects are *not* retained
+    by default: each one pins its full validation context (data graph,
     RO-Crate and loaded profiles with their shape graphs), which makes the
-    memory footprint of a batch grow linearly with the number of crates.
+    memory footprint of a batch grow linearly with the number of crates. They
+    are kept in :attr:`results` only when the batch runs with
+    ``keep_results=True`` (see :func:`~rocrate_validator.services.batch_validate`).
     """
 
-    def __init__(self, session: BatchSession):
+    def __init__(self, session: BatchSession, results: list[tuple[str, ValidationResult]] | None = None):
         self.session = session
+        self._results = results if results is not None else []
+
+    @property
+    def results(self) -> list[tuple[str, ValidationResult]]:
+        """
+        Live ``(crate_path, ValidationResult)`` pairs of the crates validated in
+        the current invocation. Empty unless the batch was run with
+        ``keep_results=True``, which is meant for debugging and interactive
+        exploration: every retained result pins its full validation context in
+        memory for the whole batch.
+        """
+        return self._results
 
     @property
     def crates(self) -> list[BatchCrateEntry]:

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -14,17 +14,35 @@
 
 
 import shutil
+import signal
+import sys
 import tempfile
+import time
 import zipfile
+from collections.abc import Callable
+from fnmatch import fnmatch
 from pathlib import Path
 
-from rocrate_validator.constants import HTTP_STATUS_BAD_REQUEST, HTTP_STATUS_GATEWAY_TIMEOUT
+from rocrate_validator.constants import (
+    HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_GATEWAY_TIMEOUT,
+    ROCRATE_METADATA_FILE,
+)
 from rocrate_validator.errors import ProfileNotFound
 from rocrate_validator.events import Subscriber
-from rocrate_validator.models import Profile, Severity, ValidationResult, ValidationSettings, Validator
+from rocrate_validator.models import (
+    BatchCrateEntry,
+    BatchSession,
+    BatchValidationResult,
+    Profile,
+    Severity,
+    ValidationResult,
+    ValidationSettings,
+    Validator,
+)
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.http import HttpRequester
-from rocrate_validator.utils.paths import get_profiles_path
+from rocrate_validator.utils.paths import get_batch_session_path, get_profiles_path
 from rocrate_validator.utils.uri import URI
 
 # set the default profiles path
@@ -186,6 +204,332 @@ def __initialise_validator__(
     raise ValueError(
         f"Invalid RO-Crate URI: {rocrate_path}. It MUST be a local directory or a ZIP file (local or remote)."
     )
+
+
+def discover_ro_crates(
+    directory: Path,
+    pattern: str = "*",
+) -> list[Path]:
+    """
+    Scan a directory for the RO-Crates it directly contains.
+
+    The directory is treated as the root of a flat list of crates. Only the
+    immediate level is inspected; crate payloads (data entities nested inside a
+    crate) are intentionally not descended into. A crate is discovered when:
+
+    - the scan directory itself holds an ``ro-crate-metadata.json`` (a crate
+      defined directly in the scan root);
+    - an immediate subdirectory holds an ``ro-crate-metadata.json``;
+    - an immediate entry is a ``.zip`` file (a zipped crate);
+    - an immediate file is a detached crate metadata file, i.e. its name ends
+      with ``ro-crate-metadata.json`` (e.g. ``crate_0001-ro-crate-metadata.json``);
+      several such files can coexist in the same directory.
+
+    All results are filtered by the glob ``pattern`` against the entry name.
+
+    :param directory: the directory to scan
+    :param pattern: glob pattern to filter entries by name (default: ``*``)
+    :return: sorted list of discovered RO-Crate paths
+    """
+    directory = Path(directory).resolve()
+    if not directory.is_dir():
+        raise NotADirectoryError(f"Not a directory: {directory}")
+
+    crates: set[Path] = set()
+
+    # The scan root itself may be a crate (its own ``ro-crate-metadata.json``).
+    if (directory / ROCRATE_METADATA_FILE).exists() and fnmatch(directory.name, pattern):
+        crates.add(directory)
+
+    # Immediate children: subdirectory crates, zipped crates and detached crate
+    # metadata files (single pass).
+    for entry in directory.iterdir():
+        if not fnmatch(entry.name, pattern):
+            continue
+        if entry.is_dir():
+            if (entry / ROCRATE_METADATA_FILE).exists():
+                crates.add(entry)
+        elif entry.suffix == ".zip":
+            crates.add(entry)
+        elif entry.name.endswith(ROCRATE_METADATA_FILE) and entry.name != ROCRATE_METADATA_FILE:
+            # A detached crate defined directly as a (prefixed) metadata file;
+            # the plain ``ro-crate-metadata.json`` is covered by the scan-root
+            # check above (it makes the directory itself the crate).
+            crates.add(entry)
+
+    return sorted(crates)
+
+
+def resolve_batch_session_path(
+    settings: ValidationSettings,
+    scan_root: Path,
+    pattern: str,
+    profile_identifiers: list[str] | None = None,
+    no_auto_profile: bool = False,
+) -> Path:
+    """
+    Resolve the auto-managed session file path for a batch target.
+
+    The path is derived deterministically from the scan root, the discovery
+    options and the validation settings that affect the outcome (profiles and
+    severity), so that re-running the same command resolves to the same file
+    and can be auto-resumed. Changing the profile selection or severity
+    intentionally starts a new session.
+
+    The profile part reflects what is *actually* applied per crate: the explicit
+    ``profile_identifiers`` list (order-independent), or the auto-detection mode
+    when no profile is given. This keeps distinct profile selections (e.g. two
+    different multi-profile sets) on separate sessions.
+    """
+    settings_dict = settings.to_dict() if hasattr(settings, "to_dict") else {}
+    if profile_identifiers:
+        profile_key = str(sorted(profile_identifiers))
+    else:
+        # No explicit profile: per-crate auto-detection, or the base-profile
+        # fallback when auto-detection is disabled.
+        profile_key = f"auto:{not no_auto_profile}"
+    # `requirement_severity_only` is dropped by ``ValidationSettings.to_dict()``,
+    # so read it from the settings object directly rather than from the dict.
+    severity_only = bool(getattr(settings, "requirement_severity_only", settings_dict.get("requirement_severity_only", False)))
+    key_parts = [
+        str(Path(scan_root).resolve()),
+        pattern,
+        profile_key,
+        str(settings_dict.get("requirement_severity", "")),
+        str(severity_only),
+    ]
+    return get_batch_session_path(key_parts)
+
+
+def _load_previous_session(session_path: Path | None) -> BatchSession | None:
+    """Load an existing batch session for auto-resume, or ``None`` if unavailable."""
+    if not session_path or not Path(session_path).exists():
+        return None
+    try:
+        return BatchSession.load(Path(session_path))
+    except Exception:
+        logger.warning("Could not load batch session at %s; starting a fresh session.", session_path)
+        return None
+
+
+def _prepare_batch_session(
+    settings: ValidationSettings,
+    rocrate_uris: list[str],
+    session_path: Path | None,
+    fresh: bool,
+) -> tuple[BatchSession, list[str]]:
+    """
+    Create or auto-resume a batch session and return it together with the
+    URIs that still need to be validated.
+
+    A previous session is resumed only when it exists and is *not* already
+    completed (i.e. it was interrupted): in that case the crates that were
+    already validated are carried over and only the remaining (plus any newly
+    discovered) crates are validated. A completed or missing session — or an
+    explicit ``fresh`` request — starts a brand-new session that revalidates
+    everything.
+    """
+    settings_dict = settings.to_dict() if hasattr(settings, "to_dict") else {}
+    session = BatchSession(
+        validation_settings=settings_dict,
+        crate_paths=rocrate_uris,
+        session_path=session_path,
+    )
+
+    previous = None if fresh else _load_previous_session(session_path)
+    if previous is None or previous.is_completed():
+        return session, list(rocrate_uris)
+
+    # Resume an interrupted session: carry over already-completed crates and
+    # validate the rest. Newly discovered crates are included as pending.
+    completed = {e.path: e for e in previous.crates if e.status == "completed"}
+    session.crates = [completed.get(p) or BatchCrateEntry(path=p, status="pending") for p in rocrate_uris]
+    session.total_crates = len(session.crates)
+    session.completed_crates = sum(1 for e in session.crates if e.status == "completed")
+    session.failed_crates = sum(1 for e in session.crates if e.status == "completed" and e.passed is False)
+    pending = [e.path for e in session.crates if e.status != "completed"]
+    logger.info(
+        "Resuming batch session: %d/%d crates already validated, %d to validate",
+        session.completed_crates,
+        session.total_crates,
+        len(pending),
+    )
+    return session, pending
+
+
+def _resolve_crate_profiles(
+    settings: ValidationSettings,
+    crate_path: str,
+    profile_identifiers: list[str] | None,
+    no_auto_profile: bool,
+) -> list[str]:
+    """
+    Resolve the profile identifier(s) to validate a single batch crate against.
+
+    Mirrors single-crate behaviour: an explicit ``--profile-identifier`` list wins
+    and is applied to every crate; otherwise the profile is auto-detected from the
+    crate itself (unless auto-detection is disabled); falling back to the base
+    ``ro-crate`` profile when nothing can be resolved.
+    """
+    if profile_identifiers:
+        return list(profile_identifiers)
+    if not no_auto_profile:
+        try:
+            crate_settings_dict = settings.to_dict() if hasattr(settings, "to_dict") else {}
+            crate_settings = ValidationSettings.parse({**crate_settings_dict, "rocrate_uri": str(crate_path)})
+            detected = detect_profiles(crate_settings)
+            if detected:
+                return [p.identifier for p in detected]
+        except Exception as e:  # pragma: no cover - detection is best-effort
+            logger.debug("Per-crate profile auto-detection failed for %s: %s", crate_path, e)
+    return ["ro-crate"]
+
+
+def _validate_one_in_batch(
+    settings: ValidationSettings,
+    session: BatchSession,
+    crate_path: str,
+    idx: int,
+    total: int,
+    progress_callback: Callable[..., None] | None,
+    profile_identifiers: list[str] | None = None,
+    no_auto_profile: bool = False,
+) -> list[tuple[str, ValidationResult]] | None:
+    """
+    Validate a single crate inside a batch, updating the session and emitting progress.
+
+    The crate is validated against each profile resolved for it (see
+    :func:`_resolve_crate_profiles`) and the per-profile outcomes are combined into
+    a single session entry (the crate passes only when it passes every profile).
+
+    Returns the list of ``(path, result)`` pairs (one per profile) on success, or
+    ``None`` if validation raised.
+    """
+    start = time.time()
+    entry = session._find_entry(str(crate_path))
+    if entry:
+        entry.status = "in_progress"
+    if progress_callback:
+        progress_callback(str(crate_path), idx + 1, total, "validating", None)
+
+    try:
+        crate_settings_dict = settings.to_dict() if hasattr(settings, "to_dict") else {}
+        profiles = _resolve_crate_profiles(settings, str(crate_path), profile_identifiers, no_auto_profile)
+        profile_results: list[tuple[str, ValidationResult]] = []
+        for profile in profiles:
+            crate_settings = ValidationSettings.parse(
+                {
+                    **crate_settings_dict,
+                    "rocrate_uri": str(crate_path),
+                    "profile_identifier": profile,
+                }
+            )
+            profile_results.append((profile, validate(crate_settings)))
+        session.add_results(str(crate_path), profile_results, time.time() - start)
+        if progress_callback:
+            passed = all(r.passed() for _, r in profile_results)
+            status = "passed" if passed else "failed"
+            total_issues = sum(len(r.issues) for _, r in profile_results)
+            # The view styles the line; pass the issue-count message and the
+            # profile(s) the crate was validated against separately.
+            progress_callback(str(crate_path), idx + 1, total, status, f"({total_issues} issues)", profiles)
+        return [(str(crate_path), r) for _, r in profile_results]
+    except Exception as e:
+        session.mark_failed(str(crate_path), str(e), time.time() - start)
+        if progress_callback:
+            progress_callback(str(crate_path), idx + 1, total, "error", str(e))
+        return None
+
+
+# Minimum interval between incremental session saves during a batch run. The
+# session is always saved once more at the end, so this only throttles the
+# intermediate (crash/interrupt-recovery) saves.
+_SESSION_SAVE_INTERVAL_SECONDS = 2.0
+
+
+def batch_validate(
+    settings: ValidationSettings,
+    rocrate_uris: list[str],
+    session_path: Path | None = None,
+    fresh: bool = False,
+    progress_callback: Callable | None = None,
+    profile_identifiers: list[str] | None = None,
+    no_auto_profile: bool = False,
+) -> BatchValidationResult:
+    """
+    Validate multiple RO-Crates in batch mode.
+
+    The batch session is always persisted incrementally to ``session_path`` and
+    auto-resumed when an interrupted session for the same target already exists
+    (unless ``fresh`` is set). The session path is managed automatically by the
+    caller (see :func:`resolve_batch_session_path`); callers do not need to
+    supply or track a session file by hand.
+
+    Profiles are resolved *per crate*: an explicit ``profile_identifiers`` list is
+    applied to every crate, otherwise each crate's profile is auto-detected
+    (unless ``no_auto_profile`` is set), matching single-crate validation.
+
+    :param settings: shared validation settings (severity, cache, availability, etc.)
+    :param rocrate_uris: list of RO-Crate paths to validate
+    :param session_path: auto-managed path where the session is saved/resumed
+    :param fresh: ignore any existing session and revalidate everything
+    :param progress_callback: optional callable(crate_path, index, total, status, message)
+    :param profile_identifiers: explicit profiles to validate every crate against
+    :param no_auto_profile: disable per-crate profile auto-detection
+    :return: aggregated batch validation result
+    """
+    session, rocrate_uris = _prepare_batch_session(settings, rocrate_uris, session_path, fresh)
+    # Persist the profile resolution options on the session so it can be resumed
+    # later (e.g. via `sessions resume`) with exactly the same criteria.
+    session.profile_identifiers = list(profile_identifiers) if profile_identifiers else None
+    session.no_auto_profile = no_auto_profile
+    session.requirement_severity_only = bool(getattr(settings, "requirement_severity_only", False))
+    results: list[tuple[str, ValidationResult]] = []
+
+    # Register SIGINT handler for graceful interruption
+    def _sigint_handler(_signum, _frame):
+        session.status = "interrupted"
+        session.save()
+        print("\n⚠  Batch interrupted. Re-run the same command to resume.", file=sys.stderr)
+        sys.exit(130)
+
+    original_handler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, _sigint_handler)
+
+    try:
+        total = len(rocrate_uris)
+        last_save = time.time()
+        for idx, crate_path in enumerate(rocrate_uris):
+            outcome = _validate_one_in_batch(
+                settings,
+                session,
+                crate_path,
+                idx,
+                total,
+                progress_callback,
+                profile_identifiers,
+                no_auto_profile,
+            )
+            if outcome is not None:
+                results.extend(outcome)
+            # Save the session incrementally for crash/interrupt recovery, but
+            # throttle it: re-serialising the whole (possibly large) session
+            # after every crate is O(n^2) and dominates the run for big batches.
+            now = time.time()
+            if now - last_save >= _SESSION_SAVE_INTERVAL_SECONDS:
+                session.save()
+                last_save = now
+    finally:
+        signal.signal(signal.SIGINT, original_handler)
+
+    # Final save (always). Announce it first so the UI can show activity, since
+    # writing a large session to disk may take a moment.
+    if progress_callback:
+        progress_callback("", total, total, "saving", None)
+    session.status = "completed" if session.is_completed() else "interrupted"
+    session.save()
+
+    return BatchValidationResult(session, results)
 
 
 def get_profiles(

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -282,15 +282,14 @@ def resolve_batch_session_path(
     different multi-profile sets) on separate sessions.
     """
     settings_dict = settings.to_dict() if hasattr(settings, "to_dict") else {}
-    if profile_identifiers:
-        profile_key = str(sorted(profile_identifiers))
-    else:
-        # No explicit profile: per-crate auto-detection, or the base-profile
-        # fallback when auto-detection is disabled.
-        profile_key = f"auto:{not no_auto_profile}"
+    # With explicit profiles the key is their sorted list; otherwise it encodes
+    # per-crate auto-detection (or the base-profile fallback when disabled).
+    profile_key = str(sorted(profile_identifiers)) if profile_identifiers else f"auto:{not no_auto_profile}"
     # `requirement_severity_only` is dropped by ``ValidationSettings.to_dict()``,
     # so read it from the settings object directly rather than from the dict.
-    severity_only = bool(getattr(settings, "requirement_severity_only", settings_dict.get("requirement_severity_only", False)))
+    severity_only = bool(
+        getattr(settings, "requirement_severity_only", settings_dict.get("requirement_severity_only", False))
+    )
     key_parts = [
         str(Path(scan_root).resolve()),
         pattern,

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -483,7 +483,6 @@ def batch_validate(
     session.profile_identifiers = list(profile_identifiers) if profile_identifiers else None
     session.no_auto_profile = no_auto_profile
     session.requirement_severity_only = bool(getattr(settings, "requirement_severity_only", False))
-    results: list[tuple[str, ValidationResult]] = []
 
     # Register SIGINT handler for graceful interruption
     def _sigint_handler(_signum, _frame):
@@ -499,7 +498,12 @@ def batch_validate(
         total = len(rocrate_uris)
         last_save = time.time()
         for idx, crate_path in enumerate(rocrate_uris):
-            outcome = _validate_one_in_batch(
+            # The returned live results are intentionally dropped: the outcome
+            # is already recorded in the session entry, and retaining every
+            # ValidationResult would pin each crate's full validation context
+            # (profiles, shape graphs, data graph), growing memory linearly
+            # with the batch size until the OOM killer steps in.
+            _validate_one_in_batch(
                 settings,
                 session,
                 crate_path,
@@ -509,8 +513,6 @@ def batch_validate(
                 profile_identifiers,
                 no_auto_profile,
             )
-            if outcome is not None:
-                results.extend(outcome)
             # Save the session incrementally for crash/interrupt recovery, but
             # throttle it: re-serialising the whole (possibly large) session
             # after every crate is O(n^2) and dominates the run for big batches.
@@ -528,7 +530,7 @@ def batch_validate(
     session.status = "completed" if session.is_completed() else "interrupted"
     session.save()
 
-    return BatchValidationResult(session, results)
+    return BatchValidationResult(session)
 
 
 def get_profiles(

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -477,7 +477,7 @@ def batch_validate(
     :param profile_identifiers: explicit profiles to validate every crate against
     :param no_auto_profile: disable per-crate profile auto-detection
     :param keep_results: retain the live :class:`ValidationResult` of every
-        crate in :attr:`BatchValidationResult.results`. Off by default because
+        crate in :attr:`BatchValidationResult.live_results`. Off by default because
         each result pins its full validation context (loaded profiles with
         their shape graphs, the crate data graph), so memory grows linearly
         with the batch size; enable it only for debugging or interactive

--- a/rocrate_validator/services.py
+++ b/rocrate_validator/services.py
@@ -454,6 +454,7 @@ def batch_validate(
     progress_callback: Callable | None = None,
     profile_identifiers: list[str] | None = None,
     no_auto_profile: bool = False,
+    keep_results: bool = False,
 ) -> BatchValidationResult:
     """
     Validate multiple RO-Crates in batch mode.
@@ -475,6 +476,12 @@ def batch_validate(
     :param progress_callback: optional callable(crate_path, index, total, status, message)
     :param profile_identifiers: explicit profiles to validate every crate against
     :param no_auto_profile: disable per-crate profile auto-detection
+    :param keep_results: retain the live :class:`ValidationResult` of every
+        crate in :attr:`BatchValidationResult.results`. Off by default because
+        each result pins its full validation context (loaded profiles with
+        their shape graphs, the crate data graph), so memory grows linearly
+        with the batch size; enable it only for debugging or interactive
+        exploration (e.g. notebooks) on batches that fit in memory
     :return: aggregated batch validation result
     """
     session, rocrate_uris = _prepare_batch_session(settings, rocrate_uris, session_path, fresh)
@@ -483,6 +490,7 @@ def batch_validate(
     session.profile_identifiers = list(profile_identifiers) if profile_identifiers else None
     session.no_auto_profile = no_auto_profile
     session.requirement_severity_only = bool(getattr(settings, "requirement_severity_only", False))
+    results: list[tuple[str, ValidationResult]] = []
 
     # Register SIGINT handler for graceful interruption
     def _sigint_handler(_signum, _frame):
@@ -498,12 +506,12 @@ def batch_validate(
         total = len(rocrate_uris)
         last_save = time.time()
         for idx, crate_path in enumerate(rocrate_uris):
-            # The returned live results are intentionally dropped: the outcome
-            # is already recorded in the session entry, and retaining every
-            # ValidationResult would pin each crate's full validation context
-            # (profiles, shape graphs, data graph), growing memory linearly
-            # with the batch size until the OOM killer steps in.
-            _validate_one_in_batch(
+            # The returned live results are dropped unless explicitly asked
+            # for: the outcome is already recorded in the session entry, and
+            # retaining every ValidationResult would pin each crate's full
+            # validation context (profiles, shape graphs, data graph), growing
+            # memory linearly with the batch size until the OOM killer steps in.
+            outcome = _validate_one_in_batch(
                 settings,
                 session,
                 crate_path,
@@ -513,6 +521,8 @@ def batch_validate(
                 profile_identifiers,
                 no_auto_profile,
             )
+            if keep_results and outcome is not None:
+                results.extend(outcome)
             # Save the session incrementally for crash/interrupt recovery, but
             # throttle it: re-serialising the whole (possibly large) session
             # after every crate is O(n^2) and dominates the run for big batches.
@@ -530,7 +540,7 @@ def batch_validate(
     session.status = "completed" if session.is_completed() else "interrupted"
     session.save()
 
-    return BatchValidationResult(session)
+    return BatchValidationResult(session, results)
 
 
 def get_profiles(

--- a/rocrate_validator/utils/io_helpers/input.py
+++ b/rocrate_validator/utils/io_helpers/input.py
@@ -93,6 +93,30 @@ def get_single_char(
     return __get_single_char_unix__(console, end, message, choices)
 
 
+def single_choice(console: Console, message: str, choices: list[tuple[object, str]]):
+    """
+    Display a single-choice list menu.
+
+    ``choices`` is a list of ``(value, label)`` pairs; the selected ``value`` is
+    returned (or ``None`` if nothing is selected).
+    """
+    question = [
+        {
+            "type": "list",
+            "name": "choice",
+            "message": message,
+            "choices": [Choice(value, label) for value, label in choices],
+        }
+    ]
+    console.print("\n")
+    answer = prompt(
+        question,
+        style={"questionmark": "#ff9d00 bold", "question": "bold", "answer": "magenta", "pointer": "magenta"},
+        style_override=False,
+    )
+    return answer.get("choice")
+
+
 def multiple_choice(console: Console, choices: list[Profile]):
     """
     Display a multiple choice menu

--- a/rocrate_validator/utils/io_helpers/output/json/__init__.py
+++ b/rocrate_validator/utils/io_helpers/output/json/__init__.py
@@ -14,10 +14,15 @@
 
 from typing import Any
 
-from rocrate_validator.models import ValidationResult, ValidationStatistics
+from rocrate_validator.models import (
+    BatchValidationResult,
+    ValidationResult,
+    ValidationStatistics,
+)
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.io_helpers.output import BaseOutputFormatter
 from rocrate_validator.utils.io_helpers.output.json.formatters import (
+    BatchValidationResultJSONOutputFormatter,
     ValidationResultJSONOutputFormatter,
     ValidationResultsJSONOutputFormatter,
     ValidationStatisticsJSONOutputFormatter,
@@ -33,3 +38,4 @@ class JSONOutputFormatter(BaseOutputFormatter):
         self.add_type_formatter(ValidationResult, ValidationResultJSONOutputFormatter)
         self.add_type_formatter(dict, ValidationResultsJSONOutputFormatter)
         self.add_type_formatter(ValidationStatistics, ValidationStatisticsJSONOutputFormatter)
+        self.add_type_formatter(BatchValidationResult, BatchValidationResultJSONOutputFormatter)

--- a/rocrate_validator/utils/io_helpers/output/json/formatters.py
+++ b/rocrate_validator/utils/io_helpers/output/json/formatters.py
@@ -19,6 +19,7 @@ from rich.console import ConsoleOptions, RenderResult
 
 from rocrate_validator.models import (
     AggregatedValidationStatistics,
+    BatchValidationResult,
     CustomEncoder,
     ValidationResult,
     ValidationStatistics,
@@ -149,3 +150,27 @@ class ValidationResultsJSONOutputFormatter(OutputFormatter):
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
         yield format_validation_results(self._results, console=console, console_options=options)
+
+
+def format_batch_validation_result(
+    data: BatchValidationResult,
+    console: Console | None = None,  # pylint: disable=unused-argument
+    console_options: ConsoleOptions | None = None,  # pylint: disable=unused-argument
+) -> str:
+    """
+    Format a BatchValidationResult as a JSON string.
+    """
+    json_output = data.to_dict()
+    json_output["meta"] = {
+        "generated_by": "rocrate-validator",
+        "version": get_version(),
+    }
+    return json.dumps(json_output, indent=4, cls=CustomEncoder)
+
+
+class BatchValidationResultJSONOutputFormatter(OutputFormatter):
+    def __init__(self, result: BatchValidationResult):
+        self._result = result
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        yield format_batch_validation_result(self._result, console=console, console_options=options)

--- a/rocrate_validator/utils/io_helpers/output/text/statistics.py
+++ b/rocrate_validator/utils/io_helpers/output/text/statistics.py
@@ -1,0 +1,675 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Textual statistics for a batch validation run.
+
+This is a port of the ``analyze`` command of the standalone ``report.py`` utility,
+adapted to integrate with the validator: it works on the in-memory batch crate
+records (``BatchCrateEntry.to_dict()`` output, the same shape stored in a session
+file) and renders to a provided :class:`rich.console.Console`. The chart
+generation of the original script is intentionally not included.
+
+Each crate is classified into one of three mutually exclusive states:
+
+* ``PASSED`` — validation succeeded (``passed`` is true);
+* ``FAILED`` — validation ran and reported one or more issues;
+* ``ERROR``  — validation could not run (e.g. a non-RO-Crate input): the crate
+  carries an ``error`` message but no issues and no statistics.
+"""
+
+from __future__ import annotations
+
+import statistics as _stats
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich import box
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+# ===========================================================================
+# Normalisation and aggregation
+# ===========================================================================
+
+def _error_types(issues: list[dict]) -> list[tuple[str, str]]:
+    """Distinct ``(check identifier, check name)`` pairs, first-seen order."""
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for issue in issues:
+        chk = issue.get("check") or {}
+        cid = chk.get("identifier")
+        if cid and cid not in seen:
+            seen.add(cid)
+            out.append((cid, (chk.get("name") or "").strip()))
+    return out
+
+
+def normalise_crate(crate: dict) -> dict:
+    """
+    Turn one raw batch crate record (``BatchCrateEntry.to_dict()`` shape) into
+    the flat record used by the statistics renderers.
+    """
+    stats = crate.get("statistics") or {}
+    issues = crate.get("issues") or []
+    passed = bool(crate.get("passed"))
+
+    if passed:
+        status = "PASSED"
+    elif issues:
+        status = "FAILED"
+    else:
+        status = "ERROR"
+
+    return {
+        "path": crate["path"],
+        "name": Path(crate["path"]).name,
+        "size_bytes": crate.get("size_bytes"),
+        "duration": crate.get("duration"),
+        "passed": passed,
+        "status": status,
+        "error": crate.get("error"),
+        "checks": stats.get("total_checks", 0),
+        "passed_checks": stats.get("total_passed_checks", 0),
+        "issues": issues,
+        "n_issues": len(issues),
+        # Individual REQUIRED issue lines (the legacy "└─ Required" count).
+        "subissues": sum(1 for i in issues if i.get("severity") == "REQUIRED"),
+        "error_types": _error_types(issues),
+    }
+
+
+def select(crates: list[dict], include_errors: bool = True) -> list[dict]:
+    """Optionally drop the *errored* crates (the spurious, non-RO-Crate inputs)."""
+    if include_errors:
+        return crates
+    return [c for c in crates if c["status"] != "ERROR"]
+
+
+def passed_crates(crates: list[dict]) -> list[dict]:
+    return [c for c in crates if c["status"] == "PASSED"]
+
+
+def failed_crates(crates: list[dict]) -> list[dict]:
+    """Crates that ran validation and reported at least one issue."""
+    return [c for c in crates if c["status"] == "FAILED"]
+
+
+def errored_crates(crates: list[dict]) -> list[dict]:
+    return [c for c in crates if c["status"] == "ERROR"]
+
+
+def crates_per_check(failed: list[dict]) -> tuple[Counter, dict[str, str]]:
+    """Number of distinct FAILED crates affected by each check identifier."""
+    counter: Counter[str] = Counter()
+    names: dict[str, str] = {}
+    for crate in failed:
+        for code, name in crate["error_types"]:
+            counter[code] += 1
+            names[code] = name
+    return counter, names
+
+
+# ===========================================================================
+# Rich rendering helpers
+# ===========================================================================
+
+# Semantic colour palette, shared across all statistics tables/bars so the same
+# kind of datum always reads with the same colour:
+_C_CRATES = "cyan"        # a neutral count of crates
+_C_CHECKS = "blue"        # total checks
+_C_PASSED = "green"       # passed checks / passed crates
+_C_ISSUES = "red"         # issues / REQUIRED issues / failed-or-affected crates
+_C_ERROR = "yellow"       # crates that errored out
+_C_DURATION = "yellow"    # validation time
+_C_TYPE = "magenta"       # check / issue-type identifiers
+_C_CRATE_ID = "bold cyan"  # crate names / ids
+_C_PERCENT = "dim"        # percentages / shares
+
+
+def _rtable(title: str = "") -> Table:
+    return Table(
+        title=title, title_style="bold", title_justify="left",
+        box=box.SIMPLE_HEAVY, header_style="bold",
+    )
+
+
+# All sub-section panel titles share one bold accent colour.
+_TITLE_STYLE = "bold yellow"
+
+
+def _spanel(title: str, description: str, *renderables, title_style: str = _TITLE_STYLE) -> Panel:
+    """
+    Wrap renderables in a Rich Panel with a bold, coloured title and a brief white
+    italic description.
+    """
+    desc = Text(description, style="white italic")
+    return Panel(
+        Group(desc, *renderables),
+        title=Text(title, style=title_style),
+        title_align="left",
+        padding=(1, 2),
+    )
+
+
+def _bar(value: float, maxv: float, width: int = 18, color: str = "cyan") -> str:
+    """A small horizontal bar made of block characters (for visual scale)."""
+    filled = int(round(width * value / maxv)) if maxv else 0
+    return f"[{color}]{'█' * filled}[/][dim]{'·' * (width - filled)}[/]"
+
+
+def _describe_lines(
+    values: list[float],
+    *,
+    value_style: str,
+    unit: str = "",
+    count_style: str = _C_CRATES,
+) -> list[Text]:
+    """
+    Build the three ``Range`` / ``Central`` / ``Spread`` descriptive-statistics
+    lines for a numeric series, used by both the issue-count and duration
+    sections so they share one consistent presentation.
+
+    ``value_style`` colours the metric values; ``unit`` is appended to each value
+    (e.g. ``"s"`` for durations); ``count_style`` colours the sample size ``n``.
+    """
+    n = len(values)
+    ordered = sorted(values)
+    total = sum(values)
+    mean_val = _stats.mean(values)
+    median_val = _stats.median(values)
+    if n >= 4:
+        q1_val, _, q3_val = _stats.quantiles(values, n=4)
+    else:
+        q1_val, q3_val = ordered[0], ordered[-1]
+    iqr_val = q3_val - q1_val
+    std_val = _stats.stdev(values) if n >= 2 else 0.0
+    var_val = _stats.variance(values) if n >= 2 else 0.0
+
+    def r(x: float) -> str:  # range values: integer when whole, else 2 decimals
+        body = f"{int(x)}" if float(x).is_integer() else f"{x:.2f}"
+        return f"[bold {value_style}]{body}{unit}[/]"
+
+    def f(x: float) -> str:  # central/spread values: always 2 decimals
+        return f"[bold {value_style}]{x:.2f}{unit}[/]"
+
+    return [
+        Text.from_markup(
+            f"[bold orange3]Range[/]   →   total={r(total)}   "
+            f"n=[bold {count_style}]{n}[/]   min={r(ordered[0])}   max={r(ordered[-1])}"
+        ),
+        Text.from_markup(
+            f"[bold orange3]Central[/] →   mean={f(mean_val)}   median={f(median_val)}   "
+            f"Q1={f(q1_val)}   Q3={f(q3_val)}"
+        ),
+        Text.from_markup(
+            f"[bold orange3]Spread[/]  →   stddev={f(std_val)}   variance={f(var_val)}   IQR={f(iqr_val)}"
+        ),
+    ]
+
+
+def _print_summary_table(con: Console, crates: list[dict]) -> None:
+    """Print a compact, coloured PASSED/FAILED/ERROR summary."""
+    total = len(crates)
+    rows = [
+        ("PASSED", len(passed_crates(crates)), "green"),
+        ("FAILED", len(failed_crates(crates)), "red"),
+        ("ERROR", len(errored_crates(crates)), "yellow"),
+    ]
+    table = _rtable()
+    table.add_column("Status")
+    table.add_column("Crates", justify="right")
+    table.add_column("Share", justify="right")
+    table.add_column("", justify="left")
+    for label, n, color in rows:
+        pct = 100 * n / total if total else 0
+        table.add_row(f"[{color}]{label}[/]", f"[{color}]{n}[/]", f"{pct:.1f}%", _bar(n, total, color=color))
+    table.add_section()
+    table.add_row("[bold]TOTAL[/]", f"[bold]{total}[/]", "100.0%", "")
+    con.print(_spanel("Outcome Summary", "Overall outcome across all analysed crates", table))
+
+
+def _render_overview(con: Console, crates, failed, errored) -> None:
+    if failed:
+        issues = [c["n_issues"] for c in failed]
+        t = _rtable()
+        t.add_column("Issues/crate", justify="right")
+        t.add_column("Crates", justify="right")
+        t.add_column("")
+        dist = Counter(issues)
+        maxv = max(dist.values())
+        for k, v in sorted(dist.items()):
+            t.add_row(f"[{_C_ISSUES}]{k}[/]", f"[{_C_CRATES}]{v}[/]", _bar(v, maxv, color=_C_CRATES))
+        con.print(_spanel(
+            "Issues Per Crate (Failed)",
+            "Distribution of issue counts among crates that did not pass validation",
+            t,
+            Text(""),
+            *_describe_lines(issues, value_style=_C_ISSUES),
+        ))
+
+    combos = Counter((c["checks"], c["passed_checks"]) for c in crates)
+    t = _rtable()
+    t.add_column("Crates", justify="right")
+    t.add_column("Checks", justify="right")
+    t.add_column("Passed", justify="right")
+    for (chk, ps), v in combos.most_common():
+        t.add_row(f"[bold {_C_CRATES}]{v}[/]", f"[bold {_C_CHECKS}]{chk}[/]", f"[bold {_C_PASSED}]{ps}[/]")
+    con.print(_spanel(
+        "Checks/Passed Combinations",
+        "Number of crates sharing the same total checks and passed checks",
+        t,
+    ))
+
+    if errored:
+        t = _rtable()
+        t.add_column("Crates", justify="right")
+        t.add_column("Reason", style="yellow")
+        for reason, v in Counter(c["error"] for c in errored).most_common():
+            t.add_row(f"[bold {_C_ERROR}]{v}[/]", reason or "(no message)")
+        con.print(_spanel(
+            "Validation Errors",
+            "Crates that encountered errors during validation and produced no results",
+            t,
+        ))
+
+
+def _render_error_types(con: Console, failed) -> None:
+    counter, names = crates_per_check(failed)
+    total = len(failed)
+    maxv = max(counter.values()) if counter else 1
+    t = _rtable()
+    t.add_column("Check", style=_C_TYPE, no_wrap=True)
+    t.add_column("Crates", justify="right")
+    t.add_column("Share", justify="right")
+    t.add_column("")
+    t.add_column("Description")
+    for code, cnt in counter.most_common():
+        pct = 100 * cnt / total if total else 0
+        t.add_row(code, f"[bold {_C_ISSUES}]{cnt}[/]", f"[{_C_PERCENT}]{pct:.1f}%[/]", _bar(cnt, maxv, color=_C_ISSUES), names[code])
+    single = sum(1 for c in failed if len(c["error_types"]) == 1)
+    multi = sum(1 for c in failed if len(c["error_types"]) > 1)
+    con.print(_spanel(
+        "Error-Type Distribution",
+        "How many crates are affected by each type of validation error",
+        t,
+        Text(""),
+        Text.from_markup(
+            f"Crates with exactly 1 error type: [bold {_C_CRATES}]{single}[/]   "
+            f"more than one: [bold {_C_CRATES}]{multi}[/]"
+        ),
+    ))
+
+
+def _render_issue_attribution(con: Console, failed) -> None:
+    single_attrib: Counter[str] = Counter()
+    multi_crates: list[dict] = []
+    total_subs = 0
+    for crate in failed:
+        total_subs += crate["subissues"]
+        if len(crate["error_types"]) == 1:
+            single_attrib[crate["error_types"][0][0]] += crate["subissues"]
+        elif len(crate["error_types"]) > 1:
+            multi_crates.append(crate)
+
+    renderables: list = [
+        Text.from_markup(f"Total REQUIRED issues: [bold {_C_ISSUES}]{total_subs}[/]"),
+    ]
+
+    if single_attrib:
+        maxv = max(single_attrib.values())
+        t = _rtable()
+        t.add_column("Check", style=_C_TYPE, no_wrap=True)
+        t.add_column("REQUIRED Issues", justify="right")
+        t.add_column("")
+        for code, cnt in sorted(single_attrib.items(), key=lambda x: -x[1]):
+            t.add_row(code, f"[bold {_C_ISSUES}]{cnt}[/]", _bar(cnt, maxv, color=_C_ISSUES))
+        renderables.append(Text(""))
+        renderables.append(t)
+
+    if multi_crates:
+        t = _rtable()
+        t.add_column("Crate", style=_C_CRATE_ID, no_wrap=True)
+        t.add_column("REQUIRED Issues", justify="right")
+        t.add_column("Types", style=_C_TYPE)
+        for c in multi_crates:
+            types = ", ".join(code for code, _ in c["error_types"])
+            t.add_row(c["name"], f"[bold {_C_ISSUES}]{c['subissues']}[/]", types)
+        renderables.append(Text(""))
+        renderables.append(t)
+
+    con.print(_spanel(
+        "Issue Attribution",
+        "Detailed breakdown of REQUIRED issues by check type",
+        *renderables,
+    ))
+
+
+def _render_durations(con: Console, failed, top_n: int) -> None:
+    durations = [(c["duration"], c) for c in failed if c.get("duration") is not None]
+    if not durations:
+        return
+    vals = [d for d, _ in durations]
+    t = _rtable()
+    t.add_column("Crate", style=_C_CRATE_ID, no_wrap=True)
+    t.add_column("Duration", justify="right")
+    t.add_column("REQUIRED Issues", justify="right")
+    for dur, c in sorted(durations, key=lambda x: -x[0])[:top_n]:
+        t.add_row(c["name"], f"[bold {_C_DURATION}]{dur:.2f}s[/]", f"[bold {_C_ISSUES}]{c['subissues']}[/]")
+    con.print(_spanel(
+        "Slowest Crates",
+        f"Top {top_n} crates with the longest validation durations",
+        t,
+        Text(""),
+        *_describe_lines(vals, value_style=_C_DURATION, unit="s"),
+    ))
+
+
+def _render_outliers(con: Console, failed, threshold: int) -> None:
+    outliers = sorted(
+        [c for c in failed if c["subissues"] >= threshold],
+        key=lambda x: -x["subissues"],
+    )
+    if not outliers:
+        con.print(_spanel(
+            f"Outlier Crates (≥ {threshold} REQUIRED issues)",
+            "Crates with an unusually high number of REQUIRED issues",
+            Text.from_markup(f"[dim]No outlier crates with ≥ {threshold} REQUIRED issues.[/]"),
+        ))
+        return
+    t = _rtable()
+    t.add_column("Crate", style=_C_CRATE_ID, no_wrap=True)
+    t.add_column("REQUIRED Issues", justify="right")
+    t.add_column("Types", style=_C_TYPE)
+    for c in outliers:
+        types = ", ".join(code for code, _ in c["error_types"])
+        t.add_row(c["name"], f"[bold {_C_ISSUES}]{c['subissues']}[/]", types)
+    con.print(_spanel(
+        f"Outlier Crates (≥ {threshold} REQUIRED issues)",
+        "Crates with an unusually high number of REQUIRED issues",
+        t,
+    ))
+
+
+def _render_detailed(con: Console, crates, failed, errored, top_n: int, outlier_threshold: int) -> None:
+    _render_overview(con, crates, failed, errored)
+    if failed:
+        con.print()
+        _render_error_types(con, failed)
+        con.print()
+        _render_issue_attribution(con, failed)
+        con.print()
+        _render_durations(con, failed, top_n)
+        con.print()
+        _render_outliers(con, failed, outlier_threshold)
+
+
+# ===========================================================================
+# Public entry point
+# ===========================================================================
+
+def render_statistics(
+    console: Console,
+    crate_dicts: list[dict],
+    *,
+    include_errors: bool = True,
+    top_n: int = 10,
+    outlier_threshold: int = 5,
+) -> None:
+    """
+    Render the textual batch statistics for ``crate_dicts`` to ``console``.
+
+    :param console: target console (the validator's Rich console)
+    :param crate_dicts: raw crate records (``BatchCrateEntry.to_dict()`` shape)
+    :param include_errors: include the crates that could not be validated at all
+    :param top_n: how many of the slowest crates to list
+    :param outlier_threshold: minimum individual issues for a crate to be an outlier
+    """
+    all_crates = [normalise_crate(c) for c in crate_dicts]
+    crates = select(all_crates, include_errors=include_errors)
+    failed = failed_crates(crates)
+    errored = errored_crates(crates)
+
+    # Separate the statistics section from whatever was printed before it.
+    console.print()
+    console.print()
+    console.rule("[bold cyan]Statistics[/]")
+    analysed = f"Crates analysed: [bold cyan]{len(crates)}[/]"
+    if errored:
+        analysed += (
+            f"   [dim]·[/dim]   [bold red]{len(errored)}[/] could not be validated [dim](ERROR)[/dim]"
+        )
+    console.print(analysed)
+    console.print()
+    _print_summary_table(console, crates)
+    console.print()
+    _render_detailed(console, crates, failed, errored, top_n, outlier_threshold)
+
+
+# ===========================================================================
+# Markdown file output
+# ===========================================================================
+
+def _md_table(headers: list[str], rows: list[list[str]], align_left: list[int] | None = None) -> str:
+    """Build a GF markdown table from headers and row data."""
+    out: list[str] = []
+    out.append("| " + " | ".join(headers) + " |")
+    separators: list[str] = []
+    for i, h in enumerate(headers):
+        if align_left and i in align_left:
+            separators.append(":" + "-" * (len(h) + 0))
+        else:
+            separators.append("-" * (len(h) + 0))
+    out.append("| " + " | ".join(separators) + " |")
+    for row in rows:
+        out.append("| " + " | ".join(str(c) for c in row) + " |")
+    return "\n".join(out) + "\n"
+
+
+def _md_describe_lines(values: list[float], *, unit: str = "") -> str:
+    """Descriptive stats lines in markdown format."""
+    n = len(values)
+    ordered = sorted(values)
+    total = sum(values)
+    mean_val = _stats.mean(values)
+    median_val = _stats.median(values)
+    if n >= 4:
+        q1_val, _, q3_val = _stats.quantiles(values, n=4)
+    else:
+        q1_val, q3_val = ordered[0], ordered[-1]
+    iqr_val = q3_val - q1_val
+    std_val = _stats.stdev(values) if n >= 2 else 0.0
+    var_val = _stats.variance(values) if n >= 2 else 0.0
+
+    def r(x: float) -> str:
+        return f"{int(x)}" if float(x).is_integer() else f"{x:.2f}"
+
+    def f(x: float) -> str:
+        return f"{x:.2f}"
+
+    lines: list[str] = []
+    lines.append(f"- **Range**   →   total={r(total)}{unit}   n={n}   "
+                  f"min={r(ordered[0])}{unit}   max={r(ordered[-1])}{unit}")
+    lines.append(f"- **Central** →   mean={f(mean_val)}{unit}   median={f(median_val)}{unit}   "
+                  f"Q1={f(q1_val)}{unit}   Q3={f(q3_val)}{unit}")
+    lines.append(f"- **Spread**  →   stddev={f(std_val)}{unit}   variance={f(var_val)}{unit}   "
+                  f"IQR={f(iqr_val)}{unit}")
+    return "\n".join(lines) + "\n"
+
+
+def render_statistics_md(
+    file,
+    crate_dicts: list[dict],
+    *,
+    include_errors: bool = True,
+    top_n: int = 10,
+    outlier_threshold: int = 5,
+) -> None:
+    """Write batch statistics to *file* in markdown format."""
+    all_crates = [normalise_crate(c) for c in crate_dicts]
+    crates = select(all_crates, include_errors=include_errors)
+    failed = failed_crates(crates)
+    errored = errored_crates(crates)
+
+    w = file.write
+
+    w("# Validation Statistics\n\n")
+    _md_write_summary_line(w, crates, errored)
+    _md_write_outcome_summary(w, crates, failed, errored)
+    _md_write_issues_per_crate(w, failed)
+    _md_write_checks_combos(w, crates)
+    _md_write_validation_errors(w, errored)
+    _md_write_error_types(w, failed)
+    _md_write_issue_attribution(w, failed)
+    _md_write_slowest(w, failed, top_n)
+    _md_write_outliers(w, failed, outlier_threshold)
+
+
+def _md_write_summary_line(w, crates, errored) -> None:
+    analysed = f"Crates analysed: **{len(crates)}**"
+    if errored:
+        analysed += f" · **{len(errored)}** could not be validated (ERROR)"
+    w(analysed + "\n\n")
+
+
+def _md_write_outcome_summary(w, crates, failed, errored) -> None:
+    w("## Outcome Summary\n\n")
+    total = len(crates)
+    rows: list[list[str]] = []
+    for label, n in [("PASSED", len(passed_crates(crates))),
+                      ("FAILED", len(failed)),
+                      ("ERROR", len(errored))]:
+        pct = 100 * n / total if total else 0
+        rows.append([label, str(n), f"{pct:.1f}%"])
+    rows.append(["**TOTAL**", f"**{total}**", "**100.0%**"])
+    w(_md_table(["Status", "Crates", "Share"], rows, align_left=[0]))
+    w("\n")
+
+
+def _md_write_issues_per_crate(w, failed) -> None:
+    if not failed:
+        return
+    issues = [c["n_issues"] for c in failed]
+    w("## Issues Per Crate (Failed)\n\n")
+    dist = Counter(issues)
+    rows = [[str(k), str(v)] for k, v in sorted(dist.items())]
+    w(_md_table(["Issues/crate", "Crates"], rows))
+    w("\n")
+    w(_md_describe_lines(issues))
+    w("\n")
+
+
+def _md_write_checks_combos(w, crates) -> None:
+    w("## Checks/Passed Combinations\n\n")
+    combos = Counter((c["checks"], c["passed_checks"]) for c in crates)
+    rows = [[str(v), str(chk), str(ps)] for (chk, ps), v in combos.most_common()]
+    w(_md_table(["Crates", "Checks", "Passed"], rows))
+    w("\n")
+
+
+def _md_write_validation_errors(w, errored) -> None:
+    if not errored:
+        return
+    w("## Validation Errors\n\n")
+    rows = []
+    for reason, v in Counter(c["error"] for c in errored).most_common():
+        rows.append([str(v), reason or "(no message)"])
+    w(_md_table(["Crates", "Reason"], rows, align_left=[1]))
+    w("\n")
+
+
+def _md_write_error_types(w, failed) -> None:
+    if not failed:
+        return
+    w("## Error-Type Distribution\n\n")
+    counter, names = crates_per_check(failed)
+    total_f = len(failed)
+    rows = []
+    for code, cnt in counter.most_common():
+        pct = 100 * cnt / total_f if total_f else 0
+        rows.append([code, str(cnt), f"{pct:.1f}%", names[code]])
+    w(_md_table(["Check", "Crates", "Share", "Description"], rows, align_left=[0, 3]))
+    single = sum(1 for c in failed if len(c["error_types"]) == 1)
+    multi = sum(1 for c in failed if len(c["error_types"]) > 1)
+    w(f"\nCrates with exactly 1 error type: **{single}**  "
+      f"more than one: **{multi}**\n\n")
+
+
+def _md_write_issue_attribution(w, failed) -> None:
+    if not failed:
+        return
+    w("## Issue Attribution\n\n")
+    single_attrib: Counter[str] = Counter()
+    multi_crates: list[dict] = []
+    total_subs = 0
+    for crate in failed:
+        total_subs += crate["subissues"]
+        if len(crate["error_types"]) == 1:
+            single_attrib[crate["error_types"][0][0]] += crate["subissues"]
+        elif len(crate["error_types"]) > 1:
+            multi_crates.append(crate)
+    w(f"Total REQUIRED issues: **{total_subs}**\n\n")
+    if single_attrib:
+        rows = [[code, str(cnt)] for code, cnt in
+                sorted(single_attrib.items(), key=lambda x: -x[1])]
+        w(_md_table(["Check", "REQUIRED Issues"], rows, align_left=[0]))
+        w("\n")
+    if multi_crates:
+        rows = [[c["name"], str(c["subissues"]),
+                 ", ".join(code for code, _ in c["error_types"])]
+                for c in multi_crates]
+        w(_md_table(["Crate", "REQUIRED Issues", "Types"], rows, align_left=[0, 2]))
+        w("\n")
+
+
+def _md_write_slowest(w, failed, top_n) -> None:
+    if not failed:
+        return
+    durations = [(c["duration"], c) for c in failed if c.get("duration") is not None]
+    if not durations:
+        return
+    w("## Slowest Crates\n\n")
+    vals = [d for d, _ in durations]
+    rows = []
+    for dur, c in sorted(durations, key=lambda x: -x[0])[:top_n]:
+        rows.append([c["name"], f"{dur:.2f}s", str(c["subissues"])])
+    w(_md_table(["Crate", "Duration", "REQUIRED Issues"], rows, align_left=[0]))
+    w("\n")
+    w(_md_describe_lines(vals, unit="s"))
+    w("\n")
+
+
+def _md_write_outliers(w, failed, outlier_threshold) -> None:
+    if not failed:
+        return
+    outliers = sorted(
+        [c for c in failed if c["subissues"] >= outlier_threshold],
+        key=lambda x: -x["subissues"],
+    )
+    w(f"## Outlier Crates (≥ {outlier_threshold} REQUIRED issues)\n\n")
+    if not outliers:
+        w(f"No outlier crates with ≥ {outlier_threshold} REQUIRED issues.\n\n")
+    else:
+        rows = [[c["name"], str(c["subissues"]),
+                 ", ".join(code for code, _ in c["error_types"])]
+                for c in outliers]
+        w(_md_table(["Crate", "REQUIRED Issues", "Types"], rows, align_left=[0, 2]))
+        w("\n")

--- a/rocrate_validator/utils/io_helpers/output/text/statistics.py
+++ b/rocrate_validator/utils/io_helpers/output/text/statistics.py
@@ -46,9 +46,16 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 
+# Minimum sample sizes for descriptive statistics: quartiles need at least four
+# data points, spread measures (stdev/variance) at least two.
+_MIN_SAMPLES_FOR_QUARTILES = 4
+_MIN_SAMPLES_FOR_SPREAD = 2
+
+
 # ===========================================================================
 # Normalisation and aggregation
 # ===========================================================================
+
 
 def _error_types(issues: list[dict]) -> list[tuple[str, str]]:
     """Distinct ``(check identifier, check name)`` pairs, first-seen order."""
@@ -134,21 +141,24 @@ def crates_per_check(failed: list[dict]) -> tuple[Counter, dict[str, str]]:
 
 # Semantic colour palette, shared across all statistics tables/bars so the same
 # kind of datum always reads with the same colour:
-_C_CRATES = "cyan"        # a neutral count of crates
-_C_CHECKS = "blue"        # total checks
-_C_PASSED = "green"       # passed checks / passed crates
-_C_ISSUES = "red"         # issues / REQUIRED issues / failed-or-affected crates
-_C_ERROR = "yellow"       # crates that errored out
-_C_DURATION = "yellow"    # validation time
-_C_TYPE = "magenta"       # check / issue-type identifiers
+_C_CRATES = "cyan"  # a neutral count of crates
+_C_CHECKS = "blue"  # total checks
+_C_PASSED = "green"  # passed checks / passed crates
+_C_ISSUES = "red"  # issues / REQUIRED issues / failed-or-affected crates
+_C_ERROR = "yellow"  # crates that errored out
+_C_DURATION = "yellow"  # validation time
+_C_TYPE = "magenta"  # check / issue-type identifiers
 _C_CRATE_ID = "bold cyan"  # crate names / ids
-_C_PERCENT = "dim"        # percentages / shares
+_C_PERCENT = "dim"  # percentages / shares
 
 
 def _rtable(title: str = "") -> Table:
     return Table(
-        title=title, title_style="bold", title_justify="left",
-        box=box.SIMPLE_HEAVY, header_style="bold",
+        title=title,
+        title_style="bold",
+        title_justify="left",
+        box=box.SIMPLE_HEAVY,
+        header_style="bold",
     )
 
 
@@ -172,7 +182,7 @@ def _spanel(title: str, description: str, *renderables, title_style: str = _TITL
 
 def _bar(value: float, maxv: float, width: int = 18, color: str = "cyan") -> str:
     """A small horizontal bar made of block characters (for visual scale)."""
-    filled = int(round(width * value / maxv)) if maxv else 0
+    filled = round(width * value / maxv) if maxv else 0
     return f"[{color}]{'█' * filled}[/][dim]{'·' * (width - filled)}[/]"
 
 
@@ -196,13 +206,13 @@ def _describe_lines(
     total = sum(values)
     mean_val = _stats.mean(values)
     median_val = _stats.median(values)
-    if n >= 4:
+    if n >= _MIN_SAMPLES_FOR_QUARTILES:
         q1_val, _, q3_val = _stats.quantiles(values, n=4)
     else:
         q1_val, q3_val = ordered[0], ordered[-1]
     iqr_val = q3_val - q1_val
-    std_val = _stats.stdev(values) if n >= 2 else 0.0
-    var_val = _stats.variance(values) if n >= 2 else 0.0
+    std_val = _stats.stdev(values) if n >= _MIN_SAMPLES_FOR_SPREAD else 0.0
+    var_val = _stats.variance(values) if n >= _MIN_SAMPLES_FOR_SPREAD else 0.0
 
     def r(x: float) -> str:  # range values: integer when whole, else 2 decimals
         body = f"{int(x)}" if float(x).is_integer() else f"{x:.2f}"
@@ -258,13 +268,15 @@ def _render_overview(con: Console, crates, failed, errored) -> None:
         maxv = max(dist.values())
         for k, v in sorted(dist.items()):
             t.add_row(f"[{_C_ISSUES}]{k}[/]", f"[{_C_CRATES}]{v}[/]", _bar(v, maxv, color=_C_CRATES))
-        con.print(_spanel(
-            "Issues Per Crate (Failed)",
-            "Distribution of issue counts among crates that did not pass validation",
-            t,
-            Text(""),
-            *_describe_lines(issues, value_style=_C_ISSUES),
-        ))
+        con.print(
+            _spanel(
+                "Issues Per Crate (Failed)",
+                "Distribution of issue counts among crates that did not pass validation",
+                t,
+                Text(""),
+                *_describe_lines(issues, value_style=_C_ISSUES),
+            )
+        )
 
     combos = Counter((c["checks"], c["passed_checks"]) for c in crates)
     t = _rtable()
@@ -273,11 +285,13 @@ def _render_overview(con: Console, crates, failed, errored) -> None:
     t.add_column("Passed", justify="right")
     for (chk, ps), v in combos.most_common():
         t.add_row(f"[bold {_C_CRATES}]{v}[/]", f"[bold {_C_CHECKS}]{chk}[/]", f"[bold {_C_PASSED}]{ps}[/]")
-    con.print(_spanel(
-        "Checks/Passed Combinations",
-        "Number of crates sharing the same total checks and passed checks",
-        t,
-    ))
+    con.print(
+        _spanel(
+            "Checks/Passed Combinations",
+            "Number of crates sharing the same total checks and passed checks",
+            t,
+        )
+    )
 
     if errored:
         t = _rtable()
@@ -285,11 +299,13 @@ def _render_overview(con: Console, crates, failed, errored) -> None:
         t.add_column("Reason", style="yellow")
         for reason, v in Counter(c["error"] for c in errored).most_common():
             t.add_row(f"[bold {_C_ERROR}]{v}[/]", reason or "(no message)")
-        con.print(_spanel(
-            "Validation Errors",
-            "Crates that encountered errors during validation and produced no results",
-            t,
-        ))
+        con.print(
+            _spanel(
+                "Validation Errors",
+                "Crates that encountered errors during validation and produced no results",
+                t,
+            )
+        )
 
 
 def _render_error_types(con: Console, failed) -> None:
@@ -304,19 +320,27 @@ def _render_error_types(con: Console, failed) -> None:
     t.add_column("Description")
     for code, cnt in counter.most_common():
         pct = 100 * cnt / total if total else 0
-        t.add_row(code, f"[bold {_C_ISSUES}]{cnt}[/]", f"[{_C_PERCENT}]{pct:.1f}%[/]", _bar(cnt, maxv, color=_C_ISSUES), names[code])
+        t.add_row(
+            code,
+            f"[bold {_C_ISSUES}]{cnt}[/]",
+            f"[{_C_PERCENT}]{pct:.1f}%[/]",
+            _bar(cnt, maxv, color=_C_ISSUES),
+            names[code],
+        )
     single = sum(1 for c in failed if len(c["error_types"]) == 1)
     multi = sum(1 for c in failed if len(c["error_types"]) > 1)
-    con.print(_spanel(
-        "Error-Type Distribution",
-        "How many crates are affected by each type of validation error",
-        t,
-        Text(""),
-        Text.from_markup(
-            f"Crates with exactly 1 error type: [bold {_C_CRATES}]{single}[/]   "
-            f"more than one: [bold {_C_CRATES}]{multi}[/]"
-        ),
-    ))
+    con.print(
+        _spanel(
+            "Error-Type Distribution",
+            "How many crates are affected by each type of validation error",
+            t,
+            Text(""),
+            Text.from_markup(
+                f"Crates with exactly 1 error type: [bold {_C_CRATES}]{single}[/]   "
+                f"more than one: [bold {_C_CRATES}]{multi}[/]"
+            ),
+        )
+    )
 
 
 def _render_issue_attribution(con: Console, failed) -> None:
@@ -356,11 +380,13 @@ def _render_issue_attribution(con: Console, failed) -> None:
         renderables.append(Text(""))
         renderables.append(t)
 
-    con.print(_spanel(
-        "Issue Attribution",
-        "Detailed breakdown of REQUIRED issues by check type",
-        *renderables,
-    ))
+    con.print(
+        _spanel(
+            "Issue Attribution",
+            "Detailed breakdown of REQUIRED issues by check type",
+            *renderables,
+        )
+    )
 
 
 def _render_durations(con: Console, failed, top_n: int) -> None:
@@ -374,13 +400,15 @@ def _render_durations(con: Console, failed, top_n: int) -> None:
     t.add_column("REQUIRED Issues", justify="right")
     for dur, c in sorted(durations, key=lambda x: -x[0])[:top_n]:
         t.add_row(c["name"], f"[bold {_C_DURATION}]{dur:.2f}s[/]", f"[bold {_C_ISSUES}]{c['subissues']}[/]")
-    con.print(_spanel(
-        "Slowest Crates",
-        f"Top {top_n} crates with the longest validation durations",
-        t,
-        Text(""),
-        *_describe_lines(vals, value_style=_C_DURATION, unit="s"),
-    ))
+    con.print(
+        _spanel(
+            "Slowest Crates",
+            f"Top {top_n} crates with the longest validation durations",
+            t,
+            Text(""),
+            *_describe_lines(vals, value_style=_C_DURATION, unit="s"),
+        )
+    )
 
 
 def _render_outliers(con: Console, failed, threshold: int) -> None:
@@ -389,11 +417,13 @@ def _render_outliers(con: Console, failed, threshold: int) -> None:
         key=lambda x: -x["subissues"],
     )
     if not outliers:
-        con.print(_spanel(
-            f"Outlier Crates (≥ {threshold} REQUIRED issues)",
-            "Crates with an unusually high number of REQUIRED issues",
-            Text.from_markup(f"[dim]No outlier crates with ≥ {threshold} REQUIRED issues.[/]"),
-        ))
+        con.print(
+            _spanel(
+                f"Outlier Crates (≥ {threshold} REQUIRED issues)",
+                "Crates with an unusually high number of REQUIRED issues",
+                Text.from_markup(f"[dim]No outlier crates with ≥ {threshold} REQUIRED issues.[/]"),
+            )
+        )
         return
     t = _rtable()
     t.add_column("Crate", style=_C_CRATE_ID, no_wrap=True)
@@ -402,11 +432,13 @@ def _render_outliers(con: Console, failed, threshold: int) -> None:
     for c in outliers:
         types = ", ".join(code for code, _ in c["error_types"])
         t.add_row(c["name"], f"[bold {_C_ISSUES}]{c['subissues']}[/]", types)
-    con.print(_spanel(
-        f"Outlier Crates (≥ {threshold} REQUIRED issues)",
-        "Crates with an unusually high number of REQUIRED issues",
-        t,
-    ))
+    con.print(
+        _spanel(
+            f"Outlier Crates (≥ {threshold} REQUIRED issues)",
+            "Crates with an unusually high number of REQUIRED issues",
+            t,
+        )
+    )
 
 
 def _render_detailed(con: Console, crates, failed, errored, top_n: int, outlier_threshold: int) -> None:
@@ -425,6 +457,7 @@ def _render_detailed(con: Console, crates, failed, errored, top_n: int, outlier_
 # ===========================================================================
 # Public entry point
 # ===========================================================================
+
 
 def render_statistics(
     console: Console,
@@ -454,9 +487,7 @@ def render_statistics(
     console.rule("[bold cyan]Statistics[/]")
     analysed = f"Crates analysed: [bold cyan]{len(crates)}[/]"
     if errored:
-        analysed += (
-            f"   [dim]·[/dim]   [bold red]{len(errored)}[/] could not be validated [dim](ERROR)[/dim]"
-        )
+        analysed += f"   [dim]·[/dim]   [bold red]{len(errored)}[/] could not be validated [dim](ERROR)[/dim]"
     console.print(analysed)
     console.print()
     _print_summary_table(console, crates)
@@ -467,6 +498,7 @@ def render_statistics(
 # ===========================================================================
 # Markdown file output
 # ===========================================================================
+
 
 def _md_table(headers: list[str], rows: list[list[str]], align_left: list[int] | None = None) -> str:
     """Build a GF markdown table from headers and row data."""
@@ -491,13 +523,13 @@ def _md_describe_lines(values: list[float], *, unit: str = "") -> str:
     total = sum(values)
     mean_val = _stats.mean(values)
     median_val = _stats.median(values)
-    if n >= 4:
+    if n >= _MIN_SAMPLES_FOR_QUARTILES:
         q1_val, _, q3_val = _stats.quantiles(values, n=4)
     else:
         q1_val, q3_val = ordered[0], ordered[-1]
     iqr_val = q3_val - q1_val
-    std_val = _stats.stdev(values) if n >= 2 else 0.0
-    var_val = _stats.variance(values) if n >= 2 else 0.0
+    std_val = _stats.stdev(values) if n >= _MIN_SAMPLES_FOR_SPREAD else 0.0
+    var_val = _stats.variance(values) if n >= _MIN_SAMPLES_FOR_SPREAD else 0.0
 
     def r(x: float) -> str:
         return f"{int(x)}" if float(x).is_integer() else f"{x:.2f}"
@@ -506,12 +538,14 @@ def _md_describe_lines(values: list[float], *, unit: str = "") -> str:
         return f"{x:.2f}"
 
     lines: list[str] = []
-    lines.append(f"- **Range**   →   total={r(total)}{unit}   n={n}   "
-                  f"min={r(ordered[0])}{unit}   max={r(ordered[-1])}{unit}")
-    lines.append(f"- **Central** →   mean={f(mean_val)}{unit}   median={f(median_val)}{unit}   "
-                  f"Q1={f(q1_val)}{unit}   Q3={f(q3_val)}{unit}")
-    lines.append(f"- **Spread**  →   stddev={f(std_val)}{unit}   variance={f(var_val)}{unit}   "
-                  f"IQR={f(iqr_val)}{unit}")
+    lines.append(
+        f"- **Range**   →   total={r(total)}{unit}   n={n}   min={r(ordered[0])}{unit}   max={r(ordered[-1])}{unit}"
+    )
+    lines.append(
+        f"- **Central** →   mean={f(mean_val)}{unit}   median={f(median_val)}{unit}   "
+        f"Q1={f(q1_val)}{unit}   Q3={f(q3_val)}{unit}"
+    )
+    lines.append(f"- **Spread**  →   stddev={f(std_val)}{unit}   variance={f(var_val)}{unit}   IQR={f(iqr_val)}{unit}")
     return "\n".join(lines) + "\n"
 
 
@@ -554,9 +588,7 @@ def _md_write_outcome_summary(w, crates, failed, errored) -> None:
     w("## Outcome Summary\n\n")
     total = len(crates)
     rows: list[list[str]] = []
-    for label, n in [("PASSED", len(passed_crates(crates))),
-                      ("FAILED", len(failed)),
-                      ("ERROR", len(errored))]:
+    for label, n in [("PASSED", len(passed_crates(crates))), ("FAILED", len(failed)), ("ERROR", len(errored))]:
         pct = 100 * n / total if total else 0
         rows.append([label, str(n), f"{pct:.1f}%"])
     rows.append(["**TOTAL**", f"**{total}**", "**100.0%**"])
@@ -609,8 +641,7 @@ def _md_write_error_types(w, failed) -> None:
     w(_md_table(["Check", "Crates", "Share", "Description"], rows, align_left=[0, 3]))
     single = sum(1 for c in failed if len(c["error_types"]) == 1)
     multi = sum(1 for c in failed if len(c["error_types"]) > 1)
-    w(f"\nCrates with exactly 1 error type: **{single}**  "
-      f"more than one: **{multi}**\n\n")
+    w(f"\nCrates with exactly 1 error type: **{single}**  more than one: **{multi}**\n\n")
 
 
 def _md_write_issue_attribution(w, failed) -> None:
@@ -628,14 +659,11 @@ def _md_write_issue_attribution(w, failed) -> None:
             multi_crates.append(crate)
     w(f"Total REQUIRED issues: **{total_subs}**\n\n")
     if single_attrib:
-        rows = [[code, str(cnt)] for code, cnt in
-                sorted(single_attrib.items(), key=lambda x: -x[1])]
+        rows = [[code, str(cnt)] for code, cnt in sorted(single_attrib.items(), key=lambda x: -x[1])]
         w(_md_table(["Check", "REQUIRED Issues"], rows, align_left=[0]))
         w("\n")
     if multi_crates:
-        rows = [[c["name"], str(c["subissues"]),
-                 ", ".join(code for code, _ in c["error_types"])]
-                for c in multi_crates]
+        rows = [[c["name"], str(c["subissues"]), ", ".join(code for code, _ in c["error_types"])] for c in multi_crates]
         w(_md_table(["Crate", "REQUIRED Issues", "Types"], rows, align_left=[0, 2]))
         w("\n")
 
@@ -668,8 +696,6 @@ def _md_write_outliers(w, failed, outlier_threshold) -> None:
     if not outliers:
         w(f"No outlier crates with ≥ {outlier_threshold} REQUIRED issues.\n\n")
     else:
-        rows = [[c["name"], str(c["subissues"]),
-                 ", ".join(code for code, _ in c["error_types"])]
-                for c in outliers]
+        rows = [[c["name"], str(c["subissues"]), ", ".join(code for code, _ in c["error_types"])] for c in outliers]
         w(_md_table(["Crate", "REQUIRED Issues", "Types"], rows, align_left=[0, 2]))
         w("\n")

--- a/rocrate_validator/utils/paths.py
+++ b/rocrate_validator/utils/paths.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import os
 from pathlib import Path
 
@@ -85,6 +86,34 @@ def get_user_cache_dir() -> Path:
     xdg = os.environ.get("XDG_CACHE_HOME")
     base = Path(xdg) if xdg else Path.home() / ".cache"
     return base / constants.USER_CACHE_DIR_NAME
+
+
+def get_user_sessions_dir() -> Path:
+    """
+    Get the directory where auto-managed batch session files are stored.
+
+    Located under the user cache directory (see :func:`get_user_cache_dir`),
+    so it honors the XDG Base Directory Specification.
+
+    :return: The path to the batch sessions directory (not guaranteed to exist)
+    """
+    return get_user_cache_dir() / constants.USER_SESSIONS_DIR_NAME
+
+
+def get_batch_session_path(key_parts: list[str]) -> Path:
+    """
+    Derive the auto-managed batch session file path for a given batch target.
+
+    The file name is a deterministic hash of ``key_parts`` (e.g. the absolute
+    scan root, the glob pattern and the relevant validation
+    settings), so that re-running the same batch command resolves to the same
+    session file and can be resumed automatically.
+
+    :param key_parts: the components that uniquely identify the batch target
+    :return: the session file path under the user sessions directory
+    """
+    digest = hashlib.sha1("|".join(key_parts).encode("utf-8")).hexdigest()
+    return get_user_sessions_dir() / f"{digest}.json"
 
 
 def get_default_http_cache_path() -> Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,21 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
-from pytest import fixture
+from pytest import fixture, mark
 
 from rocrate_validator import services
 from rocrate_validator.cli.main import cli
+from rocrate_validator.models import BatchCrateEntry, BatchSession, ValidationSettings
 from rocrate_validator.requirements.python import PyFunctionCheck
 from rocrate_validator.requirements.shacl.checks import SHACLCheck
+from rocrate_validator.services import discover_ro_crates
 from rocrate_validator.utils import log as logging
+from rocrate_validator.utils.paths import get_user_sessions_dir
 from rocrate_validator.utils.versioning import get_version
 from tests.conftest import SKIP_LOCAL_DATA_ENTITY_EXISTENCE_CHECK_IDENTIFIER
-from tests.ro_crates import InvalidFileDescriptor, ValidROC
+from tests.ro_crates import CRATES_DATA_PATH, InvalidFileDescriptor, ValidROC
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -323,3 +328,964 @@ def test_describe_check_verbose_shacl_includes_target(cli_runner: CliRunner):
         t in result.output
         for t in ("sh:targetClass", "sh:targetNode", "sh:targetSubjectsOf", "sh:targetObjectsOf", "sh:target ")
     )
+
+
+###############################################################################
+# BATCH MODE TESTS
+###############################################################################
+
+
+def test_discover_ro_crates_directory():
+    """Test discover_ro_crates finds crates in a directory."""
+    valid_path = CRATES_DATA_PATH / "valid"
+    crates = discover_ro_crates(valid_path)
+    assert len(crates) > 0
+    # Should find subdirectories with ro-crate-metadata.json
+    assert any("wrroc-paper-long-date" in str(c) for c in crates)
+    assert any("wrroc-paper" in str(c) for c in crates)
+    # Should find .zip files
+    assert any(c.suffix == ".zip" for c in crates)
+
+
+def test_discover_ro_crates_no_match_pattern():
+    """Test discover_ro_crates with a pattern that matches nothing."""
+    valid_path = CRATES_DATA_PATH / "valid"
+    crates = discover_ro_crates(valid_path, pattern="nonexistent*.zip")
+    assert len(crates) == 0
+
+
+def test_discover_ro_crates_is_flat(tmp_path):
+    """Discovery is flat: a crate's nested payload is not treated as a separate crate."""
+    crate = tmp_path / "crateB"
+    (crate / "data").mkdir(parents=True)
+    (crate / "ro-crate-metadata.json").write_text("{}")
+    # A nested metadata file is a payload of crateB and must NOT be discovered.
+    (crate / "data" / "ro-crate-metadata.json").write_text("{}")
+
+    crates = discover_ro_crates(tmp_path)
+    assert any(c.name == "crateB" for c in crates)
+    assert all(c.resolve() != (crate / "data").resolve() for c in crates)
+
+
+def test_discover_ro_crates_detached_metadata_files(tmp_path):
+    """Detached crates defined as immediate `*-ro-crate-metadata.json` files are found."""
+    # Two detached crates (metadata files directly in the scan dir).
+    (tmp_path / "crate_0001-ro-crate-metadata.json").write_text("{}")
+    (tmp_path / "crate_0002-ro-crate-metadata.json").write_text("{}")
+    # A directory crate alongside them.
+    dir_crate = tmp_path / "crate_0003"
+    dir_crate.mkdir()
+    (dir_crate / "ro-crate-metadata.json").write_text("{}")
+    # Non-crate files must be ignored.
+    (tmp_path / "generation_report.json").write_text("{}")
+    (tmp_path / ".DS_Store").write_text("")
+
+    crates = discover_ro_crates(tmp_path)
+    names = {c.name for c in crates}
+    assert "crate_0001-ro-crate-metadata.json" in names
+    assert "crate_0002-ro-crate-metadata.json" in names
+    assert "crate_0003" in names
+    assert "generation_report.json" not in names
+    assert ".DS_Store" not in names
+    assert len(crates) == 3
+
+
+def test_discover_ro_crates_self_as_crate():
+    """Test that a directory with ro-crate-metadata.json is found as a crate."""
+    crate_dir = ValidROC().wrroc_paper_long_date
+    crates = discover_ro_crates(crate_dir)
+    assert len(crates) >= 1
+    assert crate_dir.resolve() in crates
+
+
+def test_discover_ro_crates_invalid_dir():
+    """Test discover_ro_crates raises on non-directory."""
+    with tempfile.NamedTemporaryFile() as tmp:
+        import pytest
+
+        with pytest.raises(NotADirectoryError):
+            discover_ro_crates(Path(tmp.name))
+
+
+def test_batch_crate_entry_serialization():
+    """Test BatchCrateEntry to_dict/from_dict roundtrip."""
+    entry = BatchCrateEntry(
+        path="/tmp/test-crate",
+        status="completed",
+        passed=True,
+        duration=1.23,
+        issues=[{"message": "test issue"}],
+        statistics={"total_checks": 10},
+    )
+    data = entry.to_dict()
+    restored = BatchCrateEntry.from_dict(data)
+    assert restored.path == entry.path
+    assert restored.status == entry.status
+    assert restored.passed == entry.passed
+    assert restored.duration == entry.duration
+    assert restored.issues == entry.issues
+    assert restored.statistics == entry.statistics
+
+
+def test_batch_session_save_load(tmp_path):
+    """Test BatchSession save/load roundtrip."""
+    settings = {"profile_identifier": "ro-crate", "requirement_severity": "REQUIRED"}
+    session = BatchSession(
+        validation_settings=settings,
+        crate_paths=["/tmp/crate1", "/tmp/crate2"],
+        session_path=tmp_path / "session.json",
+    )
+    assert session.total_crates == 2
+    assert session.completed_crates == 0
+
+    # Simulate a completed crate
+    session.completed_crates = 1
+    session.failed_crates = 0
+    session.crates[0].status = "completed"
+    session.crates[0].passed = True
+    session.save()
+
+    # Load it back
+    loaded = BatchSession.load(tmp_path / "session.json")
+    assert loaded.total_crates == 2
+    assert loaded.completed_crates == 1
+    assert loaded.validation_settings["profile_identifier"] == "ro-crate"
+    assert loaded.crates[0].status == "completed"
+    assert loaded.crates[0].passed is True
+    assert loaded.crates[1].status == "pending"
+
+
+def test_batch_session_get_pending():
+    """Test get_pending returns only pending/in_progress entries."""
+    session = BatchSession(
+        validation_settings={},
+        crate_paths=["/tmp/a", "/tmp/b", "/tmp/c"],
+    )
+    session.crates[0].status = "completed"
+    session.crates[1].status = "in_progress"
+    pending = session.get_pending()
+    assert len(pending) == 2
+    assert pending[0].path == "/tmp/b"
+    assert pending[1].path == "/tmp/c"
+
+
+def test_batch_session_is_completed():
+    """Test is_completed returns True only when all crates done."""
+    session = BatchSession(validation_settings={}, crate_paths=["/tmp/a"])
+    assert not session.is_completed()
+    session.completed_crates = 1
+    assert session.is_completed()
+
+
+def test_batch_session_mark_failed():
+    """Test mark_failed updates session state correctly."""
+    session = BatchSession(validation_settings={}, crate_paths=["/tmp/a"])
+    session.mark_failed("/tmp/a", "Connection error", 0.5)
+    assert session.crates[0].status == "failed"
+    assert session.crates[0].passed is False
+    assert session.crates[0].error == "Connection error"
+    assert session.completed_crates == 1
+    assert session.failed_crates == 1
+
+
+def test_batch_validate_valid_crates(cli_runner: CliRunner):
+    """Test batch validation of valid crates via CLI."""
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper*",
+            # The wrroc-paper crates declare RO-Crate 1.1: validate against the
+            # matching version (the bare "ro-crate" now resolves to the newest
+            # available profile, 1.2, against which these 1.1 crates fail).
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--verbose",
+            "--no-paging",
+        ],
+    )
+    # Should succeed with at least 2 valid crates found
+    assert result.exit_code == 0, result.output
+    assert "Batch Validation Summary" in result.output
+
+
+def test_batch_validate_auto_session(cli_runner: CliRunner):
+    """Batch validation auto-manages a session file under the user sessions dir."""
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            # No --session-file / --resume: the session is always auto-managed.
+            "--no-resume",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # A session file must have been auto-created under the user sessions directory.
+    sessions = list(get_user_sessions_dir().glob("*.json"))
+    assert sessions, "no auto-managed session file was created"
+    session_data = json.loads(max(sessions, key=lambda p: p.stat().st_mtime).read_text())
+    assert session_data["session"]["status"] == "completed"
+    assert session_data["session"]["completed_crates"] >= 1
+    assert session_data["crates"][0]["status"] == "completed"
+    # The profile used is recorded per crate in the session.
+    assert session_data["crates"][0]["profiles"] == ["ro-crate-1.1"]
+
+
+def test_batch_validate_json_output(cli_runner: CliRunner, tmp_path):
+    """Test batch validation with JSON output file."""
+    output_file = tmp_path / "batch_output.json"
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--output-format",
+            "json",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_file.exists()
+    # Use strict=False to handle any embedded control characters in validation messages
+    data = json.loads(output_file.read_text(), strict=False)
+    assert "meta" in data
+    assert "batch_passed" in data
+
+
+def test_batch_validate_mixed_crates(cli_runner: CliRunner, tmp_path):
+    """Test batch validation with mix of valid and invalid crates."""
+    # Create temp dir with both valid and invalid crates
+    batch_dir = tmp_path / "batch_mixed"
+    batch_dir.mkdir()
+    valid_src = ValidROC().wrroc_paper_long_date
+    invalid_src = InvalidFileDescriptor().invalid_json_format
+
+    # Copy valid crate
+    import shutil
+
+    shutil.copytree(valid_src, batch_dir / "valid_crate", symlinks=True)
+    # Copy invalid crate
+    shutil.copytree(invalid_src, batch_dir / "invalid_crate", symlinks=True)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            str(batch_dir),
+            "--profile-identifier",
+            "ro-crate",
+            "--no-paging",
+            "--verbose",
+        ],
+    )
+    # Should fail because at least one crate fails
+    assert result.exit_code == 1, result.output
+    assert "Batch Validation Summary" in result.output
+
+
+def test_batch_prepare_session_auto_resume(tmp_path):
+    """An interrupted session is auto-resumed: completed crates are carried over."""
+    session_file = tmp_path / "auto_session.json"
+    paths = ["/tmp/crate_a", "/tmp/crate_b", "/tmp/crate_c"]
+
+    # Simulate a previously interrupted session with one completed crate.
+    session = BatchSession(validation_settings={}, crate_paths=paths, session_path=session_file)
+    session.crates[0].status = "completed"
+    session.crates[0].passed = True
+    session.completed_crates = 1
+    session.status = "interrupted"
+    session.save()
+
+    settings = ValidationSettings.parse({"profile_identifier": ("ro-crate",)})
+
+    # Resume (fresh=False): the completed crate is skipped, the rest are pending.
+    resumed, pending = services._prepare_batch_session(settings, paths, session_file, fresh=False)
+    assert resumed.completed_crates == 1
+    assert resumed.total_crates == 3
+    assert set(pending) == {"/tmp/crate_b", "/tmp/crate_c"}
+
+    # Fresh (fresh=True): everything is re-validated, nothing carried over.
+    restarted, pending_fresh = services._prepare_batch_session(settings, paths, session_file, fresh=True)
+    assert restarted.completed_crates == 0
+    assert set(pending_fresh) == set(paths)
+
+
+def test_batch_session_path_reflects_profile_selection(tmp_path):
+    """The session key must distinguish profile selections, order-independently."""
+    settings = ValidationSettings.parse(
+        {"rocrate_uri": ".", "profile_identifier": "ro-crate", "requirement_severity": "REQUIRED"}
+    )
+
+    def sp(profile_identifiers, no_auto_profile=False, severity_only=False):
+        s = ValidationSettings.parse(
+            {
+                "rocrate_uri": ".",
+                "profile_identifier": "ro-crate",
+                "requirement_severity": "REQUIRED",
+                "requirement_severity_only": severity_only,
+            }
+        )
+        return services.resolve_batch_session_path(
+            s, tmp_path, "*", profile_identifiers=profile_identifiers, no_auto_profile=no_auto_profile
+        )
+
+    # Different multi-profile sets sharing the first profile must NOT collide.
+    assert sp(["ro-crate-1.1", "ro-crate-1.2"]) != sp(["ro-crate-1.1", "ro-crate-process-run"])
+    # Profile order does not matter.
+    assert sp(["ro-crate-1.1", "ro-crate-1.2"]) == sp(["ro-crate-1.2", "ro-crate-1.1"])
+    # Auto-detection, disabled auto-detection and an explicit profile are all distinct.
+    assert sp(None, no_auto_profile=False) != sp(None, no_auto_profile=True)
+    assert sp(["ro-crate-1.1"]) != sp(None, no_auto_profile=False)
+    # requirement_severity_only changes the key (it is dropped by to_dict()).
+    assert sp(["ro-crate-1.1"], severity_only=False) != sp(["ro-crate-1.1"], severity_only=True)
+
+    # Sanity: a stable selection resolves to a stable path.
+    assert services.resolve_batch_session_path(
+        settings, tmp_path, "*", profile_identifiers=["ro-crate-1.1"]
+    ) == services.resolve_batch_session_path(
+        settings, tmp_path, "*", profile_identifiers=["ro-crate-1.1"]
+    )
+
+
+def test_batch_footer_reports_saved_paths(cli_runner: CliRunner, tmp_path):
+    """The end-of-batch footer reports where the report file and session were saved."""
+    output_file = tmp_path / "report.txt"
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--output-format",
+            "text",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # The footer (on stderr) names the saved artifacts and the input scanned.
+    assert "Report (text)" in result.stderr
+    assert str(output_file) in result.stderr
+    assert "Session" in result.stderr
+    assert ".json" in result.stderr
+    assert "Input" in result.stderr
+    # Per-crate progress lines show the crate relative to the input path
+    # (the bare crate name, not an absolute path).
+    assert "] wrroc-paper-long-date" in result.stderr
+
+
+def test_batch_validate_csv_output(cli_runner: CliRunner, tmp_path):
+    """Test batch validation with CSV output file."""
+    output_file = tmp_path / "batch_output.csv"
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--output-format",
+            "csv",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_file.exists()
+    rows = output_file.read_text().splitlines()
+    assert rows[0].startswith(
+        "source,crate,path,profiles,size_bytes,status,total_checks,passed_checks,issues,duration,error"
+    )
+    # The profile used is recorded in the CSV row.
+    assert ",ro-crate-1.1," in rows[1]
+    # At least one data row for the validated crate, reported as passed.
+    assert len(rows) >= 2
+    assert "wrroc-paper-long-date" in rows[1]
+    assert ",passed," in rows[1]
+
+
+def test_batch_validate_csv_rejected_in_single_mode(cli_runner: CliRunner):
+    """CSV output is batch-only and must be rejected for single-crate validation."""
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            str(ValidROC().wrroc_paper_long_date),
+            "--profile-identifier",
+            "ro-crate",
+            "--no-paging",
+            "--output-format",
+            "csv",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "csv" in result.output.lower()
+
+
+def test_batch_validate_no_crates_found(cli_runner: CliRunner, tmp_path):
+    """Test batch with no matching crates."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            str(empty_dir),
+            "--no-paging",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "No RO-Crates found" in result.output
+
+
+def test_batch_with_output_file_text(cli_runner: CliRunner, tmp_path):
+    """Test batch validation writes text output to file."""
+    output_file = tmp_path / "batch_report.txt"
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--output-format",
+            "text",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_file.exists()
+    content = output_file.read_text()
+    assert "Batch Validation Summary" in content
+
+
+def test_batch_canonical_positional_target(cli_runner: CliRunner):
+    """The scan root can be given as the positional RO-CRATE-URI argument (no -B)."""
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper*",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Batch Validation Summary" in result.output
+
+
+def test_no_resume_ignores_saved_session(cli_runner: CliRunner):
+    """--no-resume re-validates from scratch instead of resuming a saved session."""
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--no-resume",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Batch Validation Summary" in result.output
+
+
+@mark.parametrize("flag", ["--batch-pattern=foo*", "--no-resume"])
+def test_batch_only_options_require_batch_mode(cli_runner: CliRunner, flag: str):
+    """Batch-only options must be rejected when batch mode is not enabled."""
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            str(ValidROC().wrroc_paper_long_date),
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            *flag.split("="),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "batch mode" in result.output.lower()
+
+
+def _write_fake_session(sessions_dir, session_id, *, status, total, completed, failed, paths):
+    """Create a minimal batch session file under ``sessions_dir`` for tests."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    now = "2026-06-22T10:00:00+00:00"
+    data = {
+        "session": {
+            "version": "1.0",
+            "rocrate_validator_version": "test",
+            "created_at": now,
+            "updated_at": now,
+            "status": status,
+            "total_crates": total,
+            "completed_crates": completed,
+            "failed_crates": failed,
+        },
+        "validation_settings": {},
+        "batch_options": {"profile_identifiers": ["ro-crate-1.1"], "no_auto_profile": False},
+        "crates": [
+            {
+                "path": p,
+                "status": "completed",
+                "passed": True,
+                "profiles": ["ro-crate-1.1"],
+                "issues": [],
+                "statistics": {"total_checks": 1, "total_passed_checks": 1},
+            }
+            for p in paths
+        ],
+    }
+    (sessions_dir / f"{session_id}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+@fixture
+def isolated_sessions_dir(tmp_path, monkeypatch):
+    """Redirect the user cache dir to a tmp path so session tests stay isolated."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    return get_user_sessions_dir()
+
+
+def test_sessions_path(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "path"])
+    assert result.exit_code == 0, result.output
+    assert str(isolated_sessions_dir) in result.output
+
+
+def test_sessions_show_requires_id_non_interactive(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show"])
+    assert result.exit_code != 0
+    assert "specify a session id" in result.output.lower()
+
+
+def test_sessions_show_not_found(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "nope404"])
+    assert result.exit_code == 0, result.output
+    assert "no session matches" in result.output.lower()
+
+
+def test_validate_stats_text(cli_runner: CliRunner):
+    """`validate -b --stats` appends the textual statistics after the summary."""
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper*",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--no-resume",
+            "--stats",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Statistics" in result.output
+    assert "Outcome Summary" in result.output
+
+
+def test_validate_stats_ignored_for_json(cli_runner: CliRunner, tmp_path):
+    """--stats is ignored for JSON output (text-only): the report file stays valid JSON."""
+    output_file = tmp_path / "out.json"
+    valid_dir = str(ValidROC().wrroc_paper_long_date.parent)
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--no-interactive",
+            "validate",
+            "--batch",
+            valid_dir,
+            "--batch-pattern",
+            "wrroc-paper-long-date",
+            "--profile-identifier",
+            "ro-crate-1.1",
+            "--no-paging",
+            "--no-resume",
+            "--output-format",
+            "json",
+            "--output-file",
+            str(output_file),
+            "--stats",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ignored for 'json'" in result.stderr
+    # The report file is plain JSON, with no statistics tables mixed in.
+    data = json.loads(output_file.read_text(), strict=False)
+    assert "batch_passed" in data
+
+
+def test_sessions_show_stats(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "stat01", status="completed", total=2, completed=2, failed=0,
+        paths=["/data/crateA", "/data/crateB"],
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "stat01", "--stats"])
+    assert result.exit_code == 0, result.output
+    assert "Statistics" in result.output
+    assert "Outcome Summary" in result.output
+
+
+def test_sessions_show_output_file_requires_stats(cli_runner: CliRunner, isolated_sessions_dir):
+    """--output-file without --stats should raise a usage error."""
+    _write_fake_session(
+        isolated_sessions_dir, "s1", status="completed", total=1, completed=1, failed=0,
+        paths=["/a/x"],
+    )
+    result = cli_runner.invoke(
+        cli, ["--no-interactive", "sessions", "show", "s1", "-o", "/tmp/out.txt"]
+    )
+    assert result.exit_code != 0
+    assert "requires --stats" in result.output
+
+
+def test_sessions_show_stats_output_file_text(cli_runner: CliRunner, isolated_sessions_dir, tmp_path):
+    """Write statistics in text format (default, no colour) to a file."""
+    output_file = tmp_path / "stats.txt"
+    _write_fake_session(
+        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        paths=["/a/x", "/a/y"],
+    )
+    result = cli_runner.invoke(
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
+              "-o", str(output_file)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Statistics written to" in result.output
+    content = output_file.read_text()
+    assert "Statistics" in content
+    assert "Outcome Summary" in content
+    # No ANSI colour codes in default text output.
+    assert "\x1b[" not in content
+
+
+def test_sessions_show_stats_output_file_text_with_color(
+    cli_runner: CliRunner, isolated_sessions_dir, tmp_path
+):
+    """Write statistics in text format with ANSI colour codes."""
+    output_file = tmp_path / "stats_color.txt"
+    _write_fake_session(
+        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        paths=["/a/x", "/a/y"],
+    )
+    result = cli_runner.invoke(
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
+              "-o", str(output_file), "--color"]
+    )
+    assert result.exit_code == 0, result.output
+    content = output_file.read_text()
+    assert "Statistics" in content
+    assert "Outcome Summary" in content
+    assert "\x1b[" in content
+
+
+def test_sessions_show_stats_output_file_md(cli_runner: CliRunner, isolated_sessions_dir, tmp_path):
+    """Write statistics in markdown format to a file."""
+    output_file = tmp_path / "stats.md"
+    _write_fake_session(
+        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        paths=["/a/x", "/a/y"],
+    )
+    result = cli_runner.invoke(
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
+              "-o", str(output_file), "-f", "md"]
+    )
+    assert result.exit_code == 0, result.output
+    content = output_file.read_text()
+    assert "# Validation Statistics" in content
+    assert "## Outcome Summary" in content
+    assert "| Status | Crates | Share |" in content
+    assert "| **TOTAL**" in content
+    assert "## Checks/Passed Combinations" in content
+
+
+def test_sessions_show_stats_output_file_md_with_failures(
+    cli_runner: CliRunner, isolated_sessions_dir, tmp_path
+):
+    """Write statistics in markdown format for a session with failures."""
+    output_file = tmp_path / "stats_fail.md"
+    sessions_dir = isolated_sessions_dir
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    now = "2026-06-22T10:00:00+00:00"
+    data = {
+        "session": {
+            "version": "1.0",
+            "rocrate_validator_version": "test",
+            "created_at": now,
+            "updated_at": now,
+            "status": "completed",
+            "total_crates": 4,
+            "completed_crates": 4,
+            "failed_crates": 2,
+        },
+        "validation_settings": {},
+        "batch_options": {"profile_identifiers": ["ro-crate-1.1"], "no_auto_profile": False},
+        "crates": [
+            {
+                "path": "/a/passed1",
+                "status": "completed",
+                "passed": True,
+                "profiles": ["ro-crate-1.1"],
+                "issues": [],
+                "statistics": {"total_checks": 5, "total_passed_checks": 5},
+            },
+            {
+                "path": "/a/passed2",
+                "status": "completed",
+                "passed": True,
+                "profiles": ["ro-crate-1.1"],
+                "issues": [],
+                "statistics": {"total_checks": 5, "total_passed_checks": 5},
+            },
+            {
+                "path": "/a/failed1",
+                "status": "completed",
+                "passed": False,
+                "profiles": ["ro-crate-1.1"],
+                "issues": [
+                    {
+                        "severity": "REQUIRED",
+                        "check": {"identifier": "check-01", "name": "Check Alpha"},
+                    },
+                    {
+                        "severity": "OPTIONAL",
+                        "check": {"identifier": "check-02", "name": "Check Beta"},
+                    },
+                ],
+                "statistics": {"total_checks": 5, "total_passed_checks": 3},
+            },
+            {
+                "path": "/a/failed2",
+                "status": "completed",
+                "passed": False,
+                "profiles": ["ro-crate-1.1"],
+                "issues": [
+                    {
+                        "severity": "REQUIRED",
+                        "check": {"identifier": "check-01", "name": "Check Alpha"},
+                    },
+                ],
+                "statistics": {"total_checks": 5, "total_passed_checks": 4},
+            },
+        ],
+    }
+    (sessions_dir / "s1.json").write_text(json.dumps(data), encoding="utf-8")
+
+    result = cli_runner.invoke(
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
+              "-o", str(output_file), "-f", "md"]
+    )
+    assert result.exit_code == 0, result.output
+    content = output_file.read_text()
+    assert "Crates analysed: **4**" in content
+    assert "| PASSED | 2 | 50.0% |" in content
+    assert "| FAILED | 2 | 50.0% |" in content
+    assert "## Error-Type Distribution" in content
+    assert "## Issue Attribution" in content
+
+
+def test_sessions_show_renders_session(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "shw001", status="completed", total=2, completed=2, failed=0,
+        paths=["/data/crateA", "/data/crateB"],
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "shw001"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Header, per-crate list (relative names + profile) and summary are all shown.
+    assert "Profiles" in out
+    assert "crateA" in out and "crateB" in out
+    assert "ro-crate-1.1" in out
+    assert "Batch Validation Summary" in out
+    assert "passed validation" in out.lower()
+
+
+def test_sessions_list_empty(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "list"])
+    assert result.exit_code == 0, result.output
+    assert "no batch sessions" in result.output.lower()
+
+
+def test_sessions_list_and_json(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "aaa111", status="completed", total=2, completed=2, failed=0, paths=["/a/x", "/a/y"]
+    )
+    _write_fake_session(
+        isolated_sessions_dir, "bbb222", status="interrupted", total=3, completed=1, failed=1, paths=["/b/x"]
+    )
+
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Batch sessions (2)" in result.output
+
+    result_json = cli_runner.invoke(cli, ["--no-interactive", "sessions", "ls", "--json"])
+    assert result_json.exit_code == 0, result_json.output
+    data = json.loads(result_json.output)
+    assert {d["id"] for d in data} == {"aaa111", "bbb222"}
+
+    filtered = cli_runner.invoke(cli, ["--no-interactive", "sessions", "list", "--status", "interrupted"])
+    assert "Batch sessions (1)" in filtered.output
+
+
+def test_sessions_clear_requires_scope(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "clear"])
+    assert result.exit_code != 0
+    assert "specify" in result.output.lower()
+
+
+def test_sessions_clear_by_id(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "abc123def", status="completed", total=1, completed=1, failed=0, paths=["/a/x"]
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "clear", "abc123", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert "Removed 1 session" in result.output
+    assert not (isolated_sessions_dir / "abc123def.json").exists()
+
+
+def test_sessions_clear_completed_only(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "done1", status="completed", total=1, completed=1, failed=0, paths=["/a/x"]
+    )
+    _write_fake_session(
+        isolated_sessions_dir, "wip1", status="interrupted", total=2, completed=1, failed=0, paths=["/b/x"]
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "rm", "--completed", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not (isolated_sessions_dir / "done1.json").exists()
+    assert (isolated_sessions_dir / "wip1.json").exists()
+
+
+def test_sessions_clear_non_interactive_requires_yes(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "keep1", status="completed", total=1, completed=1, failed=0, paths=["/a/x"]
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "clear", "--all"])
+    assert result.exit_code == 1
+    assert "--yes" in result.output
+    # Nothing removed without confirmation.
+    assert (isolated_sessions_dir / "keep1.json").exists()
+
+
+def _make_interrupted_session(sessions_dir, session_id, crate_paths, completed_count, *, profile="ro-crate-1.1"):
+    """Persist an interrupted batch session with the first crates marked completed."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    session_file = sessions_dir / f"{session_id}.json"
+    settings = ValidationSettings.parse(
+        {"rocrate_uri": crate_paths[0], "profile_identifier": profile, "requirement_severity": "REQUIRED"}
+    )
+    session = BatchSession(
+        validation_settings=settings.to_dict(),
+        crate_paths=crate_paths,
+        session_path=session_file,
+    )
+    for i in range(completed_count):
+        session.crates[i].status = "completed"
+        session.crates[i].passed = True
+    session.completed_crates = completed_count
+    session.status = "interrupted"
+    session.profile_identifiers = [profile]
+    session.save()
+    return session_file
+
+
+def test_sessions_resume_requires_id_non_interactive(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "resume"])
+    assert result.exit_code != 0
+    assert "specify a session id" in result.output.lower()
+
+
+def test_sessions_resume_not_found(cli_runner: CliRunner, isolated_sessions_dir):
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "resume", "nope404"])
+    assert result.exit_code == 0, result.output
+    assert "no session matches" in result.output.lower()
+
+
+def test_sessions_resume_already_completed(cli_runner: CliRunner, isolated_sessions_dir):
+    _write_fake_session(
+        isolated_sessions_dir, "done999", status="completed", total=1, completed=1, failed=0, paths=["/a/x"]
+    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "resume", "done999"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to resume" in result.output.lower()
+
+
+def test_sessions_resume_completes_interrupted(cli_runner: CliRunner, isolated_sessions_dir):
+    valid_dir = ValidROC().wrroc_paper_long_date.parent
+    c1 = str((valid_dir / "wrroc-paper").resolve())
+    c2 = str((valid_dir / "wrroc-paper-long-date").resolve())
+    session_file = _make_interrupted_session(isolated_sessions_dir, "feedface01", [c1, c2], completed_count=1)
+
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "resume", "feedface"])
+    assert result.exit_code == 0, result.output
+    assert "passed validation" in result.output.lower()
+
+    data = json.loads(session_file.read_text())
+    assert data["session"]["status"] == "completed"
+    assert data["session"]["completed_crates"] == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -667,9 +667,7 @@ def test_batch_session_path_reflects_profile_selection(tmp_path):
     # Sanity: a stable selection resolves to a stable path.
     assert services.resolve_batch_session_path(
         settings, tmp_path, "*", profile_identifiers=["ro-crate-1.1"]
-    ) == services.resolve_batch_session_path(
-        settings, tmp_path, "*", profile_identifiers=["ro-crate-1.1"]
-    )
+    ) == services.resolve_batch_session_path(settings, tmp_path, "*", profile_identifiers=["ro-crate-1.1"])
 
 
 def test_batch_footer_reports_saved_paths(cli_runner: CliRunner, tmp_path):
@@ -983,7 +981,12 @@ def test_validate_stats_ignored_for_json(cli_runner: CliRunner, tmp_path):
 
 def test_sessions_show_stats(cli_runner: CliRunner, isolated_sessions_dir):
     _write_fake_session(
-        isolated_sessions_dir, "stat01", status="completed", total=2, completed=2, failed=0,
+        isolated_sessions_dir,
+        "stat01",
+        status="completed",
+        total=2,
+        completed=2,
+        failed=0,
         paths=["/data/crateA", "/data/crateB"],
     )
     result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "stat01", "--stats"])
@@ -995,12 +998,15 @@ def test_sessions_show_stats(cli_runner: CliRunner, isolated_sessions_dir):
 def test_sessions_show_output_file_requires_stats(cli_runner: CliRunner, isolated_sessions_dir):
     """--output-file without --stats should raise a usage error."""
     _write_fake_session(
-        isolated_sessions_dir, "s1", status="completed", total=1, completed=1, failed=0,
+        isolated_sessions_dir,
+        "s1",
+        status="completed",
+        total=1,
+        completed=1,
+        failed=0,
         paths=["/a/x"],
     )
-    result = cli_runner.invoke(
-        cli, ["--no-interactive", "sessions", "show", "s1", "-o", "/tmp/out.txt"]
-    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "s1", "-o", "/tmp/out.txt"])
     assert result.exit_code != 0
     assert "requires --stats" in result.output
 
@@ -1009,13 +1015,15 @@ def test_sessions_show_stats_output_file_text(cli_runner: CliRunner, isolated_se
     """Write statistics in text format (default, no colour) to a file."""
     output_file = tmp_path / "stats.txt"
     _write_fake_session(
-        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        isolated_sessions_dir,
+        "s1",
+        status="completed",
+        total=2,
+        completed=2,
+        failed=0,
         paths=["/a/x", "/a/y"],
     )
-    result = cli_runner.invoke(
-        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
-              "-o", str(output_file)]
-    )
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "s1", "--stats", "-o", str(output_file)])
     assert result.exit_code == 0, result.output
     assert "Statistics written to" in result.output
     content = output_file.read_text()
@@ -1025,18 +1033,20 @@ def test_sessions_show_stats_output_file_text(cli_runner: CliRunner, isolated_se
     assert "\x1b[" not in content
 
 
-def test_sessions_show_stats_output_file_text_with_color(
-    cli_runner: CliRunner, isolated_sessions_dir, tmp_path
-):
+def test_sessions_show_stats_output_file_text_with_color(cli_runner: CliRunner, isolated_sessions_dir, tmp_path):
     """Write statistics in text format with ANSI colour codes."""
     output_file = tmp_path / "stats_color.txt"
     _write_fake_session(
-        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        isolated_sessions_dir,
+        "s1",
+        status="completed",
+        total=2,
+        completed=2,
+        failed=0,
         paths=["/a/x", "/a/y"],
     )
     result = cli_runner.invoke(
-        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
-              "-o", str(output_file), "--color"]
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats", "-o", str(output_file), "--color"]
     )
     assert result.exit_code == 0, result.output
     content = output_file.read_text()
@@ -1049,12 +1059,16 @@ def test_sessions_show_stats_output_file_md(cli_runner: CliRunner, isolated_sess
     """Write statistics in markdown format to a file."""
     output_file = tmp_path / "stats.md"
     _write_fake_session(
-        isolated_sessions_dir, "s1", status="completed", total=2, completed=2, failed=0,
+        isolated_sessions_dir,
+        "s1",
+        status="completed",
+        total=2,
+        completed=2,
+        failed=0,
         paths=["/a/x", "/a/y"],
     )
     result = cli_runner.invoke(
-        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
-              "-o", str(output_file), "-f", "md"]
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats", "-o", str(output_file), "-f", "md"]
     )
     assert result.exit_code == 0, result.output
     content = output_file.read_text()
@@ -1065,9 +1079,7 @@ def test_sessions_show_stats_output_file_md(cli_runner: CliRunner, isolated_sess
     assert "## Checks/Passed Combinations" in content
 
 
-def test_sessions_show_stats_output_file_md_with_failures(
-    cli_runner: CliRunner, isolated_sessions_dir, tmp_path
-):
+def test_sessions_show_stats_output_file_md_with_failures(cli_runner: CliRunner, isolated_sessions_dir, tmp_path):
     """Write statistics in markdown format for a session with failures."""
     output_file = tmp_path / "stats_fail.md"
     sessions_dir = isolated_sessions_dir
@@ -1138,8 +1150,7 @@ def test_sessions_show_stats_output_file_md_with_failures(
     (sessions_dir / "s1.json").write_text(json.dumps(data), encoding="utf-8")
 
     result = cli_runner.invoke(
-        cli, ["--no-interactive", "sessions", "show", "s1", "--stats",
-              "-o", str(output_file), "-f", "md"]
+        cli, ["--no-interactive", "sessions", "show", "s1", "--stats", "-o", str(output_file), "-f", "md"]
     )
     assert result.exit_code == 0, result.output
     content = output_file.read_text()
@@ -1152,10 +1163,15 @@ def test_sessions_show_stats_output_file_md_with_failures(
 
 def test_sessions_show_renders_session(cli_runner: CliRunner, isolated_sessions_dir):
     _write_fake_session(
-        isolated_sessions_dir, "shw001", status="completed", total=2, completed=2, failed=0,
+        isolated_sessions_dir,
+        "sess001",
+        status="completed",
+        total=2,
+        completed=2,
+        failed=0,
         paths=["/data/crateA", "/data/crateB"],
     )
-    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "shw001"])
+    result = cli_runner.invoke(cli, ["--no-interactive", "sessions", "show", "sess001"])
     assert result.exit_code == 0, result.output
     out = result.output
     # Header, per-crate list (relative names + profile) and summary are all shown.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -665,7 +665,7 @@ def test_batch_validate_keep_results(tmp_path):
         profile_identifiers=["ro-crate"],
         no_auto_profile=True,
     )
-    assert dropped.results == [], "live results must not be retained by default"
+    assert dropped.live_results == [], "live results must not be retained by default"
     assert dropped.total_crates() == 1, "the session outcome is recorded regardless"
 
     kept = services.batch_validate(
@@ -676,8 +676,8 @@ def test_batch_validate_keep_results(tmp_path):
         no_auto_profile=True,
         keep_results=True,
     )
-    assert [path for path, _ in kept.results] == [crate]
-    assert all(hasattr(result, "passed") for _, result in kept.results)
+    assert [path for path, _ in kept.live_results] == [crate]
+    assert all(hasattr(result, "passed") for _, result in kept.live_results)
 
 
 def test_batch_prepare_session_auto_resume(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,6 +653,33 @@ def test_batch_verbose_details_rendered_from_session_entries():
     assert "RO-Crate metadata not found" in rendered
 
 
+def test_batch_validate_keep_results(tmp_path):
+    """Live results are dropped by default and retained only with keep_results=True."""
+    crate = str(ValidROC().wrroc_paper_long_date)
+    settings = ValidationSettings.parse({"profile_identifier": ("ro-crate",)})
+
+    dropped = services.batch_validate(
+        settings,
+        [crate],
+        session_path=tmp_path / "dropped.json",
+        profile_identifiers=["ro-crate"],
+        no_auto_profile=True,
+    )
+    assert dropped.results == [], "live results must not be retained by default"
+    assert dropped.total_crates() == 1, "the session outcome is recorded regardless"
+
+    kept = services.batch_validate(
+        settings,
+        [crate],
+        session_path=tmp_path / "kept.json",
+        profile_identifiers=["ro-crate"],
+        no_auto_profile=True,
+        keep_results=True,
+    )
+    assert [path for path, _ in kept.results] == [crate]
+    assert all(hasattr(result, "passed") for _, result in kept.results)
+
+
 def test_batch_prepare_session_auto_resume(tmp_path):
     """An interrupted session is auto-resumed: completed crates are carried over."""
     session_file = tmp_path / "auto_session.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -606,6 +606,51 @@ def test_batch_validate_mixed_crates(cli_runner: CliRunner, tmp_path):
     # Should fail because at least one crate fails
     assert result.exit_code == 1, result.output
     assert "Batch Validation Summary" in result.output
+    # Verbose per-crate details are rendered (from the session entries)
+    assert "Failed crate details:" in result.output
+
+
+def test_batch_verbose_details_rendered_from_session_entries():
+    """
+    Verbose failed-crate details must come from the persisted session entries:
+    no live ValidationResult is retained by a batch run (their contexts would
+    pin every crate's graphs in memory for the whole batch).
+    """
+    import io
+
+    from rocrate_validator.cli.ui.text.validate import BatchValidationCommandView
+    from rocrate_validator.models import BatchValidationResult
+    from rocrate_validator.utils.io_helpers.output.console import Console
+
+    session = BatchSession(validation_settings={}, crate_paths=["/tmp/crate_x", "/tmp/crate_y"])
+    failed = session.crates[0]
+    failed.status = "completed"
+    failed.passed = False
+    failed.duration = 1.2
+    failed.statistics = {"total_checks": 3, "total_passed_checks": 2, "total_failed_checks": 1}
+    failed.issues = [
+        {
+            "severity": "REQUIRED",
+            "message": "The root entity is missing",
+            "check": {"identifier": "ro-crate-1.1_1.1", "name": "Root entity existence"},
+        }
+    ]
+    errored = session.crates[1]
+    errored.status = "failed"
+    errored.passed = False
+    errored.error = "RO-Crate metadata not found"
+    session.completed_crates = 2
+    session.failed_crates = 2
+
+    out = Console(file=io.StringIO(), width=200, color_system=None)
+    BatchValidationCommandView(console=out).show_summary(BatchValidationResult(session), verbose=True)
+    rendered = out.file.getvalue()
+
+    assert "Failed crate details:" in rendered
+    assert "ro-crate-1.1_1.1" in rendered
+    assert "The root entity is missing" in rendered
+    # Entries that errored out (no check breakdown) show their error message
+    assert "RO-Crate metadata not found" in rendered
 
 
 def test_batch_prepare_session_auto_resume(tmp_path):


### PR DESCRIPTION
This PR adds **batch validation** to the CLI: `validate --batch` validates every RO-Crate found under a directory and aggregates the results, with progress reporting, a per-crate summary table and machine-readable outputs. Each run is recorded as an **auto-managed session** that is saved incrementally (one save per validated crate), so an interrupted run — `Ctrl+C`, a crash, a killed job — can be resumed from where it stopped, either automatically by re-running the same command or explicitly via the new `sessions` subcommand.

  ## What's included

  ### CLI — `validate --batch`
  - `--batch/-b` validates every crate under `RO-CRATE-URI` (subdirectory crates, zipped crates and detached `*-ro-crate-metadata.json` files); `--batch-pattern` filters the crate names.
  - Live progress bar on stderr (passed/failed/remaining), per-crate result lines, and a final summary table (size, status, checks, issues, duration per crate); `-v` adds the details of every failed crate.
  - Exit code reflects the aggregated outcome (0 only if every crate passed).
  - Output formats: `text` (console or file), `json`, `csv` (one row per crate).

  ### CLI — `sessions`
  - `sessions list` (alias `ls`): stored sessions with status, progress and target (`--status`, `--json`).
  - `sessions show <ID>`: re-render the recorded output of a session without re-validating anything; `--stats` for the statistics, `-o report.md -f md` to write them to a file.
  - `sessions resume <ID>`: continue an interrupted session (only the pending crates are processed).
  - `sessions clear` (alias `rm`) and `sessions path` to manage the history.
  - Interactive mode offers the stored sessions as a menu when no ID is given.

  ### Sessions & resumability
  - Sessions are stored under the user cache directory and keyed deterministically by scan target, profile
  selection and severity: re-running the same command resumes the same session automatically; `--no-resume` starts over. Changing profiles or severity intentionally starts a new session.
  - The session file records per-crate outcomes (status, checks counters, serialized issues, duration, size), so summaries and reports can be rebuilt entirely from what was saved.

  ### Memory behaviour

  Batch runs keep memory usage **flat regardless of the corpus size**: per-crate outcomes are persisted to the session file instead of being retained in memory (retaining every live `ValidationResult` pinned ~4 MB/crate and got large batches OOM-killed). Live results can still be retained explicitly for debugging or scripting purposes via `batch_validate(..., keep_results=True)`, exposed as `BatchValidationResult.live_results`; the recorded outcome of every crate is always available in `.crates`.

  ## Usage

```bash
# Validate every crate under a directory (auto-resumes if interrupted)
rocrate-validator validate --batch path/to/crates/ -p ro-crate-1.1

# Machine-readable report + statistics
rocrate-validator validate --batch path/to/crates/ -f csv -o report.csv
rocrate-validator validate --batch path/to/crates/ --stats

# Browse and resume past runs
rocrate-validator sessions list
rocrate-validator sessions resume <ID>
```