### PR TITLE
fix: prevent misleading metadata validation errors

### DIFF
--- a/rocrate_validator/models/requirement.py
+++ b/rocrate_validator/models/requirement.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import importlib
-import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import total_ordering
@@ -226,11 +225,6 @@ class Requirement(ABC):
                 logger.debug("Skipping check '%s' because: %s", check.name, e)
                 context.result._add_skipped_check(check)
                 continue
-            except json.JSONDecodeError as e:
-                # The file descriptor is not valid JSON, so this check could not run.
-                # This is a malformed-input problem (reported as an ad-hoc issue by the
-                # dedicated "File Descriptor JSON format" check), not a validator bug.
-                logger.debug("Skipping check %s: file descriptor is not valid JSON: %s", check, e)
             except Exception as e:
                 if context.maybe_warn_offline_cache_miss(e):
                     logger.debug("Offline cache miss during check %s: %s", check, e)

--- a/rocrate_validator/profiles/ro-crate/1.1/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.1/must/0_file_descriptor_format.py
@@ -20,6 +20,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 from rocrate_validator.constants import HTTP_STATUS_OK
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -55,11 +56,7 @@ class FileDescriptorExistence(PyFunctionCheck):
         if context.settings.metadata_only:
             logger.debug("Skipping file descriptor existence check in metadata-only mode")
             return True
-        if not context.ro_crate.has_descriptor():
-            message = f"file descriptor {context.rel_fd_path} is empty"
-            context.result.add_issue(message, self)
-            return False
-        if context.ro_crate.metadata.size == 0:
+        if context.ro_crate.has_descriptor() and context.ro_crate.metadata.size == 0:
             context.result.add_issue(f'RO-Crate "{context.rel_fd_path}" file descriptor is empty', self)
             return False
         return True
