### PR TITLE
 fix(versioning): avoid false version mismatch warnings

### DIFF
--- a/rocrate_validator/constants.py
+++ b/rocrate_validator/constants.py
@@ -17,6 +17,9 @@ import typing
 
 from rdflib import Namespace
 
+# Define the package distribution name
+PACKAGE_NAME = "roc-validator"
+
 # Define SHACL namespace
 SHACL_NS = "http://www.w3.org/ns/shacl#"
 

--- a/rocrate_validator/utils/versioning.py
+++ b/rocrate_validator/utils/versioning.py
@@ -18,12 +18,12 @@ import sys
 from importlib import metadata
 from pathlib import Path
 
+from rocrate_validator.constants import PACKAGE_NAME
 from rocrate_validator.utils import log as logging
 from rocrate_validator.utils.config import get_config, get_config_path
 
 # set up logging
 logger = logging.getLogger(__name__)
-PACKAGE_NAME = "roc-validator"
 
 
 def run_git_command(command: list[str], cwd: Path | None = None) -> str | None:

--- a/rocrate_validator/utils/versioning.py
+++ b/rocrate_validator/utils/versioning.py
@@ -15,69 +15,78 @@
 import re
 import subprocess
 import sys
+from importlib import metadata
+from pathlib import Path
 
 from rocrate_validator.utils import log as logging
-from rocrate_validator.utils.config import get_config
+from rocrate_validator.utils.config import get_config, get_config_path
 
 # set up logging
 logger = logging.getLogger(__name__)
+PACKAGE_NAME = "roc-validator"
 
 
-def run_git_command(command: list[str]) -> str | None:
+def run_git_command(command: list[str], cwd: Path | None = None) -> str | None:
     """
     Run a git command and return the output
 
     :param command: The git command
+    :param cwd: The directory in which to run the command
     :return: The output of the command
     """
 
     try:
-        return subprocess.check_output(command, stderr=subprocess.DEVNULL).decode().strip()
+        return subprocess.check_output(command, cwd=cwd, stderr=subprocess.DEVNULL).decode().strip()
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(e)
         return None
 
 
-def get_git_commit() -> str:
+def get_git_commit(cwd: Path | None = None) -> str:
     """
     Get the git commit hash
 
+    :param cwd: The directory of the git repository
     :return: The git commit hash
     """
-    return run_git_command(["git", "rev-parse", "--short", "HEAD"]) or ""
+    return run_git_command(["git", "rev-parse", "--short", "HEAD"], cwd=cwd) or ""
 
 
-def is_release_tag(git_sha: str) -> bool:
+def is_release_tag(git_sha: str, cwd: Path | None = None) -> bool:
     """
     Check whether a git sha corresponds to a release tag
 
     :param git_sha: The git sha
+    :param cwd: The directory of the git repository
     :return: True if the sha corresponds to a release tag, False otherwise
     """
-    tags = run_git_command(["git", "tag", "--points-at", git_sha])
+    tags = run_git_command(["git", "tag", "--points-at", git_sha], cwd=cwd)
     return bool(tags)
 
 
-def get_last_tag() -> str:
+def get_last_tag(cwd: Path | None = None) -> str:
     """
     Get the last tag in the git repository
 
+    :param cwd: The directory of the git repository
     :return: The last tag
     """
-    return run_git_command(["git", "describe", "--tags", "--abbrev=0"]) or ""
+    return run_git_command(["git", "describe", "--tags", "--abbrev=0"], cwd=cwd) or ""
 
 
-def get_commit_distance(tag: str | None = None) -> int:
+def get_commit_distance(tag: str | None = None, cwd: Path | None = None) -> int:
     """
     Get the distance in commits between the current commit and the last tag
 
+    :param tag: The tag from which to count
+    :param cwd: The directory of the git repository
     :return: The distance in commits
     """
     if not tag:
-        tag = get_last_tag()
+        tag = get_last_tag(cwd=cwd)
     try:
-        count = run_git_command(["git", "rev-list", "--count", f"{tag}..HEAD"])
+        count = run_git_command(["git", "rev-list", "--count", f"{tag}..HEAD"], cwd=cwd)
         return int(count) if count else 0
     except Exception as e:
         if logger.isEnabledFor(logging.DEBUG):
@@ -86,13 +95,23 @@ def get_commit_distance(tag: str | None = None) -> int:
     return 0
 
 
-def has_uncommitted_changes() -> bool:
+def has_uncommitted_changes(cwd: Path | None = None) -> bool:
     """
     Check whether there are any uncommitted changes in the repository
 
+    :param cwd: The directory of the git repository
     :return: True if there are uncommitted changes, False otherwise
     """
-    return bool(run_git_command(["git", "status", "--porcelain"]))
+    return bool(run_git_command(["git", "status", "--porcelain"], cwd=cwd))
+
+
+def _is_source_checkout(package_root: Path) -> bool:
+    """Return whether the package files belong to their own Git checkout."""
+    if not (package_root / ".git").exists():
+        return False
+
+    git_root = run_git_command(["git", "rev-parse", "--show-toplevel"], cwd=package_root)
+    return bool(git_root) and Path(git_root).resolve() == package_root.resolve()
 
 
 def get_version() -> str:
