### PR TITLE
fix(cli): 🐛 disable Rich word-wrap in JSON validation report

### DIFF
--- a/rocrate_validator/cli/commands/validate.py
+++ b/rocrate_validator/cli/commands/validate.py
@@ -670,7 +670,10 @@ def _emit_json_report(
     with output_file.open("w", encoding="utf-8") if output_file else nullcontext(sys.stdout) as f:
         out = Console(width=output_line_width, file=f)
         out.register_formatter(JSONOutputFormatter())
-        out.print(results)
+        # Disable word-wrap/cropping: Rich would otherwise insert literal line
+        # breaks into long string values (e.g. messages, URLs), producing
+        # invalid, unescaped control characters in the JSON output.
+        out.print(results, soft_wrap=True)
 
     if interactive and output_file:
         console.print("[bold]DONE![/bold]", end="\n\n")


### PR DESCRIPTION
Rich's `Console.print()`was wrapping long string values (messages, URLs) in the JSON output at the configured line width, inserting literal newlines inside quoted strings and producing invalid JSON. Pass `soft_wrap=True` to emit the report unmodified.

[ fix #189 ]