@@ -89,6 +86,9 @@ class FileDescriptorJsonFormat(PyFunctionCheck):
             # The metadata cannot be parsed: abort to avoid false positives downstream.
             context.abort_validation(f"file descriptor is not valid JSON: {e}")
             return False
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor JSON check: metadata descriptor is not available")
+            return True
         except Exception:
             context.result.add_issue(
                 f'RO-Crate file descriptor "{context.rel_fd_path}" is not in the correct format', self
@@ -214,7 +214,8 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
 
     @check(name="File Descriptor @context property validation")
     def check_context(self, context: ValidationContext) -> bool:
-        """Check if the file descriptor contains
+        """
+        Check if the file descriptor contains
         the @context property and it is a valid JSON-LD context
         """
         try:
@@ -227,6 +228,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
 
             # Check if the context is valid
             return self.__check_contexts__(context, json_dict["@context"])
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor JSON-LD context check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Error extracting @context from file descriptor")
@@ -320,6 +324,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                     if fail_fast:
                         return False
             return result
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor flattening check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Error flattening JSON-LD file descriptor")
@@ -340,6 +347,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                     )
                     return False
             return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor identifier check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Error validating @id property of file descriptor entities")
@@ -359,6 +369,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                         self,
                     )
                     return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor type check: metadata descriptor is not available")
             return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
@@ -481,6 +494,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                         )
                 return False
 
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor compaction check: metadata descriptor is not available")
             return True
         except Exception as e:
             if logger.isEnabledFor(logging.DEBUG):

--- a/rocrate_validator/profiles/ro-crate/1.1/must/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/1.1/must/4_data_entity_metadata.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -42,7 +43,12 @@ class DataEntityRequiredChecker(PyFunctionCheck):
         # Web-based Data Entities (absolute URIs with any scheme other than `file`,
         # e.g. http://, https://, ftp://, scp://, s3://, ...) are not required to
         # be part of the local payload per the RO-Crate specification.
-        for entity in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True):
+        try:
+            entities = context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
             try:

--- a/rocrate_validator/profiles/ro-crate/1.1/should/2_root_data_entity_relative_uri.py
+++ b/rocrate_validator/profiles/ro-crate/1.1/should/2_root_data_entity_relative_uri.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -35,6 +36,9 @@ class RootDataEntityRelativeURI(PyFunctionCheck):
             if context.ro_crate.metadata.get_root_data_entity().id != "./":
                 context.result.add_issue("Root Data Entity URI is not denoted by the string `./`", self)
                 return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity URI check: metadata descriptor is not available")
             return True
         except Exception as e:
             context.result.add_issue(f"Error checking Root Data Entity URI: {e!s}", self)

--- a/rocrate_validator/profiles/ro-crate/1.1/should/4_data_entity_existence.py
+++ b/rocrate_validator/profiles/ro-crate/1.1/should/4_data_entity_existence.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -41,11 +42,16 @@ class DataEntityRecommendedChecker(PyFunctionCheck):
             return True
         # Perform the check
         result = True
-        for entity in [
-            _
-            for _ in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)
-            if _.has_absolute_path()
-        ]:
+        try:
+            entities = [
+                _
+                for _ in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)
+                if _.has_absolute_path()
+            ]
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             try:
                 if not entity.is_available():

--- a/rocrate_validator/profiles/ro-crate/1.1/should/5_web_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/1.1/should/5_web_data_entity_metadata.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -42,7 +43,12 @@ class WebDataEntityRecommendedChecker(PyFunctionCheck):
         and logged as warnings, without invalidating the validation.
         """
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             try:
                 status = entity.check_availability()
@@ -81,7 +87,12 @@ class WebDataEntityRecommendedChecker(PyFunctionCheck):
         and if it is set to actual size of the downloadable content
         """
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity content size check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             # Skip entities whose scheme the validator cannot natively fetch
             # (e.g. scp://, s3://): without retrieving the content there is

--- a/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
@@ -15,7 +15,6 @@
 import json
 import re
 from http import HTTPStatus
-from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
 
@@ -105,9 +104,7 @@ class FileDescriptorEncodingCheck(PyFunctionCheck):
             logger.debug("Skipping file descriptor encoding check in metadata-only mode")
             return True
         try:
-            raw_data = context.ro_crate.get_file_content(
-                Path(context.ro_crate.metadata_descriptor_id), binary_mode=True
-            )
+            raw_data = context.ro_crate.metadata.as_bytes()
             if isinstance(raw_data, str):
                 return True
             raw_data.decode("utf-8")

--- a/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
@@ -112,10 +112,10 @@ class FileDescriptorEncodingCheck(PyFunctionCheck):
                 return True
             raw_data.decode("utf-8")
             return True
-        except Exception:
+        except UnicodeDecodeError:
             context.result.add_issue(f'RO-Crate file descriptor "{context.rel_fd_path}" is not UTF-8 encoded', self)
             if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Unexpected error during file descriptor validation")
+                logger.debug("RO-Crate file descriptor is not UTF-8 encoded", exc_info=True)
             return False
 
 

--- a/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
@@ -101,6 +101,9 @@ class FileDescriptorEncodingCheck(PyFunctionCheck):
         """
         Check if the file descriptor is UTF-8 encoded
         """
+        if context.settings.metadata_only:
+            logger.debug("Skipping file descriptor encoding check in metadata-only mode")
+            return True
         try:
             raw_data = context.ro_crate.get_file_content(
                 Path(context.ro_crate.metadata_descriptor_id), binary_mode=True

--- a/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/0_file_descriptor_format.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from typing import Any
 from urllib.parse import urljoin
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -79,11 +80,7 @@ class FileDescriptorExistence(PyFunctionCheck):
         if context.settings.metadata_only:
             logger.debug("Skipping file descriptor existence check in metadata-only mode")
             return True
-        if not context.ro_crate.has_descriptor():
-            message = f"file descriptor {context.rel_fd_path} is empty"
-            context.result.add_issue(message, self)
-            return False
-        if context.ro_crate.metadata.size == 0:
+        if context.ro_crate.has_descriptor() and context.ro_crate.metadata.size == 0:
             context.result.add_issue(f'RO-Crate "{context.rel_fd_path}" file descriptor is empty', self)
             return False
         return True
@@ -114,6 +111,9 @@ class FileDescriptorEncodingCheck(PyFunctionCheck):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("RO-Crate file descriptor is not UTF-8 encoded", exc_info=True)
             return False
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor encoding check: metadata descriptor is not available")
+            return True
 
 
 @requirement(name="File Descriptor JSON format")
@@ -140,6 +140,9 @@ class FileDescriptorJsonFormat(PyFunctionCheck):
             # The metadata cannot be parsed: abort to avoid false positives downstream.
             context.abort_validation(f"file descriptor is not valid JSON: {e}")
             return False
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor JSON check: metadata descriptor is not available")
+            return True
         except Exception:
             context.result.add_issue(
                 f'RO-Crate file descriptor "{context.rel_fd_path}" is not in the correct format', self
@@ -250,7 +253,8 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
 
     @check(name="File Descriptor @context property validation")
     def check_context(self, context: ValidationContext) -> bool:
-        """Check if the file descriptor contains
+        """
+        Check if the file descriptor contains
         the @context property and it is a valid JSON-LD context
         """
         try:
@@ -281,6 +285,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
 
             # Check if the context is valid
             return self.__check_contexts__(context, json_dict["@context"])
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor JSON-LD context check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Unexpected error during file descriptor validation")
@@ -380,6 +387,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                     if fail_fast:
                         return False
             return result
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor flattening check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Unexpected error during file descriptor validation")
@@ -399,6 +409,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                         self,
                     )
                     return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor identifier check: metadata descriptor is not available")
             return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
@@ -420,6 +433,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                     )
                     return False
             return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor type check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Unexpected error during file descriptor validation")
@@ -436,6 +452,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                     f"Duplicate @id values detected in RO-Crate metadata: {sorted(duplicates)}", self
                 )
                 return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping unique identifier check: metadata descriptor is not available")
             return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