@@ -101,20 +120,31 @@ def get_version() -> str:
 
     :return: The version
     """
-    version = None
+    package_root = get_config_path().parent
+    source_checkout = _is_source_checkout(package_root)
+
+    if not source_checkout:
+        try:
+            return metadata.version(PACKAGE_NAME)
+        except metadata.PackageNotFoundError:
+            pass
+
     config = get_config()
     declared_version = config["tool"]["poetry"]["version"]
-    commit_sha = get_git_commit()
-    is_release = is_release_tag(commit_sha)
-    latest_tag = get_last_tag()
+    if not source_checkout:
+        return declared_version
+
+    commit_sha = get_git_commit(cwd=package_root)
+    is_release = is_release_tag(commit_sha, cwd=package_root)
+    latest_tag = get_last_tag(cwd=package_root)
     if is_release:
         if declared_version != latest_tag:
             logger.warning("The declared version %s is different from the last tag %s", declared_version, latest_tag)
         version = latest_tag
     else:
-        commit_distance = get_commit_distance(latest_tag)
+        commit_distance = get_commit_distance(latest_tag, cwd=package_root)
         version = f"{declared_version}_{commit_sha}+{commit_distance}" if commit_sha else declared_version
-    dirty = has_uncommitted_changes()
+    dirty = has_uncommitted_changes(cwd=package_root)
     return f"{version}-dirty" if dirty else version
 
 

--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2024-2026 CRS4
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from rocrate_validator.utils import versioning
+
+PACKAGE_VERSION = versioning.get_config()["tool"]["poetry"]["version"]
+
+
+def _version_config(version: str = PACKAGE_VERSION) -> dict:
+    return {"tool": {"poetry": {"version": version}}}
+
+
+def _run_git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_get_version_uses_distribution_metadata_outside_source_checkout(monkeypatch, tmp_path: Path):
+    package_root = tmp_path / "site-packages"
+    package_root.mkdir()
+    monkeypatch.setattr(versioning, "get_config_path", lambda: package_root / "pyproject.toml")
+    monkeypatch.setattr(versioning, "_is_source_checkout", lambda _: False)
+    monkeypatch.setattr(versioning.metadata, "version", lambda name: PACKAGE_VERSION)
+    run_git_command = Mock(side_effect=AssertionError("Git must not be queried for an installed package"))
+    get_config = Mock(side_effect=AssertionError("pyproject.toml is not needed when metadata is available"))
+    monkeypatch.setattr(versioning, "run_git_command", run_git_command)
+    monkeypatch.setattr(versioning, "get_config", get_config)
+
+    assert versioning.get_version() == PACKAGE_VERSION
+    run_git_command.assert_not_called()
+    get_config.assert_not_called()
+
+
+def test_get_version_falls_back_to_declared_version_when_metadata_is_missing(monkeypatch, tmp_path: Path):
+    package_root = tmp_path / "source-distribution"
+    package_root.mkdir()
+    monkeypatch.setattr(versioning, "get_config_path", lambda: package_root / "pyproject.toml")
+    monkeypatch.setattr(versioning, "_is_source_checkout", lambda _: False)
+
+    def missing_distribution(name: str) -> str:
+        raise versioning.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(versioning.metadata, "version", missing_distribution)
+    monkeypatch.setattr(versioning, "get_config", _version_config)
+
+    assert versioning.get_version() == PACKAGE_VERSION
+
+
+def test_get_version_anchors_source_checkout_git_commands(monkeypatch, tmp_path: Path):
+    package_root = tmp_path / "rocrate-validator"
+    package_root.mkdir()
+    monkeypatch.setattr(versioning, "get_config_path", lambda: package_root / "pyproject.toml")
+    monkeypatch.setattr(versioning, "_is_source_checkout", lambda _: True)
+    monkeypatch.setattr(versioning.metadata, "version", lambda _: pytest.fail("Source checkouts must use Git"))
+    monkeypatch.setattr(versioning, "get_config", _version_config)
+
+    outputs = iter(["abc1234", "", PACKAGE_VERSION, "7", ""])
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def run_git_command(command: list[str], cwd: Path | None = None) -> str:
+        calls.append((command, cwd))
+        return next(outputs)
+
+    monkeypatch.setattr(versioning, "run_git_command", run_git_command)
+
+    assert versioning.get_version() == f"{PACKAGE_VERSION}_abc1234+7"
+    assert len(calls) == 5
+    assert all(cwd == package_root for _, cwd in calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="Git is required for the consumer-repository regression")
+def test_source_import_ignores_consumer_repository_tag(tmp_path: Path):
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    _run_git(consumer, "init", "--quiet")
+    _run_git(
+        consumer,
+        "-c",
+        "user.name=Issue 198 Test",
+        "-c",
+        "user.email=issue-198@example.invalid",
+        "-c",
+        "commit.gpgSign=false",
+        "commit",
+        "--allow-empty",
+        "--quiet",
+        "-m",
+        "consumer release",
+    )
+    _run_git(consumer, "tag", "0.3.1")
+
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    result = subprocess.run(
+        [sys.executable, "-c", "import rocrate_validator; print(rocrate_validator.__version__)"],
+        cwd=consumer,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "0.3.1" not in output
+    assert "different from the last tag" not in output


### PR DESCRIPTION
This PR addresses issue #198 by ensuring that `rocrate-validator` uses its installed distribution metadata when imported as a dependency, while still deriving development versions from its own Git repository when running from a source checkout.

This prevents version detection from inspecting the consuming package's Git repository and emitting misleading warnings.

Fixes #198 