@@ -483,6 +502,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                         context.result.add_issue(message, self)
                         return False
             return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping entity reference check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Unexpected error during file descriptor validation")
@@ -501,6 +523,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                 if "keyword" in entity:
                     context.result.add_issue(f"Entity '{entity_id}' should use schema.org 'keywords'", self)
                     return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping subject and keyword check: metadata descriptor is not available")
             return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
@@ -618,6 +643,9 @@ class FileDescriptorJsonLdFormat(PyFunctionCheck):
                         )
                 return False
 
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping file descriptor compaction check: metadata descriptor is not available")
             return True
         except Exception as e:
             if logger.isEnabledFor(logging.DEBUG):

--- a/rocrate_validator/profiles/ro-crate/1.2/must/1_ro_crate_preview.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/1_ro_crate_preview.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -30,7 +31,11 @@ class ROCrateWebsiteChecker(PyFunctionCheck):
 
     @check(name="RO-Crate Website HTML5 doctype")
     def check_preview_html(self, context: ValidationContext) -> bool:
-        if context.ro_crate.is_detached():
+        try:
+            if context.ro_crate.is_detached():
+                return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping RO-Crate Website check: metadata descriptor is not available")
             return True
         preview_path = Path("ro-crate-preview.html")
         if not context.ro_crate.has_file(preview_path):

--- a/rocrate_validator/profiles/ro-crate/1.2/must/2_root_data_entity_cite_as.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/2_root_data_entity_cite_as.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -81,6 +82,9 @@ class CiteAsDownloadableChecker(PyFunctionCheck):
             )
             return True
 
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity cite-as check: metadata descriptor is not available")
+            return True
         except Exception as e:
             context.result.add_issue(f"Error checking `cite-as` downloadability: {e!s}", self)
             return False

--- a/rocrate_validator/profiles/ro-crate/1.2/must/2_root_data_entity_identifier.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/2_root_data_entity_identifier.py
@@ -14,6 +14,7 @@
 
 import re
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -42,6 +43,9 @@ class RootDataEntityIdentifierChecker(PyFunctionCheck):
                 self,
             )
             return False
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity identifier check: metadata descriptor is not available")
+            return True
         except Exception as e:
             context.result.add_issue(f"Error checking Root Data Entity @id: {e!s}", self)
             return False

--- a/rocrate_validator/profiles/ro-crate/1.2/must/2_root_identifier_property.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/2_root_identifier_property.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -42,6 +43,9 @@ class RootIdentifierPropertyChecker(PyFunctionCheck):
                 if not identifier.get_property("value"):
                     context.result.add_issue("PropertyValue identifiers MUST include a `value`", self)
                     return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity identifier check: metadata descriptor is not available")
             return True
         except Exception as e:
             context.result.add_issue(f"Error checking identifier PropertyValue: {e!s}", self)

--- a/rocrate_validator/profiles/ro-crate/1.2/must/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/must/4_data_entity_metadata.py
@@ -15,6 +15,7 @@
 import contextlib
 import re
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -31,11 +32,16 @@ class DataEntityRequiredChecker(PyFunctionCheck):
     """
 
     @check(name="Data Entity: REQUIRED resource availability")
-    def check_availability(self, context: ValidationContext) -> bool:
+    def check_availability(self, context: ValidationContext) -> bool:  # noqa: C901
         """
         Check the presence of the Data Entity in the RO-Crate
         """
-        if context.ro_crate.is_detached():
+        try:
+            is_detached = context.ro_crate.is_detached()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity availability check: metadata descriptor is not available")
+            return True
+        if is_detached:
             logger.debug("Skipping data entity payload checks for detached RO-Crate")
             return True
         # Skip the check in metadata-only mode
@@ -44,7 +50,12 @@ class DataEntityRequiredChecker(PyFunctionCheck):
             return True
         # Perform the check
         result = True
-        for entity in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True):
+        try:
+            entities = context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             logger.debug("Ensure the presence of the Data Entity '%s' within the RO-Crate", entity.id)
             try:
@@ -94,13 +105,23 @@ class DetachedDataEntityChecker(PyFunctionCheck):
 
     @check(name="Detached RO-Crate: data entities MUST be web-based")
     def check_detached_entities(self, context: ValidationContext) -> bool:
-        if not context.ro_crate.is_detached():
+        try:
+            is_detached = context.ro_crate.is_detached()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping detached Data Entity check: metadata descriptor is not available")
+            return True
+        if not is_detached:
             return True
         result = True
         root_entity_id = None
         with contextlib.suppress(Exception):
             root_entity_id = context.ro_crate.metadata.get_root_data_entity().id
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping detached Data Entity check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if root_entity_id and entity.id == root_entity_id:
                 continue
             if not entity.is_remote():
@@ -123,7 +144,7 @@ class DataEntityIdentifierChecker(PyFunctionCheck):
     """
 
     @check(name="Data Entity: @id value requirements")
-    def check_identifiers(self, context: ValidationContext) -> bool:
+    def check_identifiers(self, context: ValidationContext) -> bool:  # noqa: C901
         result = True
         root_entity_id = None
         root_entity_is_local = False
@@ -135,7 +156,12 @@ class DataEntityIdentifierChecker(PyFunctionCheck):
                 root_data_entity.id_as_uri.is_local_resource() if root_data_entity.id_as_uri else False
             )
             root_entity_absolute_path = root_data_entity.id_as_path if root_data_entity.has_absolute_path() else None
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity identifier check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if root_entity_id and entity.id == root_entity_id:
                 continue
             if not root_entity_is_local and not entity.is_remote():
@@ -172,10 +198,20 @@ class DataEntityIdentifierChecker(PyFunctionCheck):
 
     @check(name="Data Entity: relative @id for payload files")
     def check_relative_paths(self, context: ValidationContext) -> bool:
-        if context.ro_crate.is_detached():
+        try:
+            is_detached = context.ro_crate.is_detached()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping relative Data Entity identifier check: metadata descriptor is not available")
+            return True
+        if is_detached:
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping relative Data Entity identifier check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if entity.has_local_identifier() or entity.is_remote():
                 continue
             if entity.has_absolute_path() and (
@@ -199,7 +235,12 @@ class DataEntityCitationChecker(PyFunctionCheck):
     @check(name="Data Entity: citation must include @id")
     def check_citation(self, context: ValidationContext) -> bool:
         result = True
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity citation check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             citations = entity.get_property("citation")
             if citations is None:
                 continue
@@ -256,7 +297,12 @@ class WebDataEntityRequiredChecker(PyFunctionCheck):
         ):
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             # Skip directory URIs: assumed available, not directly downloadable by spec
             if entity.id.endswith("/"):

--- a/rocrate_validator/profiles/ro-crate/1.2/should/0_entity_identifier_format.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/0_entity_identifier_format.py
@@ -22,6 +22,7 @@ RECOMMENDED checks on entity @id values:
 import contextlib
 import re
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -52,7 +53,12 @@ class EntityIdentifierFormatChecker(PyFunctionCheck):
         (RO-Crate 1.2, JSON-LD appendix).
         """
         result = True
-        for entity in context.ro_crate.metadata.as_dict().get("@graph", []):
+        try:
+            entities = context.ro_crate.metadata.as_dict().get("@graph", [])
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping parent traversal check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             entity_id = entity.get("@id", "")
             if "../" in entity_id:
                 context.result.add_issue(
@@ -75,7 +81,12 @@ class EntityIdentifierFormatChecker(PyFunctionCheck):
         UTF-8 rather than percent-encoded (RO-Crate 1.2, JSON-LD appendix).
         """
         result = True
-        for entity in context.ro_crate.metadata.as_dict().get("@graph", []):
+        try:
+            entities = context.ro_crate.metadata.as_dict().get("@graph", [])
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping entity identifier encoding check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             entity_id = entity.get("@id", "")
             if _PCT_NON_ASCII_RE.search(entity_id):
                 context.result.add_issue(
@@ -110,7 +121,12 @@ class EntityIdentifierFormatChecker(PyFunctionCheck):
         with contextlib.suppress(Exception):
             non_contextual_ids.update(e.id for e in ro_crate_metadata.get_data_entities())
 
-        for entity in ro_crate_metadata.as_dict().get("@graph", []):
+        try:
+            entities = ro_crate_metadata.as_dict().get("@graph", [])
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping named entity identifier check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             entity_id = entity.get("@id", "")
             if entity_id in non_contextual_ids:
                 continue

--- a/rocrate_validator/profiles/ro-crate/1.2/should/2_root_data_entity_identifier.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/2_root_data_entity_identifier.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -28,7 +29,7 @@ class DetachedROCrateRootDataEntityIdentifierChecker(PyFunctionCheck):
     """
 
     @check(name="Root Data Entity: RECOMMENDED identifier")
-    def check_identifier(self, context: ValidationContext) -> bool:
+    def check_identifier(self, context: ValidationContext) -> bool:  # noqa: PLR0911
         """
         In a detached RO-Crate, the Root Data Entity @id SHOULD be an absolute URI.
         """
@@ -51,6 +52,9 @@ class DetachedROCrateRootDataEntityIdentifierChecker(PyFunctionCheck):
                 return False
 
             return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity identifier check: metadata descriptor is not available")
+            return True
         except Exception as e:
             context.result.add_issue(f"Error checking Root Data Entity @id: {e!s}", self)
             return False
@@ -64,7 +68,7 @@ class RootDataEntityCiteAsIdentifierChecker(PyFunctionCheck):
     """
 
     @check(name="Root Data Entity: use cite-as for resolvable identifiers")
-    def check_cite_as_reference(self, context: ValidationContext) -> bool:
+    def check_cite_as_reference(self, context: ValidationContext) -> bool:  # noqa: PLR0911
         """
         If the Root Data Entity has a resolvable identifier,
         it SHOULD be included in the `cite-as` property of the RO-Crate Metadata Entity.
@@ -95,6 +99,9 @@ class RootDataEntityCiteAsIdentifierChecker(PyFunctionCheck):
                 )
                 return False
 
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity cite-as check: metadata descriptor is not available")
             return True
         except Exception as e:
             context.result.add_issue(f"Error checking Root Data Entity `cite-as` reference: {e!s}", self)
@@ -140,7 +147,7 @@ class RootDataEntityPersistentIdentifierChecker(PyFunctionCheck):
     """
 
     @check(name="Root Data Entity: identifier SHOULD resolve to RO-Crate content", severity=Severity.RECOMMENDED)
-    def check_identifier_resolvable(self, context: ValidationContext) -> bool:
+    def check_identifier_resolvable(self, context: ValidationContext) -> bool:  # noqa: PLR0911
         if context.settings.skip_availability_check:
             return True
         if context.settings.metadata_only:
@@ -169,6 +176,9 @@ class RootDataEntityPersistentIdentifierChecker(PyFunctionCheck):
                     context.result.add_issue(msg, self)
                     result = False
             return result
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Root Data Entity identifier resolution check: metadata descriptor is not available")
+            return True
         except Exception as e:
             context.result.add_issue(f"Error checking Root Data Entity identifier resolution: {e!s}", self)
             return False

--- a/rocrate_validator/profiles/ro-crate/1.2/should/4_data_entity_license.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/4_data_entity_license.py
@@ -46,6 +46,7 @@
 # check provides actionable feedback to authors without penalising
 # valid crates.
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -100,7 +101,7 @@ class DataEntityLicenseDivergenceChecker(PyFunctionCheck):
     """
 
     @check(name="Data Entity SHOULD NOT redundantly declare the Root license", severity=Severity.RECOMMENDED)
-    def check_license_divergence(self, context: ValidationContext) -> bool:
+    def check_license_divergence(self, context: ValidationContext) -> bool:  # noqa: C901
         root_entity = None
         try:
             root_entity = context.ro_crate.metadata.get_root_data_entity()
@@ -117,7 +118,12 @@ class DataEntityLicenseDivergenceChecker(PyFunctionCheck):
         if not root_license_id:
             return True
 
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity license check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if entity.id == root_entity.id:
                 continue
             entity_license_raw = entity.get_property("license")

--- a/rocrate_validator/profiles/ro-crate/1.2/should/4_data_entity_metadata.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/4_data_entity_metadata.py
@@ -14,6 +14,7 @@
 
 import re
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -32,7 +33,12 @@ class DataEntityCitationChecker(PyFunctionCheck):
     @check(name="Data Entity: citation must include @id")
     def check_citation(self, context: ValidationContext) -> bool:
         result = True
-        for entity in context.ro_crate.metadata.get_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Data Entity citation check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             citations = entity.get_property("citation")
             if citations is None:
                 continue
@@ -90,7 +96,12 @@ class WebDataEntityRequiredChecker(PyFunctionCheck):
         ):
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity availability check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             if entity.id.endswith("/"):
                 continue
@@ -107,11 +118,16 @@ class WebDataEntityRequiredChecker(PyFunctionCheck):
         return result
 
     @check(name="Web-based Data Entity: `contentSize` property", severity=Severity.RECOMMENDED)
-    def check_content_size(self, context: ValidationContext) -> bool:
+    def check_content_size(self, context: ValidationContext) -> bool:  # noqa: C901
         if context.settings.skip_availability_check:
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity content size check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             assert entity.id is not None, "Entity has no @id"
             if entity.is_available():
                 content_size = entity.get_property("contentSize")
@@ -143,11 +159,16 @@ class WebDataEntityRequiredChecker(PyFunctionCheck):
         return result
 
     @check(name="Web-based Data Entity: `contentUrl` availability", severity=Severity.RECOMMENDED)
-    def check_content_url(self, context: ValidationContext) -> bool:
+    def check_content_url(self, context: ValidationContext) -> bool:  # noqa: C901
         if context.settings.skip_availability_check:
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_web_data_entities():
+        try:
+            entities = context.ro_crate.metadata.get_web_data_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping web-based Data Entity content URL check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             content_url = entity.get_property("contentUrl")
             if not content_url:
                 continue

--- a/rocrate_validator/profiles/ro-crate/1.2/should/4_missing_file_local_path.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/4_missing_file_local_path.py
@@ -32,6 +32,7 @@
 
 import contextlib
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -100,13 +101,23 @@ class MissingFileLocalPathChecker(PyFunctionCheck):
 
     @check(name="Missing local File SHOULD use localPath", severity=Severity.RECOMMENDED)
     def check_missing_file_local_path(self, context: ValidationContext) -> bool:
-        if context.ro_crate.is_detached() or context.settings.metadata_only:
+        try:
+            is_detached = context.ro_crate.is_detached()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping missing local file check: metadata descriptor is not available")
+            return True
+        if is_detached or context.settings.metadata_only:
             return True
         root_entity_id = None
         with contextlib.suppress(Exception):
             root_entity_id = context.ro_crate.metadata.get_root_data_entity().id
         result = True
-        for entity in context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True):
+        try:
+            entities = context.ro_crate.metadata.get_data_entities(exclude_web_data_entities=True)
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping missing local file check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if root_entity_id and entity.id == root_entity_id:
                 continue
             if not entity.is_file():

--- a/rocrate_validator/profiles/ro-crate/1.2/should/4_referenced_rocrate.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/4_referenced_rocrate.py
@@ -23,6 +23,7 @@ relaxes that obligation when the URI declares Signposting
 This Python check performs the network-dependent refinement.
 """
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -81,7 +82,12 @@ class ReferencedROCrateSignpostingCiteAsChecker(PyFunctionCheck):
         except Exception:
             return True
 
-        for entity in context.ro_crate.metadata.get_dataset_entities():
+        try:
+            entities = context.ro_crate.metadata.get_dataset_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping referenced RO-Crate check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             if not self._needs_sddatepublished_check(entity, root.id):
                 continue
             entity_id = entity.id

--- a/rocrate_validator/profiles/ro-crate/1.2/should/4_web_dataset_distribution.py
+++ b/rocrate_validator/profiles/ro-crate/1.2/should/4_web_dataset_distribution.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import Severity, ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -83,7 +84,12 @@ class DatasetDistributionChecker(PyFunctionCheck):
         if context.settings.skip_availability_check or context.settings.metadata_only:
             return True
         result = True
-        for entity in context.ro_crate.metadata.get_dataset_entities():
+        try:
+            entities = context.ro_crate.metadata.get_dataset_entities()
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping Dataset distribution check: metadata descriptor is not available")
+            return True
+        for entity in entities:
             distribution_raw = entity.get_property("distribution")
             if not distribution_raw:
                 continue

--- a/rocrate_validator/profiles/workflow-ro-crate/may/1_main_workflow.py
+++ b/rocrate_validator/profiles/workflow-ro-crate/may/1_main_workflow.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -44,6 +45,9 @@ class WorkflowFilesExistence(PyFunctionCheck):
                 context.result.add_issue(f"Workflow diagram '{image.id}' not found in crate", self)
                 return False
             return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping workflow diagram check: metadata descriptor is not available")
+            return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.exception("Unexpected error checking main workflow image existence")
@@ -64,6 +68,9 @@ class WorkflowFilesExistence(PyFunctionCheck):
                     f"Workflow CWL description {main_workflow_subject.id} not found in crate", self
                 )
                 return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping workflow description check: metadata descriptor is not available")
             return True
         except Exception:
             if logger.isEnabledFor(logging.DEBUG):

--- a/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
+++ b/rocrate_validator/profiles/workflow-ro-crate/must/0_main_workflow.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=invalid-name  # profile filename uses digit prefix (load-order convention)
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import ValidationContext
 from rocrate_validator.requirements.python import PyFunctionCheck, check, requirement
 from rocrate_validator.utils import log as logging
@@ -37,6 +38,9 @@ class MainWorkflowFileExistence(PyFunctionCheck):
             if not context.settings.metadata_only and not main_workflow.is_available():
                 context.result.add_issue(f"Main Workflow {main_workflow.id} not found in crate", self)
                 return False
+            return True
+        except ROCrateMetadataNotFoundError:
+            logger.debug("Skipping main workflow check: metadata descriptor is not available")
             return True
         except ValueError:
             context.result.add_issue(

--- a/rocrate_validator/requirements/shacl/checks.py
+++ b/rocrate_validator/requirements/shacl/checks.py
@@ -277,7 +277,7 @@ class SHACLCheck(RequirementCheck):
                 "Unable to perform metadata validation due to missing metadata file: %s",
                 e,
             )
-            return False
+            return True
 
     def __do_execute_check__(self, shacl_context: SHACLValidationContext):
         # get the shapes registry

--- a/rocrate_validator/requirements/shacl/requirements.py
+++ b/rocrate_validator/requirements/shacl/requirements.py
@@ -18,6 +18,7 @@ from typing import Any, cast  # pylint: disable=unused-import
 from rdflib import RDF
 
 from rocrate_validator.constants import VALIDATOR_NS
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.models import (
     Profile,
     Requirement,
@@ -139,6 +140,12 @@ class SHACLRequirement(Requirement):
         shacl_context._current_validation_profile = target
         try:
             runner.__do_execute_check__(shacl_context)
+        except ROCrateMetadataNotFoundError as e:
+            logger.debug(
+                "Forced SHACL run for zero-shape target profile %s skipped: metadata descriptor is not available (%s)",
+                target.identifier,
+                e,
+            )
         except Exception as e:
             if context.maybe_warn_offline_cache_miss(e):
                 logger.debug(

--- a/rocrate_validator/rocrate/metadata.py
+++ b/rocrate_validator/rocrate/metadata.py
@@ -150,6 +150,12 @@ class ROCrateMetadata:
                 path=self.ro_crate.metadata_descriptor_id,
             ) from e
 
+    def as_bytes(self) -> bytes:
+        """Return the raw metadata descriptor content."""
+        if self._dict is not None:
+            return self.as_json().encode("utf-8")
+        return cast("bytes", self.__get_file_content__(binary_mode=True))
+
     def as_json(self) -> str:
         if not self._json:
             self._json = cast("str", self.__get_file_content__(binary_mode=False))

--- a/rocrate_validator/rocrate/metadata.py
+++ b/rocrate_validator/rocrate/metadata.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from rdflib import Graph
 
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
 from rocrate_validator.utils import log as logging
 
 from .entity import ROCrateEntity
@@ -139,11 +140,19 @@ class ROCrateMetadata:
                 logger.exception("Error getting entity identifiers by type")
             return None
 
+    def __get_file_content__(self, binary_mode: bool) -> str | bytes:
+        """Read the metadata descriptor and identify a missing descriptor explicitly."""
+        try:
+            return self.ro_crate.get_file_content(Path(self.ro_crate.metadata_descriptor_id), binary_mode=binary_mode)
+        except FileNotFoundError as e:
+            raise ROCrateMetadataNotFoundError(
+                message=str(e),
+                path=self.ro_crate.metadata_descriptor_id,
+            ) from e
+
     def as_json(self) -> str:
         if not self._json:
-            self._json = cast(
-                "str", self.ro_crate.get_file_content(Path(self.ro_crate.metadata_descriptor_id), binary_mode=False)
-            )
+            self._json = cast("str", self.__get_file_content__(binary_mode=False))
         return self._json
 
     def as_dict(self) -> dict[Any, Any]:

--- a/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
+++ b/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
@@ -92,9 +92,12 @@ def test_missing_descriptor_does_not_emit_unexpected_warnings(monkeypatch, tmp_p
 
     issues = [issue.message for issue in result.get_issues()]
     assert result.passed() is False
-    assert any('file descriptor "ro-crate-metadata.json" is not present' in issue for issue in issues)
+    assert any(
+        issue is not None and 'file descriptor "ro-crate-metadata.json" is not present' in issue for issue in issues
+    )
     assert not any(
-        any(message in issue for message in ("Unexpected error", "Error checking", "not in the correct format"))
+        issue is not None
+        and any(message in issue for message in ("Unexpected error", "Error checking", "not in the correct format"))
         for issue in issues
     )
     assert requirement_logger.warning.call_count == 0
@@ -167,8 +170,10 @@ def test_invalid_context_reference():
         profile_identifier="ro-crate-1.2",
         expected_triggered_requirements=["File Descriptor JSON-LD format"],
         expected_triggered_issues=[
-            'RO-Crate file descriptor "ro-crate-metadata.json" '
-            'does not reference the required context "https://w3id.org/ro/crate/1.2/context"'
+            (
+                'RO-Crate file descriptor "ro-crate-metadata.json" '
+                'does not reference the required context "https://w3id.org/ro/crate/1.2/context"'
+            )
         ],
     )
 
@@ -238,8 +243,10 @@ def test_not_described_contextual_entity():
         profile_identifier="ro-crate-1.2",
         expected_triggered_requirements=["Contextual Entity RECOMMENDED description"],
         expected_triggered_issues=[
-            "Contextual entities that are referenced by other entities SHOULD be "
-            "described in the same @graph, with at least an RDF type specified."
+            (
+                "Contextual entities that are referenced by other entities SHOULD be "
+                "described in the same @graph, with at least an RDF type specified."
+            )
         ],
     )
 

--- a/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
+++ b/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 
 from rocrate_validator import models
+from rocrate_validator.rocrate.plain import ROCrateLocalFolder
 from tests.ro_crates_v1_2 import MetadataDocument, MetadataDocumentFormat
 from tests.shared import do_entity_test
 
@@ -37,6 +39,33 @@ def test_not_utf8():
         expected_triggered_requirements=["File Descriptor UTF-8 encoding"],
         expected_triggered_issues=['RO-Crate file descriptor "ro-crate-metadata.json" is not UTF-8 encoded'],
     )
+
+
+def test_utf8_check_is_skipped_for_metadata_dict(monkeypatch, tmp_path):
+    """Metadata-only validation must not read a file descriptor from the CWD."""
+    crate_path = __metadata_document_crates__.valid_context_reference
+    with (crate_path / "ro-crate-metadata.json").open(encoding="utf-8") as stream:
+        metadata_dict = json.load(stream)
+
+    descriptor_reads = []
+    original_get_file_content = ROCrateLocalFolder.get_file_content
+
+    def track_descriptor_reads(crate, path, binary_mode=True):
+        if path.name == "ro-crate-metadata.json":
+            descriptor_reads.append((path, binary_mode))
+        return original_get_file_content(crate, path, binary_mode)
+
+    monkeypatch.setattr(ROCrateLocalFolder, "get_file_content", track_descriptor_reads)
+    monkeypatch.chdir(tmp_path)
+    do_entity_test(
+        crate_path,
+        models.Severity.REQUIRED,
+        True,
+        profile_identifier="ro-crate-1.2",
+        metadata_dict=metadata_dict,
+        metadata_only=True,
+    )
+    assert descriptor_reads == []
 
 
 def test_not_json():

--- a/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
+++ b/tests/integration/profiles/ro-crate-1.2/test_metadata_document.py
@@ -14,9 +14,16 @@
 
 import json
 import logging
+from unittest.mock import MagicMock
 
-from rocrate_validator import models
+import pytest
+
+from rocrate_validator import models, services
+from rocrate_validator.errors import ROCrateMetadataNotFoundError
+from rocrate_validator.models import requirement as requirement_module
+from rocrate_validator.requirements.shacl import requirements as shacl_requirements_module
 from rocrate_validator.rocrate.plain import ROCrateLocalFolder
+from rocrate_validator.utils.uri import URI
 from tests.ro_crates_v1_2 import MetadataDocument, MetadataDocumentFormat
 from tests.shared import do_entity_test
 
@@ -66,6 +73,43 @@ def test_utf8_check_is_skipped_for_metadata_dict(monkeypatch, tmp_path):
         metadata_only=True,
     )
     assert descriptor_reads == []
+
+
+def test_missing_descriptor_does_not_emit_unexpected_warnings(monkeypatch, tmp_path):
+    """Checks depending on metadata should defer to the descriptor checks."""
+    requirement_logger = MagicMock()
+    shacl_logger = MagicMock()
+    monkeypatch.setattr(requirement_module, "logger", requirement_logger)
+    monkeypatch.setattr(shacl_requirements_module, "logger", shacl_logger)
+
+    result = services.validate(
+        models.ValidationSettings(
+            rocrate_uri=URI(tmp_path),
+            profile_identifier="ro-crate-1.2",
+            requirement_severity=models.Severity.OPTIONAL,
+        )
+    )
+
+    issues = [issue.message for issue in result.get_issues()]
+    assert result.passed() is False
+    assert any('file descriptor "ro-crate-metadata.json" is not present' in issue for issue in issues)
+    assert not any(
+        any(message in issue for message in ("Unexpected error", "Error checking", "not in the correct format"))
+        for issue in issues
+    )
+    assert requirement_logger.warning.call_count == 0
+    assert shacl_logger.warning.call_count == 0
+
+
+def test_missing_descriptor_raises_specific_metadata_error(tmp_path):
+    """Reading a missing descriptor must preserve its metadata-specific cause."""
+    crate = ROCrateLocalFolder(tmp_path)
+
+    with pytest.raises(ROCrateMetadataNotFoundError) as error:
+        crate.metadata.as_dict()
+
+    assert error.value.path == "ro-crate-metadata.json"
+    assert isinstance(error.value.__cause__, FileNotFoundError)
 
 
 def test_not_json():


### PR DESCRIPTION
This PR primarily fixes the false "not UTF-8 encoded" issue reported in #192 when validating metadata-only RO-Crates. It also prevents misleading metadata validation errors and redundant warnings when the metadata descriptor is unavailable.

When validation is performed from an in-memory metadata_dict, no metadata descriptor is available on disk. Previously, the file descriptor encoding check still attempted to read `ro-crate-metadata.json` relative to the current working directory. If the file was missing, the resulting `FileNotFoundError` was caught and incorrectly reported as an encoding failure.

The encoding check now returns early in metadata-only mode, consistently with the existing file descriptor existence and size checks. During regular file-based validation, it reports an encoding issue only when UTF-8 decoding raises `UnicodeDecodeError`, preventing unrelated errors from being misclassified as encoding problems.

`ROCrateMetadata` now wraps a missing descriptor `FileNotFoundError` in `ROCrateMetadataNotFoundError`, preserving the original exception as its cause and identifying `ro-crate-metadata.json` as the missing file. Raw descriptor bytes are also exposed through the metadata abstraction so that encoding checks no longer need to access the descriptor independently.

When the metadata descriptor is missing, dedicated descriptor checks already report the problem. Metadata-dependent checks now handle `ROCrateMetadataNotFoundError` locally and skip validation without emitting duplicate issues or warnings.

### Future Work

This PR partially addresses the broader exception-handling problem described in #199 by moving the handling of expected metadata descriptor errors from the global requirement runner to the individual checks responsible for them.

More comprehensive handling of unexpected validation errors will be addressed in follow-up PRs. The scope of this PR is intentionally limited to preventing misleading UTF-8 diagnostics, avoiding duplicate warnings for missing descriptors, and narrowing local exception handling to the errors each check is responsible for reporting.


Fixes #192